### PR TITLE
Add Last Updated Column to Change Set Table

### DIFF
--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -88,7 +88,7 @@ function NewCaptureModal() {
                 metadata: {
                     catalogNamespace,
                     changeType: 'New Entity',
-                    dateUpdated: Date(),
+                    dateCreated: Date(),
                     entityType: 'Capture',
                     name: catalogNamespace.substring(
                         catalogNamespace.lastIndexOf('/') + 1,

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -88,6 +88,7 @@ function NewCaptureModal() {
                 metadata: {
                     catalogNamespace,
                     changeType: 'New Entity',
+                    dateUpdated: Date(),
                     entityType: 'Capture',
                     name: catalogNamespace.substring(
                         catalogNamespace.lastIndexOf('/') + 1,

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -58,7 +58,7 @@ function ChangeSetTable() {
             headerIntlKey: 'changeSet.data.entity',
         },
         {
-            field: 'dateUpdated',
+            field: 'dateCreated',
             headerIntlKey: 'changeSet.data.lastUpdated',
         },
         {
@@ -122,7 +122,7 @@ function ChangeSetTable() {
                                             name,
                                             entityType,
                                             catalogNamespace,
-                                            dateUpdated,
+                                            dateCreated: dateUpdated,
                                             changeType,
                                         },
                                         index

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -12,6 +12,7 @@ import {
     TableRow,
     Tooltip,
 } from '@mui/material';
+import formatDistanceToNow from 'date-fns/formatDistanceToNow';
 import { MouseEvent, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import useChangeSetStore, {
@@ -28,25 +29,13 @@ const selectors = {
 function ChangeSetTable() {
     const [page, setPage] = useState(0);
     const rowsPerPage = 10;
-
-    const handleChangePage = (
-        event: MouseEvent<HTMLButtonElement> | null,
-        newPage: number
-    ) => {
-        setPage(newPage);
-    };
+    const rowHeight = 57;
 
     const newChangeCount = useChangeSetStore(selectors.newChangeCount);
     const resetNewChangeCount = useChangeSetStore(
         selectors.resetNewChangeCount
     );
     const captureState = useChangeSetStore(selectors.captures);
-
-    useEffect(() => {
-        if (newChangeCount > 0) {
-            resetNewChangeCount();
-        }
-    }, [newChangeCount, resetNewChangeCount]);
 
     const captures = Object.values(captureState);
     const captureDetails: EntityMetadata[] = captures.map(
@@ -69,10 +58,27 @@ function ChangeSetTable() {
             headerIntlKey: 'changeSet.data.entity',
         },
         {
+            field: 'dateUpdated',
+            headerIntlKey: 'changeSet.data.lastUpdated',
+        },
+        {
             field: 'changeType',
             headerIntlKey: 'changeSet.data.details',
         },
     ];
+
+    const handleChangePage = (
+        event: MouseEvent<HTMLButtonElement> | null,
+        newPage: number
+    ) => {
+        setPage(newPage);
+    };
+
+    useEffect(() => {
+        if (newChangeCount > 0) {
+            resetNewChangeCount();
+        }
+    }, [newChangeCount, resetNewChangeCount]);
 
     return (
         <Box sx={{ mb: 2, mx: 2 }}>
@@ -116,6 +122,7 @@ function ChangeSetTable() {
                                             name,
                                             entityType,
                                             catalogNamespace,
+                                            dateUpdated,
                                             changeType,
                                         },
                                         index
@@ -141,6 +148,12 @@ function ChangeSetTable() {
                                                 </Tooltip>
                                                 <span>{name}</span>
                                             </TableCell>
+                                            <TableCell>
+                                                {formatDistanceToNow(
+                                                    new Date(dateUpdated),
+                                                    { addSuffix: true }
+                                                )}
+                                            </TableCell>
                                             <TableCell>{changeType}</TableCell>
                                         </TableRow>
                                     )
@@ -149,7 +162,7 @@ function ChangeSetTable() {
                                 <TableRow>
                                     <TableCell
                                         colSpan={4}
-                                        sx={{ height: 57 * emptyRows }}
+                                        sx={{ height: rowHeight * emptyRows }}
                                     />
                                 </TableRow>
                             )}

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -98,6 +98,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
 
     'changeSet.data.entityType': `Entity Type`,
     'changeSet.data.entity': `Entity`,
+    'changeSet.data.lastUpdated': `Last Updated`,
     'changeSet.data.details': `Details`,
 };
 

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -8,7 +8,7 @@ export interface EntityMetadata {
     entityType: EntityType;
     name: string;
     catalogNamespace: string;
-    dateUpdated: string;
+    dateCreated: string;
     changeType: ChangeType;
 }
 
@@ -23,8 +23,8 @@ interface EntityDictionary<T = any> {
 
 // TODO: Create a distinct capture state slice that is spread into the change set store.
 export interface CaptureState<T = any> {
-    addCapture: (key: string, newCapture: Entity<T>) => void;
     captures: EntityDictionary;
+    addCapture: (key: string, newCapture: Entity<T>) => void;
     // TODO: Move the following properties into the overarching state.
     newChangeCount: number;
     resetNewChangeCount: () => void;

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -1,14 +1,15 @@
 import create from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
-type ChangeType = 'New Entity' | 'Update';
 type EntityType = 'Capture';
+type ChangeType = 'New Entity' | 'Update';
 
 export interface EntityMetadata {
-    changeType: ChangeType;
     entityType: EntityType;
     name: string;
     catalogNamespace: string;
+    dateUpdated: string;
+    changeType: ChangeType;
 }
 
 export interface Entity<T = any> {


### PR DESCRIPTION
### Changes

The change set table now includes a _Last Updated_ column that consists of statements indicating when an entity was last altered. For the time being, an _alteration_ is synonymous with the creation of a new entity.

**NOTE:** The time-related message shown in the change set table is updated when the table is rendered. Therefore, the _Builds_ page must be refreshed to update the message displayed in the _Last Updated_ column. This is temporary.

### Screenshots

**Change Set Table with Last Updated Column**
<img width="774" alt="pr-screenshot__44__change-set-table__last-updated-column-added" src="https://user-images.githubusercontent.com/77648584/158457968-eb7662a1-1375-44ca-a657-3315840518be.PNG">
