### PR TITLE
Open Help Menu External Links in New Tab.

### DIFF
--- a/src/components/menus/HelpMenu.tsx
+++ b/src/components/menus/HelpMenu.tsx
@@ -1,6 +1,5 @@
 import HelpIcon from '@mui/icons-material/Help';
-import MenuItem from '@mui/material/MenuItem';
-import ExternalLink from 'components/shared/ExternalLink';
+import ExternalLinkMenuItem from 'components/shared/ExternalLinkMenuItem';
 import IconMenu from './IconMenu';
 
 function HelpMenu() {
@@ -12,21 +11,15 @@ function HelpMenu() {
                 identifier="help-menu"
                 tooltip="Help Links"
             >
-                <MenuItem>
-                    <ExternalLink link="https://docs.estuary.dev/" disableHover>
-                        Flow Docs
-                    </ExternalLink>
-                </MenuItem>
-                <MenuItem>
-                    <ExternalLink link="https://join.slack.com/t/estuary-dev/shared_invite/zt-86nal6yr-VPbv~YfZE9Q~6Zl~gmZdFQ" disableHover>
-                        Estuary's Slack
-                    </ExternalLink>
-                </MenuItem>
-                <MenuItem>
-                    <ExternalLink link="https://www.estuary.dev/#get-in-touch" disableHover>
-                        Contact Us
-                    </ExternalLink>
-                </MenuItem>
+                <ExternalLinkMenuItem link="https://docs.estuary.dev/">
+                    Flow Docs
+                </ExternalLinkMenuItem>
+                <ExternalLinkMenuItem link="https://join.slack.com/t/estuary-dev/shared_invite/zt-86nal6yr-VPbv~YfZE9Q~6Zl~gmZdFQ">
+                    Estuary's Slack
+                </ExternalLinkMenuItem>
+                <ExternalLinkMenuItem link="https://www.estuary.dev/#get-in-touch">
+                    Contact Us
+                </ExternalLinkMenuItem>
             </IconMenu>
         </>
     );

--- a/src/components/shared/ExternalLink.tsx
+++ b/src/components/shared/ExternalLink.tsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 ExternalLink.propTypes = {
     children: PropTypes.any.isRequired,
     link: PropTypes.string.isRequired,
-    disableHover: PropTypes.bool,
 };
 
 function ExternalLink(
@@ -21,10 +20,6 @@ function ExternalLink(
             color="secondary"
             sx={{
                 fontWeight: 700,
-                '&:hover': {
-                    // TODO: Retrieve the background hex code from AppTheme.tsx 
-                    backgroundColor: props.disableHover ? 'transparent' : '#F7F7F7'
-                }
             }}
         >
             {props.children}

--- a/src/components/shared/ExternalLinkMenuItem.tsx
+++ b/src/components/shared/ExternalLinkMenuItem.tsx
@@ -1,0 +1,35 @@
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Link, MenuItem } from '@mui/material';
+import PropTypes from 'prop-types';
+
+ExternalLinkMenuItem.propTypes = {
+    children: PropTypes.any.isRequired,
+    link: PropTypes.string.isRequired,
+};
+
+function ExternalLinkMenuItem(
+    props: PropTypes.InferProps<typeof ExternalLinkMenuItem.propTypes>
+) {
+    return (
+        <MenuItem
+            component={Link}
+            href={props.link}
+            target="_blank"
+            rel="noopener"
+            tabIndex={0}
+            sx={{
+                px: 3,
+                py: 1.5,
+                fontSize: 14,
+                fontWeight: 700,
+                color: '#3c5584',
+                textTransform: 'uppercase',
+            }}
+        >
+            <span>{props.children}</span>
+            <OpenInNewIcon sx={{ width: 36, height: 20 }} />
+        </MenuItem>
+    );
+}
+
+export default ExternalLinkMenuItem;


### PR DESCRIPTION
The following features are included in this PR:

1. Create a shared `ExternalLinkMenuItem` component, to be used whenever an external link needs to be included in a menu. The external links listed in the help menu will open in a new browser tab.

1. Remove the `ExternalLink` component's `disableHover` prop as it is no longer needed.

**NOTE:** The help menu is keyboard accessible with one caveat: to access its menu items, one must tab into the menu after it is opened. Once in focus, the menu handles standard keyboard interactions as expected. Additionally, the styles applied to the `ExternalLinkMenuItem` component replicate that of the `ExternalLink` component for external link uniformity.