### PR TITLE
Create Reusable Entity Table

### DIFF
--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -133,6 +133,7 @@ function NewCaptureModal() {
                     catalogNamespace,
                     changeType: 'New Entity',
                     dateCreated: Date(),
+                    deploymentStatus: 'ACTIVE',
                     entityType: 'Capture',
                     name: catalogNamespace.substring(
                         catalogNamespace.lastIndexOf('/') + 1,

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -132,7 +132,6 @@ function NewCaptureModal() {
             const capture: Entity = {
                 metadata: {
                     catalogNamespace,
-                    changeType: 'New Entity',
                     dateCreated: Date(),
                     deploymentStatus: 'ACTIVE',
                     connectorType: 'Hello World',

--- a/src/components/capture/creation/index.tsx
+++ b/src/components/capture/creation/index.tsx
@@ -128,13 +128,14 @@ function NewCaptureModal() {
 
             const catalogNamespace = captureName;
 
+            // TODO: Get connector type value from store.
             const capture: Entity = {
                 metadata: {
                     catalogNamespace,
                     changeType: 'New Entity',
                     dateCreated: Date(),
                     deploymentStatus: 'ACTIVE',
-                    entityType: 'Capture',
+                    connectorType: 'Hello World',
                     name: catalogNamespace.substring(
                         catalogNamespace.lastIndexOf('/') + 1,
                         catalogNamespace.length

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -9,6 +9,7 @@ import {
     TableHead,
     TablePagination,
     TableRow,
+    TableSortLabel,
     Tooltip,
 } from '@mui/material';
 import formatDistanceToNow from 'date-fns/formatDistanceToNow';
@@ -100,9 +101,11 @@ function ChangeSetTable(props: EntityTableProps) {
                                         <TableCell
                                             key={`${column.field}-${index}`}
                                         >
-                                            <FormattedMessage
-                                                id={column.headerIntlKey}
-                                            />
+                                            <TableSortLabel>
+                                                <FormattedMessage
+                                                    id={column.headerIntlKey}
+                                                />
+                                            </TableSortLabel>
                                         </TableCell>
                                     );
                                 })}

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -1,7 +1,5 @@
-import InfoIcon from '@mui/icons-material/Info';
 import {
     Box,
-    IconButton,
     Table,
     TableBody,
     TableCell,
@@ -50,10 +48,6 @@ function ChangeSetTable() {
 
     const intl = useIntl();
     const columns = [
-        {
-            field: 'deploymentStatus',
-            headerIntlKey: 'changeSet.data.deploymentStatus',
-        },
         {
             field: 'name',
             headerIntlKey: 'changeSet.data.entity',
@@ -147,10 +141,7 @@ function ChangeSetTable() {
                                         <TableRow
                                             key={`Entity-${name}-${index}`}
                                         >
-                                            <TableCell
-                                                align="center"
-                                                sx={{ width: 77 }}
-                                            >
+                                            <TableCell sx={{ minWidth: 216 }}>
                                                 <span
                                                     style={{
                                                         height: 20,
@@ -162,25 +153,23 @@ function ChangeSetTable() {
                                                         borderRadius: 50,
                                                         display: 'inline-block',
                                                         verticalAlign: 'middle',
+                                                        marginRight: 16,
                                                     }}
                                                 />
-                                            </TableCell>
-                                            <TableCell sx={{ minWidth: 216 }}>
+
                                                 <Tooltip
                                                     title={catalogNamespace}
                                                     placement="bottom-start"
                                                 >
-                                                    <IconButton
-                                                        sx={{ mr: 0.5, p: 0.5 }}
+                                                    <span
+                                                        style={{
+                                                            verticalAlign:
+                                                                'middle',
+                                                        }}
                                                     >
-                                                        <InfoIcon
-                                                            sx={{
-                                                                fontSize: 16,
-                                                            }}
-                                                        />
-                                                    </IconButton>
+                                                        {name}
+                                                    </span>
                                                 </Tooltip>
-                                                <span>{name}</span>
                                             </TableCell>
                                             <TableCell>{entityType}</TableCell>
                                             <TableCell>

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -142,33 +142,36 @@ function ChangeSetTable() {
                                             key={`Entity-${name}-${index}`}
                                         >
                                             <TableCell sx={{ minWidth: 216 }}>
-                                                <span
-                                                    style={{
-                                                        height: 20,
-                                                        width: 20,
-                                                        backgroundColor:
-                                                            getDeploymentStatusHexCode(
-                                                                deploymentStatus
-                                                            ),
-                                                        borderRadius: 50,
-                                                        display: 'inline-block',
-                                                        verticalAlign: 'middle',
-                                                        marginRight: 16,
-                                                    }}
-                                                />
-
                                                 <Tooltip
                                                     title={catalogNamespace}
                                                     placement="bottom-start"
                                                 >
-                                                    <span
-                                                        style={{
-                                                            verticalAlign:
-                                                                'middle',
-                                                        }}
-                                                    >
-                                                        {name}
-                                                    </span>
+                                                    <Box>
+                                                        <span
+                                                            style={{
+                                                                height: 20,
+                                                                width: 20,
+                                                                backgroundColor:
+                                                                    getDeploymentStatusHexCode(
+                                                                        deploymentStatus
+                                                                    ),
+                                                                borderRadius: 50,
+                                                                display:
+                                                                    'inline-block',
+                                                                verticalAlign:
+                                                                    'middle',
+                                                                marginRight: 16,
+                                                            }}
+                                                        />
+                                                        <span
+                                                            style={{
+                                                                verticalAlign:
+                                                                    'middle',
+                                                            }}
+                                                        >
+                                                            {name}
+                                                        </span>
+                                                    </Box>
                                                 </Tooltip>
                                             </TableCell>
                                             <TableCell>

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -17,6 +17,7 @@ import { MouseEvent, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import useChangeSetStore, {
     ChangeSetState,
+    DeploymentStatus,
     EntityMetadata,
 } from 'stores/ChangeSetStore';
 
@@ -50,12 +51,16 @@ function ChangeSetTable() {
     const intl = useIntl();
     const columns = [
         {
-            field: 'entityType',
-            headerIntlKey: 'changeSet.data.entityType',
+            field: 'deploymentStatus',
+            headerIntlKey: 'changeSet.data.deploymentStatus',
         },
         {
             field: 'name',
             headerIntlKey: 'changeSet.data.entity',
+        },
+        {
+            field: 'entityType',
+            headerIntlKey: 'changeSet.data.entityType',
         },
         {
             field: 'dateCreated',
@@ -66,6 +71,17 @@ function ChangeSetTable() {
             headerIntlKey: 'changeSet.data.details',
         },
     ];
+
+    const getDeploymentStatusHexCode = (status: DeploymentStatus): string => {
+        switch (status) {
+            case 'ACTIVE':
+                return '#40B763';
+            case 'INACTIVE':
+                return '#C9393E';
+            default:
+                return '#000000';
+        }
+    };
 
     const handleChangePage = (
         event: MouseEvent<HTMLButtonElement> | null,
@@ -119,6 +135,7 @@ function ChangeSetTable() {
                                 .map(
                                     (
                                         {
+                                            deploymentStatus,
                                             name,
                                             entityType,
                                             catalogNamespace,
@@ -130,7 +147,24 @@ function ChangeSetTable() {
                                         <TableRow
                                             key={`Entity-${name}-${index}`}
                                         >
-                                            <TableCell>{entityType}</TableCell>
+                                            <TableCell
+                                                align="center"
+                                                sx={{ width: 77 }}
+                                            >
+                                                <span
+                                                    style={{
+                                                        height: 20,
+                                                        width: 20,
+                                                        backgroundColor:
+                                                            getDeploymentStatusHexCode(
+                                                                deploymentStatus
+                                                            ),
+                                                        borderRadius: 50,
+                                                        display: 'inline-block',
+                                                        verticalAlign: 'middle',
+                                                    }}
+                                                />
+                                            </TableCell>
                                             <TableCell sx={{ minWidth: 216 }}>
                                                 <Tooltip
                                                     title={catalogNamespace}
@@ -148,6 +182,7 @@ function ChangeSetTable() {
                                                 </Tooltip>
                                                 <span>{name}</span>
                                             </TableCell>
+                                            <TableCell>{entityType}</TableCell>
                                             <TableCell>
                                                 {formatDistanceToNow(
                                                     new Date(dateUpdated),

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -53,8 +53,8 @@ function ChangeSetTable() {
             headerIntlKey: 'changeSet.data.entity',
         },
         {
-            field: 'entityType',
-            headerIntlKey: 'changeSet.data.entityType',
+            field: 'connectorType',
+            headerIntlKey: 'changeSet.data.connectorType',
         },
         {
             field: 'dateCreated',
@@ -131,7 +131,7 @@ function ChangeSetTable() {
                                         {
                                             deploymentStatus,
                                             name,
-                                            entityType,
+                                            connectorType,
                                             catalogNamespace,
                                             dateCreated: dateUpdated,
                                             changeType,
@@ -171,7 +171,9 @@ function ChangeSetTable() {
                                                     </span>
                                                 </Tooltip>
                                             </TableCell>
-                                            <TableCell>{entityType}</TableCell>
+                                            <TableCell>
+                                                {connectorType}
+                                            </TableCell>
                                             <TableCell>
                                                 {formatDistanceToNow(
                                                     new Date(dateUpdated),

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -1,5 +1,6 @@
 import {
     Box,
+    Button,
     Table,
     TableBody,
     TableCell,
@@ -61,8 +62,8 @@ function ChangeSetTable() {
             headerIntlKey: 'changeSet.data.lastUpdated',
         },
         {
-            field: 'changeType',
-            headerIntlKey: 'changeSet.data.details',
+            field: null,
+            headerIntlKey: 'changeSet.data.actions',
         },
     ];
 
@@ -131,10 +132,9 @@ function ChangeSetTable() {
                                         {
                                             deploymentStatus,
                                             name,
-                                            connectorType,
                                             catalogNamespace,
+                                            connectorType,
                                             dateCreated: dateUpdated,
-                                            changeType,
                                         },
                                         index
                                     ) => (
@@ -180,7 +180,15 @@ function ChangeSetTable() {
                                                     { addSuffix: true }
                                                 )}
                                             </TableCell>
-                                            <TableCell>{changeType}</TableCell>
+                                            <TableCell>
+                                                <Button
+                                                    variant="contained"
+                                                    size="small"
+                                                    disableElevation
+                                                >
+                                                    Edit
+                                                </Button>
+                                            </TableCell>
                                         </TableRow>
                                     )
                                 )}

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -171,13 +171,37 @@ function ChangeSetTable(props: EntityTableProps) {
                                                 )}
                                             </TableCell>
                                             <TableCell>
-                                                <Button
-                                                    variant="contained"
-                                                    size="small"
-                                                    disableElevation
-                                                >
-                                                    Edit
-                                                </Button>
+                                                <Box sx={{ display: 'flex' }}>
+                                                    <Button
+                                                        variant="contained"
+                                                        size="small"
+                                                        disableElevation
+                                                        sx={{ mr: 1 }}
+                                                    >
+                                                        Edit
+                                                    </Button>
+
+                                                    {deploymentStatus ===
+                                                    'ACTIVE' ? (
+                                                        <Button
+                                                            variant="contained"
+                                                            size="small"
+                                                            color="error"
+                                                            disableElevation
+                                                        >
+                                                            Stop
+                                                        </Button>
+                                                    ) : (
+                                                        <Button
+                                                            variant="contained"
+                                                            size="small"
+                                                            color="success"
+                                                            disableElevation
+                                                        >
+                                                            Run
+                                                        </Button>
+                                                    )}
+                                                </Box>
                                             </TableCell>
                                         </TableRow>
                                     )

--- a/src/components/tables/ChangeSet.tsx
+++ b/src/components/tables/ChangeSet.tsx
@@ -12,58 +12,51 @@ import {
     Tooltip,
 } from '@mui/material';
 import formatDistanceToNow from 'date-fns/formatDistanceToNow';
-import { MouseEvent, useEffect, useState } from 'react';
+import { MouseEvent, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import useChangeSetStore, {
-    ChangeSetState,
+import {
     DeploymentStatus,
+    Entity,
     EntityMetadata,
 } from 'stores/ChangeSetStore';
 
-const selectors = {
-    captures: (state: ChangeSetState) => state.captures,
-    newChangeCount: (state: ChangeSetState) => state.newChangeCount,
-    resetNewChangeCount: (state: ChangeSetState) => state.resetNewChangeCount,
-};
+interface EntityTableProps {
+    entities: Entity[];
+}
 
-function ChangeSetTable() {
+function ChangeSetTable(props: EntityTableProps) {
+    const { entities } = props;
+
     const [page, setPage] = useState(0);
     const rowsPerPage = 10;
     const rowHeight = 57;
 
-    const newChangeCount = useChangeSetStore(selectors.newChangeCount);
-    const resetNewChangeCount = useChangeSetStore(
-        selectors.resetNewChangeCount
-    );
-    const captureState = useChangeSetStore(selectors.captures);
-
-    const captures = Object.values(captureState);
-    const captureDetails: EntityMetadata[] = captures.map(
-        (capture) => capture.metadata
+    const entityDetails: EntityMetadata[] = entities.map(
+        (entity) => entity.metadata
     );
 
     const emptyRows =
         page > 0
-            ? Math.max(0, (1 + page) * rowsPerPage - captureDetails.length)
+            ? Math.max(0, (1 + page) * rowsPerPage - entityDetails.length)
             : 0;
 
     const intl = useIntl();
     const columns = [
         {
             field: 'name',
-            headerIntlKey: 'changeSet.data.entity',
+            headerIntlKey: 'entityTable.data.entity',
         },
         {
             field: 'connectorType',
-            headerIntlKey: 'changeSet.data.connectorType',
+            headerIntlKey: 'entityTable.data.connectorType',
         },
         {
             field: 'dateCreated',
-            headerIntlKey: 'changeSet.data.lastUpdated',
+            headerIntlKey: 'entityTable.data.lastUpdated',
         },
         {
             field: null,
-            headerIntlKey: 'changeSet.data.actions',
+            headerIntlKey: 'entityTable.data.actions',
         },
     ];
 
@@ -85,20 +78,14 @@ function ChangeSetTable() {
         setPage(newPage);
     };
 
-    useEffect(() => {
-        if (newChangeCount > 0) {
-            resetNewChangeCount();
-        }
-    }, [newChangeCount, resetNewChangeCount]);
-
     return (
         <Box sx={{ mb: 2, mx: 2 }}>
-            {captures.length > 0 ? (
+            {entities.length > 0 ? (
                 <TableContainer component={Box}>
                     <Table
                         sx={{ minWidth: 350 }}
                         aria-label={intl.formatMessage({
-                            id: 'changeSet.title',
+                            id: 'entityTable.title',
                         })}
                     >
                         <TableHead>
@@ -122,7 +109,7 @@ function ChangeSetTable() {
                             </TableRow>
                         </TableHead>
                         <TableBody>
-                            {captureDetails
+                            {entityDetails
                                 .slice(
                                     page * rowsPerPage,
                                     page * rowsPerPage + rowsPerPage
@@ -149,8 +136,8 @@ function ChangeSetTable() {
                                                     <Box>
                                                         <span
                                                             style={{
-                                                                height: 20,
-                                                                width: 20,
+                                                                height: 16,
+                                                                width: 16,
                                                                 backgroundColor:
                                                                     getDeploymentStatusHexCode(
                                                                         deploymentStatus
@@ -160,7 +147,7 @@ function ChangeSetTable() {
                                                                     'inline-block',
                                                                 verticalAlign:
                                                                     'middle',
-                                                                marginRight: 16,
+                                                                marginRight: 12,
                                                             }}
                                                         />
                                                         <span
@@ -208,7 +195,7 @@ function ChangeSetTable() {
                             <TableRow>
                                 <TablePagination
                                     rowsPerPageOptions={[rowsPerPage]}
-                                    count={captures.length}
+                                    count={entities.length}
                                     rowsPerPage={rowsPerPage}
                                     page={page}
                                     onPageChange={handleChangePage}

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -25,6 +25,10 @@ type SortDirection = 'asc' | 'desc';
 
 interface EntityTableProps {
     entities: Entity[];
+    updateDeploymentStatus: (
+        key: string,
+        deploymentStatus: DeploymentStatus
+    ) => void;
 }
 
 interface TableColumn {
@@ -33,7 +37,7 @@ interface TableColumn {
 }
 
 function EntityTable(props: EntityTableProps) {
-    const { entities } = props;
+    const { entities, updateDeploymentStatus } = props;
 
     const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
     const [columnToSort, setColumnToSort] =
@@ -146,6 +150,11 @@ function EntityTable(props: EntityTableProps) {
         ) => {
             setPage(newPage);
         },
+        deploymentStatusUpdate:
+            (catalogNamespace: string, deploymentStatus: DeploymentStatus) =>
+            () => {
+                updateDeploymentStatus(catalogNamespace, deploymentStatus);
+            },
     };
 
     return (
@@ -290,6 +299,10 @@ function EntityTable(props: EntityTableProps) {
                                                             size="small"
                                                             color="error"
                                                             disableElevation
+                                                            onClick={handlers.deploymentStatusUpdate(
+                                                                catalogNamespace,
+                                                                'INACTIVE'
+                                                            )}
                                                         >
                                                             Stop
                                                         </Button>
@@ -299,6 +312,10 @@ function EntityTable(props: EntityTableProps) {
                                                             size="small"
                                                             color="success"
                                                             disableElevation
+                                                            onClick={handlers.deploymentStatusUpdate(
+                                                                catalogNamespace,
+                                                                'ACTIVE'
+                                                            )}
                                                         >
                                                             Run
                                                         </Button>

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -32,7 +32,7 @@ interface TableColumn {
     headerIntlKey: string;
 }
 
-function ChangeSetTable(props: EntityTableProps) {
+function EntityTable(props: EntityTableProps) {
     const { entities } = props;
 
     const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
@@ -335,4 +335,4 @@ function ChangeSetTable(props: EntityTableProps) {
     );
 }
 
-export default ChangeSetTable;
+export default EntityTable;

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -101,8 +101,8 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'changeSet.header': `Unsaved Changes`,
     'changeSet.title': `Unsaved Changes Table`,
 
-    'changeSet.data.entityType': `Entity Type`,
     'changeSet.data.entity': `Entity`,
+    'changeSet.data.connectorType': `Type`,
     'changeSet.data.lastUpdated': `Last Updated`,
     'changeSet.data.details': `Details`,
 };

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -98,13 +98,13 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'logs.main.message': `This is where we will show the logs for the system.`,
     'users.main.message': `This is where you will be able to manage your users... basically a little User CRUD UI.`,
 
-    'changeSet.header': `Unsaved Changes`,
-    'changeSet.title': `Unsaved Changes Table`,
+    'entityTable.header': `Unsaved Changes`,
+    'entityTable.title': `Unsaved Changes Table`,
 
-    'changeSet.data.entity': `Entity`,
-    'changeSet.data.connectorType': `Type`,
-    'changeSet.data.lastUpdated': `Last Updated`,
-    'changeSet.data.actions': `Actions`,
+    'entityTable.data.entity': `Entity`,
+    'entityTable.data.connectorType': `Type`,
+    'entityTable.data.lastUpdated': `Last Updated`,
+    'entityTable.data.actions': `Actions`,
 };
 
 export default enUSMessages;

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -101,7 +101,6 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'changeSet.header': `Unsaved Changes`,
     'changeSet.title': `Unsaved Changes Table`,
 
-    'changeSet.data.deploymentStatus': `Status`,
     'changeSet.data.entityType': `Entity Type`,
     'changeSet.data.entity': `Entity`,
     'changeSet.data.lastUpdated': `Last Updated`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -98,8 +98,8 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'logs.main.message': `This is where we will show the logs for the system.`,
     'users.main.message': `This is where you will be able to manage your users... basically a little User CRUD UI.`,
 
-    'entityTable.header': `Unsaved Changes`,
-    'entityTable.title': `Unsaved Changes Table`,
+    'captureTable.header': `Published Captures`,
+    'entityTable.title': `Entity Table`,
 
     'entityTable.data.entity': `Name`,
     'entityTable.data.connectorType': `Type`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -104,7 +104,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'changeSet.data.entity': `Entity`,
     'changeSet.data.connectorType': `Type`,
     'changeSet.data.lastUpdated': `Last Updated`,
-    'changeSet.data.details': `Details`,
+    'changeSet.data.actions': `Actions`,
 };
 
 export default enUSMessages;

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -101,6 +101,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'changeSet.header': `Unsaved Changes`,
     'changeSet.title': `Unsaved Changes Table`,
 
+    'changeSet.data.deploymentStatus': `Status`,
     'changeSet.data.entityType': `Entity Type`,
     'changeSet.data.entity': `Entity`,
     'changeSet.data.lastUpdated': `Last Updated`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -101,7 +101,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     'entityTable.header': `Unsaved Changes`,
     'entityTable.title': `Unsaved Changes Table`,
 
-    'entityTable.data.entity': `Entity`,
+    'entityTable.data.entity': `Name`,
     'entityTable.data.connectorType': `Type`,
     'entityTable.data.lastUpdated': `Last Updated`,
     'entityTable.data.actions': `Actions`,

--- a/src/pages/Builds.tsx
+++ b/src/pages/Builds.tsx
@@ -1,5 +1,5 @@
 import SearchIcon from '@mui/icons-material/Search';
-import { Box, Button, TextField, Toolbar, Typography } from '@mui/material';
+import { Box, TextField, Toolbar, Typography } from '@mui/material';
 import PageContainer from 'components/shared/PageContainer';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -80,20 +80,6 @@ const Builds = () => {
                             variant="standard"
                             onChange={handlers.change}
                         />
-                    </Box>
-
-                    <Box marginTop={2}>
-                        <Button
-                            /* TODO: Differentiate bkg color of delete button */
-                            variant="contained"
-                            disabled
-                        >
-                            Delete
-                        </Button>
-
-                        <Button sx={{ ml: 2 }} variant="contained" disabled>
-                            Build
-                        </Button>
                     </Box>
                 </Toolbar>
             </Box>

--- a/src/pages/Builds.tsx
+++ b/src/pages/Builds.tsx
@@ -11,6 +11,8 @@ import EntityTable from '../components/tables/EntityTable';
 
 const selectors = {
     captures: (state: ChangeSetState) => state.captures,
+    updateDeploymentStatus: (state: ChangeSetState) =>
+        state.updateDeploymentStatus,
     newChangeCount: (state: ChangeSetState) => state.newChangeCount,
     resetNewChangeCount: (state: ChangeSetState) => state.resetNewChangeCount,
 };
@@ -20,6 +22,9 @@ const Builds = () => {
         null
     );
 
+    const updateCaptureDeploymentStatus = useChangeSetStore(
+        selectors.updateDeploymentStatus
+    );
     const newChangeCount = useChangeSetStore(selectors.newChangeCount);
     const resetNewChangeCount = useChangeSetStore(
         selectors.resetNewChangeCount
@@ -84,7 +89,10 @@ const Builds = () => {
                 </Toolbar>
             </Box>
 
-            <EntityTable entities={filteredCaptures ?? captures} />
+            <EntityTable
+                entities={filteredCaptures ?? captures}
+                updateDeploymentStatus={updateCaptureDeploymentStatus}
+            />
         </PageContainer>
     );
 };

--- a/src/pages/Builds.tsx
+++ b/src/pages/Builds.tsx
@@ -7,7 +7,7 @@ import useChangeSetStore, {
     ChangeSetState,
     Entity,
 } from 'stores/ChangeSetStore';
-import ChangeSetTable from '../components/tables/ChangeSet';
+import EntityTable from '../components/tables/EntityTable';
 
 const selectors = {
     captures: (state: ChangeSetState) => state.captures,
@@ -84,7 +84,7 @@ const Builds = () => {
                 </Toolbar>
             </Box>
 
-            <ChangeSetTable entities={filteredCaptures ?? captures} />
+            <EntityTable entities={filteredCaptures ?? captures} />
         </PageContainer>
     );
 };

--- a/src/pages/Builds.tsx
+++ b/src/pages/Builds.tsx
@@ -61,14 +61,14 @@ const Builds = () => {
     return (
         <PageContainer>
             <Box sx={{ mx: 2 }}>
-                <Typography variant="h6" sx={{ my: 2 }}>
-                    <FormattedMessage id="entityTable.header" />
-                </Typography>
-
                 <Toolbar
                     disableGutters
                     sx={{ mb: 2, justifyContent: 'space-between' }}
                 >
+                    <Typography variant="h6">
+                        <FormattedMessage id="captureTable.header" />
+                    </Typography>
+
                     <Box
                         margin={0}
                         sx={{ display: 'flex', alignItems: 'flex-end' }}

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -3,15 +3,13 @@ import { devtools, persist } from 'zustand/middleware';
 
 export type DeploymentStatus = 'ACTIVE' | 'INACTIVE';
 type ConnectorType = 'Hello World' | 'Postgres';
-type ChangeType = 'New Entity' | 'Update';
 
 export interface EntityMetadata {
     deploymentStatus: DeploymentStatus;
-    connectorType: ConnectorType;
     name: string;
     catalogNamespace: string;
+    connectorType: ConnectorType;
     dateCreated: string;
-    changeType: ChangeType;
 }
 
 export interface Entity<T = any> {

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -2,12 +2,12 @@ import create from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
 export type DeploymentStatus = 'ACTIVE' | 'INACTIVE';
-type EntityType = 'Capture';
+type ConnectorType = 'Hello World' | 'Postgres';
 type ChangeType = 'New Entity' | 'Update';
 
 export interface EntityMetadata {
     deploymentStatus: DeploymentStatus;
-    entityType: EntityType;
+    connectorType: ConnectorType;
     name: string;
     catalogNamespace: string;
     dateCreated: string;

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -24,6 +24,10 @@ interface EntityDictionary<T = any> {
 export interface ChangeSetState<T = any> {
     captures: EntityDictionary;
     addCapture: (key: string, newCapture: Entity<T>) => void;
+    updateDeploymentStatus: (
+        key: string,
+        deploymentStatus: DeploymentStatus
+    ) => void;
     newChangeCount: number;
     resetNewChangeCount: () => void;
 }
@@ -44,6 +48,19 @@ const useChangeSetStore = create<ChangeSetState>(
                         }),
                         false,
                         'New Capture Added'
+                    ),
+                updateDeploymentStatus: (key, deploymentStatus) =>
+                    set(
+                        (state) => {
+                            const capture = state.captures[key];
+
+                            capture.metadata.deploymentStatus =
+                                deploymentStatus;
+
+                            return { captures: { ...state.captures } };
+                        },
+                        false,
+                        'Deployment Status Updated'
                     ),
                 newChangeCount: 0,
                 resetNewChangeCount: () =>

--- a/src/stores/ChangeSetStore.ts
+++ b/src/stores/ChangeSetStore.ts
@@ -1,10 +1,12 @@
 import create from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
+export type DeploymentStatus = 'ACTIVE' | 'INACTIVE';
 type EntityType = 'Capture';
 type ChangeType = 'New Entity' | 'Update';
 
 export interface EntityMetadata {
+    deploymentStatus: DeploymentStatus;
     entityType: EntityType;
     name: string;
     catalogNamespace: string;


### PR DESCRIPTION
### Changes

The following features are included in this PR:

1. Rename `ChangeSetTable` component to `EntityTable`.

1. Rename the _Entity_ column, responsible for displaying the full catalog namespace of a given entity, to _Name_, display a deployment status indicator to the left of the text, and remove the info icon originally used to display the tooltip. The tooltip is triggered whenever the data in this column is in a hover state.

1. Add a connector type column to the table. This value will be hardcoded to _Hello World_ until an endpoint is created to retrieve the deployment information for a given entity type.

1. Add an _Actions_ column to the table with the following options: edit and run/stop. The run/stop action will change the deployment status of the selected entity in the store, prompting an update to the deployment status indicator in the _Name_ column. The edit button currently has no function.

1. Enable row sorting by column data.

1. Enable row filtering by catalog namespace.

**NOTE:** The intent of this PR is to create the foundation for a shared entity table. Ideally, this table would have more sophisticated tooling and cleaner styling. To avoid any errors, any change set state in local storage should be deleted once this code is merged.

### Screenshots

**Entity Table | Default View**
<img width="748" alt="pr-screenshot__46__entity-table__deployment-status-(run-all)__nav-menu-collapsed" src="https://user-images.githubusercontent.com/77648584/160859089-71e796f8-9da4-46da-bcd0-2299daa3c12a.PNG">

<br />

**Entity Table | Mixed Deployment Statuses**
<img width="750" alt="pr-screenshot__46__entity-table__deployment-status-(mixed)__nav-menu-collapsed" src="https://user-images.githubusercontent.com/77648584/160859580-9df452e7-a915-464c-b151-4dc55f8523f2.PNG">

<br />

**Entity Table | Filter Applied**
<img width="748" alt="pr-screenshot__46__entity-table__deployment-status-(mixed)__filtered__nav-menu-collapsed" src="https://user-images.githubusercontent.com/77648584/160859794-39f1b94c-c8f2-4d6d-a567-6ebf907fbeb6.PNG">

<br />

**Entity Table | Ascending Sort | Last Updated Column**
<img width="748" alt="pr-screenshot__46__entity-table__deployment-status-(mixed)__sort-(last-updated-asc)__nav-menu-collapsed" src="https://user-images.githubusercontent.com/77648584/160860054-79a7f69b-d9e5-4150-a134-e2a5ba3e20ca.PNG">

<br />

**Entity Table | Ascending Sort | Name Column**
<img width="748" alt="pr-screenshot__46__entity-table__deployment-status-(mixed)__sort-(name-asc)__nav-menu-collapsed" src="https://user-images.githubusercontent.com/77648584/160860325-7f7b9092-e75d-4ddc-8803-ee985f1ad8fa.PNG">

<br />

**Entity Table | Descending Sort | Name Column**
<img width="748" alt="pr-screenshot__46__entity-table__deployment-status-(mixed)__sort-(name-desc)__nav-menu-collapsed" src="https://user-images.githubusercontent.com/77648584/160861109-969ef21d-bbb3-4355-86ee-38988aad2a91.PNG">

