### PR TITLE
Add confirmation dialog

### DIFF
--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -227,7 +227,6 @@ function NewCaptureModal() {
             fullScreen={fullScreen}
             fullWidth={!fullScreen}
             maxWidth="md"
-            disableEscapeKeyDown
             sx={{
                 '.MuiDialog-container': {
                     alignItems: 'flex-start',

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -18,6 +18,7 @@ import useCaptureCreationStore, {
     CaptureCreationState,
 } from 'components/capture/creation/Store';
 import ErrorBoundryWrapper from 'components/shared/ErrorBoundryWrapper';
+import { useConfirmationModalContext } from 'context/Confirmation';
 import {
     DiscoveredCatalog,
     discoveredCatalogEndpoint,
@@ -69,6 +70,7 @@ function NewCaptureModal() {
     const theme = useTheme();
     const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
     const navigate = useNavigate();
+    const confirmationModalContext = useConfirmationModalContext();
 
     // Schema editor store
     const schemaFromEditor = useSchemaEditorStore(selectors.schema);
@@ -104,6 +106,16 @@ function NewCaptureModal() {
     // TODO Schema Editor
     //const [availableSchemas, setAvailableSchemas] = useState<any[]>([]);
 
+    const exitModal = () => {
+        if (schemaFromEditor) {
+            removeSchema();
+        }
+
+        cleanUp();
+
+        navigate('..');
+    };
+
     // Form Event Handlers
     const handlers = {
         addToChangeSet: (event: MouseEvent<HTMLElement>) => {
@@ -136,20 +148,24 @@ function NewCaptureModal() {
 
             setFormSubmitting(true);
 
-            handlers.close();
+            exitModal();
         },
 
         close: () => {
             if (hasChanges()) {
-                console.log('uh oh');
+                confirmationModalContext
+                    ?.showConfirmation({
+                        message: 'You will lose unsaved work if you exit now.',
+                    })
+                    .then((confirmed) => {
+                        if (confirmed) {
+                            exitModal();
+                        }
+                    })
+                    .catch(() => {});
+            } else {
+                exitModal();
             }
-            if (schemaFromEditor) {
-                removeSchema();
-            }
-
-            cleanUp();
-
-            navigate('..');
         },
 
         test: (event: MouseEvent<HTMLElement>) => {

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -155,7 +155,7 @@ function NewCaptureModal() {
             if (hasChanges()) {
                 confirmationModalContext
                     ?.showConfirmation({
-                        message: 'You will lose unsaved work if you exit now.',
+                        message: 'confirm.loseData',
                     })
                     .then((confirmed) => {
                         if (confirmed) {

--- a/src/context/Confirmation.tsx
+++ b/src/context/Confirmation.tsx
@@ -7,10 +7,11 @@ import {
     DialogTitle,
 } from '@mui/material';
 import React, { createContext, useContext, useRef, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 
 export interface IConfirmationModalOptions {
-    confirmButton?: string;
-    cancelButton?: string;
+    confirmText?: string;
+    cancelText?: string;
     title?: string;
     message: string;
 }
@@ -19,17 +20,17 @@ interface IConfirmationModalContext {
     showConfirmation: ({
         title,
         message,
-        confirmButton,
-        cancelButton,
+        confirmText,
+        cancelText,
     }: IConfirmationModalOptions) => Promise<any>;
 }
 
 const getDefaultSettings = (): IConfirmationModalOptions => {
     return {
-        title: 'Are you sure?',
+        title: 'confirm.title',
         message: '',
-        confirmButton: 'Yes',
-        cancelButton: 'No',
+        confirmText: 'cta.continue',
+        cancelText: 'cta.cancel',
     };
 };
 
@@ -78,20 +79,16 @@ const ConfirmationModalContextProvider: React.FC = ({ children }) => {
                 aria-describedby="alert-dialog-description"
             >
                 <DialogTitle id="alert-dialog-title">
-                    {settings.title}
+                    <FormattedMessage id={settings.title} />
                 </DialogTitle>
                 <DialogContent>
                     <DialogContentText id="alert-dialog-description">
-                        {settings.message}
+                        <FormattedMessage id={settings.message} />
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>
-                    <Button
-                        color="error"
-                        variant="contained"
-                        onClick={handlers.dismiss}
-                    >
-                        {settings.cancelButton}
+                    <Button color="error" onClick={handlers.dismiss}>
+                        <FormattedMessage id={settings.cancelText} />
                     </Button>
                     <Button
                         color="success"
@@ -99,7 +96,7 @@ const ConfirmationModalContextProvider: React.FC = ({ children }) => {
                         onClick={handlers.confirm}
                         autoFocus
                     >
-                        {settings.confirmButton}
+                        <FormattedMessage id={settings.confirmText} />
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/src/context/Confirmation.tsx
+++ b/src/context/Confirmation.tsx
@@ -1,0 +1,114 @@
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+} from '@mui/material';
+import React, { createContext, useContext, useRef, useState } from 'react';
+
+export interface IConfirmationModalOptions {
+    confirmButton?: string;
+    cancelButton?: string;
+    title?: string;
+    message: string;
+}
+
+interface IConfirmationModalContext {
+    showConfirmation: ({
+        title,
+        message,
+        confirmButton,
+        cancelButton,
+    }: IConfirmationModalOptions) => Promise<any>;
+}
+
+const getDefaultSettings = (): IConfirmationModalOptions => {
+    return {
+        title: 'Are you sure?',
+        message: '',
+        confirmButton: 'Yes',
+        cancelButton: 'No',
+    };
+};
+
+const ConfirmationModalContext =
+    createContext<IConfirmationModalContext | null>(null);
+
+const ConfirmationModalContextProvider: React.FC = ({ children }) => {
+    const [settings, setSettings] = useState<IConfirmationModalOptions>(
+        getDefaultSettings()
+    );
+    const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+    const resolver = useRef<any>();
+
+    const handlers = {
+        confirm: () => {
+            resolver.current?.(true);
+            setShowConfirmationModal(false);
+        },
+        dismiss: () => {
+            resolver.current?.(false);
+            setShowConfirmationModal(false);
+        },
+        show: (userSettings: IConfirmationModalOptions) => {
+            setSettings({
+                ...getDefaultSettings(),
+                ...userSettings,
+            });
+            setShowConfirmationModal(true);
+
+            return new Promise((resolve) => {
+                resolver.current = resolve;
+            });
+        },
+    };
+
+    return (
+        <ConfirmationModalContext.Provider
+            value={{ showConfirmation: handlers.show }}
+        >
+            {children}
+
+            <Dialog
+                open={showConfirmationModal}
+                onClose={handlers.dismiss}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+            >
+                <DialogTitle id="alert-dialog-title">
+                    {settings.title}
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="alert-dialog-description">
+                        {settings.message}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        color="error"
+                        variant="contained"
+                        onClick={handlers.dismiss}
+                    >
+                        {settings.cancelButton}
+                    </Button>
+                    <Button
+                        color="success"
+                        variant="contained"
+                        onClick={handlers.confirm}
+                        autoFocus
+                    >
+                        {settings.confirmButton}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </ConfirmationModalContext.Provider>
+    );
+};
+
+export const useConfirmationModalContext = () => {
+    return useContext(ConfirmationModalContext);
+};
+
+export default ConfirmationModalContextProvider;

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -1,3 +1,4 @@
+import ConfirmationModalContextProvider from 'context/Confirmation';
 import { AuthProvider } from './Auth';
 import AppContent from './Content';
 import AppRouter from './Router';
@@ -8,7 +9,11 @@ const AppProviders: React.FC = ({ children }) => {
         <AppContent>
             <AuthProvider>
                 <AppTheme>
-                    <AppRouter>{children}</AppRouter>
+                    <AppRouter>
+                        <ConfirmationModalContextProvider>
+                            {children}
+                        </ConfirmationModalContextProvider>
+                    </AppRouter>
                 </AppTheme>
             </AuthProvider>
         </AppContent>

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -17,6 +17,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     // CTA
     'cta.addToChangeSet': `Add to Change Set`,
     'cta.cancel': `Cancel`,
+    'cta.continue': `Continue`,
     'cta.delete': `Delete`,
     'cta.download': `Download`,
     'cta.login': `Login`,
@@ -35,6 +36,10 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'data.updated_at': `Updated`,
     'data.email': `Email`,
     'data.display_name': `User Name`,
+
+    // Confirmations
+    'confirm.title': `Are you sure?`,
+    'confirm.loseData': `You have unsaved worked. If you continue you will lose your changes.`,
 
     // Full Page
     'fullpage.error': `Major Error`,


### PR DESCRIPTION
### Changes

- Very basic context driven confirmation dialog
- Capture creation has a stand along "exit" function now so we don't call this confirmation when adding to changeset
- Modal will not close if there are changes and the user does not agree
- If the user closes the modal without choosing an option we default that as "no" and don't close the modal
- No real styling added beyond the buttons as I assume we'll handle that in the future.

### Tests

Manual

### Content

- Some new default messaging in the lang folder
- Also created a new "category" for confirmations
- 
![image](https://user-images.githubusercontent.com/270078/158896936-29694f04-3ee3-47e4-b203-266cfe398ffb.png)


### Screenshots

![image](https://user-images.githubusercontent.com/270078/158896855-18649aae-f4dc-48e4-9e82-45316b55e9d2.png)
