### PR TITLE
Store Multiple Schemas in Schema Editor State

### DIFF
--- a/src/components/capture/creation/SchemaEditor.tsx
+++ b/src/components/capture/creation/SchemaEditor.tsx
@@ -20,10 +20,14 @@ type NewCaptureEditorProps = {
     data?: DiscoveredCatalogAttributes;
 };
 
-const setSchemaSelector = (state: SchemaEditorState) => state.setSchema;
+const selectors = {
+    loadResource: (state: SchemaEditorState) => state.loadResource,
+    updateResource: (state: SchemaEditorState) => state.updateResource,
+};
 
 function NewCaptureEditor(props: NewCaptureEditorProps) {
-    const setSchema = useSchemaEditorStore(setSchemaSelector);
+    const loadResource = useSchemaEditorStore(selectors.loadResource);
+    const updateResource = useSchemaEditorStore(selectors.updateResource);
 
     const { data } = props;
 
@@ -46,13 +50,19 @@ function NewCaptureEditor(props: NewCaptureEditorProps) {
         },
         change: () => {
             if (editorRef.current) {
-                setSchema(editorRef.current.getValue());
+                updateResource(currentFileName, editorRef.current.getValue());
             }
         },
         mount: (editor: monacoEditor.editor.IStandaloneCodeEditor) => {
             editorRef.current = editor;
 
             handlers.fileList.click(resourceList[0]);
+
+            if (resourceList.length > 0) {
+                resourceList.forEach((name) => {
+                    loadResource(name, data?.resources[name].content);
+                });
+            }
 
             // Commented out as it stands as the main example of how to handle "events"
             // const handler = editor.onDidChangeModelDecorations(() => {

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -12,16 +12,16 @@ import {
     Paper,
     Typography,
     useMediaQuery,
-    useTheme,
+    useTheme
 } from '@mui/material';
 import useCaptureCreationStore, {
-    CaptureCreationState,
+    CaptureCreationState
 } from 'components/capture/creation/Store';
 import ErrorBoundryWrapper from 'components/shared/ErrorBoundryWrapper';
 import { useConfirmationModalContext } from 'context/Confirmation';
 import {
     DiscoveredCatalog,
-    discoveredCatalogEndpoint,
+    discoveredCatalogEndpoint
 } from 'endpoints/discoveredCatalog';
 import { MouseEvent, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -29,10 +29,10 @@ import { useNavigate } from 'react-router-dom';
 import useChangeSetStore, { CaptureState, Entity } from 'stores/ChangeSetStore';
 import useNotificationStore, {
     Notification,
-    NotificationState,
+    NotificationState
 } from 'stores/NotificationStore';
 import useSchemaEditorStore, {
-    SchemaEditorState,
+    SchemaEditorState
 } from 'stores/SchemaEditorStore';
 import NewCaptureDetails from './DetailsForm';
 import NewCaptureError from './Error';
@@ -50,8 +50,8 @@ enum Steps {
 
 const selectors = {
     addCapture: (state: CaptureState) => state.addCapture,
-    removeSchema: (state: SchemaEditorState) => state.removeSchema,
-    schema: (state: SchemaEditorState) => state.schema,
+    clearResources: (state: SchemaEditorState) => state.clearResources,
+    resources: (state: SchemaEditorState) => state.resources,
     showNotification: (state: NotificationState) => state.showNotification,
     captureName: (state: CaptureCreationState) => state.details.data.name,
     setDetails: (state: CaptureCreationState) => state.setDetails,
@@ -73,8 +73,8 @@ function NewCaptureModal() {
     const confirmationModalContext = useConfirmationModalContext();
 
     // Schema editor store
-    const schemaFromEditor = useSchemaEditorStore(selectors.schema);
-    const removeSchema = useSchemaEditorStore(selectors.removeSchema);
+    const resourcesFromEditor = useSchemaEditorStore(selectors.resources);
+    const clearResources = useSchemaEditorStore(selectors.clearResources);
 
     // Change set store
     const addCaptureToChangeSet = useChangeSetStore(selectors.addCapture);
@@ -107,8 +107,8 @@ function NewCaptureModal() {
     //const [availableSchemas, setAvailableSchemas] = useState<any[]>([]);
 
     const exitModal = () => {
-        if (schemaFromEditor) {
-            removeSchema();
+        if (Object.keys(resourcesFromEditor).length > 0) {
+            clearResources();
         }
 
         cleanUp();
@@ -134,7 +134,10 @@ function NewCaptureModal() {
                         catalogNamespace.length
                     ),
                 },
-                schema: schemaFromEditor || catalogResponse,
+                schema:
+                    Object.keys(resourcesFromEditor).length > 0
+                        ? resourcesFromEditor
+                        : catalogResponse,
             };
 
             const notification: Notification = {

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -137,7 +137,7 @@ function NewCaptureModal() {
                         catalogNamespace.length
                     ),
                 },
-                schema:
+                resources:
                     Object.keys(resourcesFromEditor).length > 0
                         ? resourcesFromEditor
                         : catalogResponse,

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -77,7 +77,9 @@ function NewCaptureModal() {
 
     // Schema editor store
     const resourcesFromEditor = useSchemaEditorStore(selectors.resources);
-    const clearResources = useSchemaEditorStore(selectors.clearResources);
+    const clearResourcesFromEditor = useSchemaEditorStore(
+        selectors.clearResources
+    );
 
     // Change set store
     const addCaptureToChangeSet = useChangeSetStore(selectors.addCapture);
@@ -111,7 +113,7 @@ function NewCaptureModal() {
 
     const exitModal = () => {
         if (Object.keys(resourcesFromEditor).length > 0) {
-            clearResources();
+            clearResourcesFromEditor();
         }
 
         cleanUp();

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -12,27 +12,30 @@ import {
     Paper,
     Typography,
     useMediaQuery,
-    useTheme
+    useTheme,
 } from '@mui/material';
 import useCaptureCreationStore, {
-    CaptureCreationState
+    CaptureCreationState,
 } from 'components/capture/creation/Store';
 import ErrorBoundryWrapper from 'components/shared/ErrorBoundryWrapper';
 import { useConfirmationModalContext } from 'context/Confirmation';
 import {
     DiscoveredCatalog,
-    discoveredCatalogEndpoint
+    discoveredCatalogEndpoint,
 } from 'endpoints/discoveredCatalog';
 import { MouseEvent, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
-import useChangeSetStore, { CaptureState, Entity } from 'stores/ChangeSetStore';
+import useChangeSetStore, {
+    ChangeSetState,
+    Entity,
+} from 'stores/ChangeSetStore';
 import useNotificationStore, {
     Notification,
-    NotificationState
+    NotificationState,
 } from 'stores/NotificationStore';
 import useSchemaEditorStore, {
-    SchemaEditorState
+    SchemaEditorState,
 } from 'stores/SchemaEditorStore';
 import NewCaptureDetails from './DetailsForm';
 import NewCaptureError from './Error';
@@ -49,7 +52,7 @@ enum Steps {
 }
 
 const selectors = {
-    addCapture: (state: CaptureState) => state.addCapture,
+    addCapture: (state: ChangeSetState) => state.addCapture,
     clearResources: (state: SchemaEditorState) => state.clearResources,
     resources: (state: SchemaEditorState) => state.resources,
     showNotification: (state: NotificationState) => state.showNotification,

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -7,7 +7,7 @@ import InputIcon from '@mui/icons-material/Input';
 import StorageIcon from '@mui/icons-material/Storage';
 import { Box, List, Toolbar, useMediaQuery, useTheme } from '@mui/material';
 import MuiDrawer from '@mui/material/Drawer';
-import useChangeSetStore, { CaptureState } from 'stores/ChangeSetStore';
+import useChangeSetStore, { ChangeSetState } from 'stores/ChangeSetStore';
 import ListItemLink from './ListItemLink';
 
 interface NavigationProps {
@@ -17,7 +17,7 @@ interface NavigationProps {
 }
 
 const selectors = {
-    newChangeCount: (state: CaptureState) => state.newChangeCount,
+    newChangeCount: (state: ChangeSetState) => state.newChangeCount,
 };
 
 const Navigation = (props: NavigationProps) => {

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -16,14 +16,14 @@ import formatDistanceToNow from 'date-fns/formatDistanceToNow';
 import { MouseEvent, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import useChangeSetStore, {
-    CaptureState,
+    ChangeSetState,
     EntityMetadata,
 } from 'stores/ChangeSetStore';
 
 const selectors = {
-    captures: (state: CaptureState) => state.captures,
-    newChangeCount: (state: CaptureState) => state.newChangeCount,
-    resetNewChangeCount: (state: CaptureState) => state.resetNewChangeCount,
+    captures: (state: ChangeSetState) => state.captures,
+    newChangeCount: (state: ChangeSetState) => state.newChangeCount,
+    resetNewChangeCount: (state: ChangeSetState) => state.resetNewChangeCount,
 };
 
 function ChangeSetTable() {

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -21,8 +21,7 @@ interface EntityDictionary<T = any> {
     [key: string]: Entity<T>;
 }
 
-// TODO: Create a distinct capture state slice that is spread into the change set store.
-export interface CaptureState<T = any> {
+export interface ChangeSetState<T = any> {
     captures: EntityDictionary;
     addCapture: (key: string, newCapture: Entity<T>) => void;
     // TODO: Move the following properties into the overarching state.
@@ -33,7 +32,7 @@ export interface CaptureState<T = any> {
 const name = 'change-set-state';
 
 // TODO: Look into a better way to hydrate the state.
-const useChangeSetStore = create<CaptureState>(
+const useChangeSetStore = create<ChangeSetState>(
     devtools(
         persist(
             (set) => ({

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -24,7 +24,6 @@ interface EntityDictionary<T = any> {
 export interface ChangeSetState<T = any> {
     captures: EntityDictionary;
     addCapture: (key: string, newCapture: Entity<T>) => void;
-    // TODO: Move the following properties into the overarching state.
     newChangeCount: number;
     resetNewChangeCount: () => void;
 }
@@ -36,6 +35,7 @@ const useChangeSetStore = create<ChangeSetState>(
     devtools(
         persist(
             (set) => ({
+                captures: {},
                 addCapture: (key, newCapture) =>
                     set(
                         (state) => ({
@@ -45,7 +45,6 @@ const useChangeSetStore = create<ChangeSetState>(
                         false,
                         'New Capture Added'
                     ),
-                captures: {},
                 newChangeCount: 0,
                 resetNewChangeCount: () =>
                     set(

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -14,7 +14,7 @@ export interface EntityMetadata {
 
 export interface Entity<T = any> {
     metadata: EntityMetadata;
-    schema: T;
+    resources: T;
 }
 
 interface EntityDictionary<T = any> {

--- a/src/stores/SchemaEditorStore.ts
+++ b/src/stores/SchemaEditorStore.ts
@@ -1,24 +1,44 @@
 import create from 'zustand';
 import { devtools } from 'zustand/middleware';
 
+type GenericSchema = string | JSON;
+
 export interface SchemaEditorState {
-    schema: string;
-    setSchema: (schema: string) => void;
-    removeSchema: () => void;
+    resources: { [name: string]: GenericSchema };
+    loadResource: (name: string, schema: GenericSchema) => void;
+    updateResource: (name: string, schema: GenericSchema) => void;
+    clearResources: () => void;
 }
 
 const useSchemaEditorStore = create<SchemaEditorState>(
     devtools(
         (set) => ({
-            removeSchema: () =>
-                set(() => ({ schema: '' }), false, 'Schema Removed'),
-            schema: '',
-            setSchema: (schema) =>
+            resources: {},
+            loadResource: (name, schema) =>
                 set(
-                    () => ({ schema: JSON.parse(schema) }),
+                    (state) => ({
+                        resources: { ...state.resources, [name]: schema },
+                    }),
                     false,
-                    'Schema Set'
+                    `Resource Loaded: ${name}`
                 ),
+            // TODO: Add error handling for JSON.parse().
+            updateResource: (name, schema) =>
+                set(
+                    (state) => ({
+                        resources: {
+                            ...state.resources,
+                            [name]:
+                                typeof schema === 'string'
+                                    ? JSON.parse(schema)
+                                    : schema,
+                        },
+                    }),
+                    false,
+                    `Resource Updated: ${name}`
+                ),
+            clearResources: () =>
+                set(() => ({ resources: {} }), false, 'Resources Cleared'),
         }),
         { name: 'schema-editor-state' }
     )


### PR DESCRIPTION
### Changes

The following features are included in this PR:

1. Store all resources returned by the _discover_catalog_ endpoint in the schema editor state when the editor is mounted.

1. Retain the alterations made to a given schema in the schema editor state.

1. Rename `CaptureState` to `ChangeSetState` and remove to-dos related to their separation.

1. Rename and reorder assets within the change set and schema editor states.

**NOTE:** To avoid any errors, any change set state in local storage should be deleted once this code is merged.