### PR TITLE
Rename and Update the Change Set Page

### DIFF
--- a/src/apps/Authenticated.tsx
+++ b/src/apps/Authenticated.tsx
@@ -17,7 +17,7 @@ const NewMaterialization = lazy(
 
 const Collections = lazy(() => import('../pages/Collections'));
 
-const ChangeSet = lazy(() => import('../pages/ChangeSet'));
+const Builds = lazy(() => import('../pages/Builds'));
 
 const Users = lazy(() => import('../pages/Users'));
 
@@ -47,7 +47,7 @@ const Authenticated = () => {
                                 element={<NewMaterialization />}
                             />
                         </Route>
-                        <Route path="change-set" element={<ChangeSet />} />
+                        <Route path="builds" element={<Builds />} />
                         <Route path="admin/*" element={<Admin />}>
                             <Route path="logs" element={<Logs />} />
                             <Route path="alerts" element={<Alerts />} />

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -84,7 +84,6 @@ function NewCaptureModal() {
 
             const catalogNamespace: string = details.data.name;
 
-            // TODO: Get user identifier from authentication-related application state.
             const capture: Entity = {
                 metadata: {
                     catalogNamespace,
@@ -94,7 +93,6 @@ function NewCaptureModal() {
                         catalogNamespace.lastIndexOf('/') + 1,
                         catalogNamespace.length
                     ),
-                    user: 'temp@gmail.com',
                 },
                 schema: schemaFromEditor || catalogResponse,
             };

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import CodeIcon from '@mui/icons-material/Code';
-import CompareArrows from '@mui/icons-material/CompareArrows';
+import Construction from '@mui/icons-material/Construction';
 import ExploreIcon from '@mui/icons-material/Explore';
 import HomeRepairServiceIcon from '@mui/icons-material/HomeRepairService';
 //TODO - These icons are not final
@@ -89,10 +89,10 @@ const Navigation = (props: PropTypes.InferProps<typeof NavigationProps>) => {
                         disabled={true}
                     />
                     <ListItemLink
-                        icon={<CompareArrows />}
-                        title="Change Set"
-                        link="/app/change-set"
-                        key="ChangeSet"
+                        icon={<Construction />}
+                        title="Builds"
+                        link="/app/builds"
+                        key="Builds"
                         menuWidth={width}
                         badgeContent={newChangeCount}
                     />

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -69,10 +69,6 @@ function ChangeSetTable() {
             headerIntlKey: 'changeSet.data.entity',
         },
         {
-            field: 'user',
-            headerIntlKey: 'changeSet.data.user',
-        },
-        {
             field: 'changeType',
             headerIntlKey: 'changeSet.data.details',
         },
@@ -120,7 +116,6 @@ function ChangeSetTable() {
                                             name,
                                             entityType,
                                             catalogNamespace,
-                                            user,
                                             changeType,
                                         },
                                         index
@@ -146,7 +141,6 @@ function ChangeSetTable() {
                                                 </Tooltip>
                                                 <span>{name}</span>
                                             </TableCell>
-                                            <TableCell>{user}</TableCell>
                                             <TableCell>{changeType}</TableCell>
                                         </TableRow>
                                     )

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -93,8 +93,8 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'logs.main.message': `This is where we will show the logs for the system.`,
     'users.main.message': `This is where you will be able to manage your users... basically a little User CRUD UI.`,
 
-    'changeSet.header': `Change Set`,
-    'changeSet.title': `Change Set Table`,
+    'changeSet.header': `Unsaved Changes`,
+    'changeSet.title': `Unsaved Changes Table`,
 
     'changeSet.data.entityType': `Entity Type`,
     'changeSet.data.entity': `Entity`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -98,7 +98,6 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
 
     'changeSet.data.entityType': `Entity Type`,
     'changeSet.data.entity': `Entity`,
-    'changeSet.data.user': `User`,
     'changeSet.data.details': `Details`,
 };
 

--- a/src/pages/Builds.tsx
+++ b/src/pages/Builds.tsx
@@ -3,7 +3,7 @@ import PageContainer from 'components/shared/PageContainer';
 import { FormattedMessage } from 'react-intl';
 import ChangeSetTable from '../components/tables/ChangeSet';
 
-const ChangeSet = () => {
+const Builds = () => {
     return (
         <PageContainer>
             <Toolbar sx={{ justifyContent: 'space-between' }}>
@@ -33,4 +33,4 @@ const ChangeSet = () => {
     );
 };
 
-export default ChangeSet;
+export default Builds;

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -9,7 +9,6 @@ export interface EntityMetadata {
     entityType: EntityType;
     name: string;
     catalogNamespace: string;
-    user: string;
 }
 
 export interface Entity<T = any> {


### PR DESCRIPTION
### Changes

The following features are included in this PR:

1. Rename the Change Set page from _Change Set_ to _Builds_ and adjust the URL accordingly.

1. Update the icon and text displayed in the navigation menu for the formerly known Change Set page.

1. Rename the change set table from _Change Set_ to _Unsaved Changes_.

1. Remove the User column from the change set table and the corresponding prop from the change set state.

**NOTE:** To avoid any errors, any change set state in local storage should be deleted once this code is merged.

### Screenshots

**Builds Page | Navigation Menu Collapsed**
<img width="1058" alt="pr-screenshot__40__updated-change-set-table__nav-menu-collapsed" src="https://user-images.githubusercontent.com/77648584/157540074-9fa3fa70-8cdf-4f92-9892-1f9d9ae41c97.PNG">

<br />

**Builds Page | Navigation Menu Expanded**
<img width="1055" alt="pr-screenshot__40__updated-change-set-table__nav-menu-expanded" src="https://user-images.githubusercontent.com/77648584/157540183-4c31017e-f5b4-495d-b895-f03609dcaaa8.PNG">
