### PR TITLE
Add an npm script to regenerate Flow types

### DIFF
--- a/flow_deps/.gitignore
+++ b/flow_deps/.gitignore
@@ -1,0 +1,1 @@
+flow-bin/

--- a/flow_deps/README.MD
+++ b/flow_deps/README.MD
@@ -1,13 +1,13 @@
 ### What is this folder?
+
 This folder houses the files we pull in from the [estuary/flow](https://github.com/estuary/flow/) project. 
 
 The types should be used along with the server responses.
 
 ### How do we update the types?
-For this you'll need `flowctl` installed and the Flow project pulled locally. In the root of the flow project you will need to run the following command:
-`flowctl schemalate typescript --name catalog --hoist-definitions < flow.schema.json > flow.d.ts`
 
-After that you need to copy the `flow.d.ts` file into the `flow_deps` folder.
+Run `npm run generate-flow-types`, which will download the latest Flow binaries and generate the typescript types into `flow_deps/flow.d.ts`.
 
 ### How often do we update these files?
+#
 It is still undecided. Probably whenever the folks that "own" Flow tell us we need to update. This should not happen _all_ the time, but will be frequent enough we'll want to automate this. 

--- a/flow_deps/fetch-flow.sh
+++ b/flow_deps/fetch-flow.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Fetches the latest binary release of Flow and writes the binaries to the `flow-bin/` directory.
+# The release name is read from the `FLOW_RELEASE` env variable, but it defaults to "dev".
+
+FLOW_RELEASE="${FLOW_RELEASE:-dev}"
+mkdir -p flow-bin
+rm -f flow-bin/*
+cd flow-bin && curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flow-x86-linux.tar.gz" | tar -zx 

--- a/flow_deps/flow.d.ts
+++ b/flow_deps/flow.d.ts
@@ -1,4 +1,4 @@
-export type catalog = /* Catalog Each catalog source defines a portion of a Flow Catalog, by defining collections, derivations, tests, and materializations of the Catalog. Catalog sources may reference and import other sources, in order to collections and other entities that source defines. */ {
+export type Catalog = /* Catalog Each catalog source defines a portion of a Flow Catalog, by defining collections, derivations, tests, and materializations of the Catalog. Catalog sources may reference and import other sources, in order to collections and other entities that source defines. */ {
     "$schema"?: /* JSON-Schema against which the Catalog is validated. */ string | null;
     captures?: /* Captures of this Catalog. */ {
         [k: string]: CaptureDef;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "lint": "eslint --ext js,jsx,ts,tsx .",
         "lint:fix": "eslint --fix --ext js,jsx,ts,tsx .",
         "lint-staged": "lint-staged --config .lint-staged.js",
-        "typecheck": "tsc"
+        "typecheck": "tsc",
+        "generate-flow-types": "cd flow_deps && ./fetch-flow.sh && ./flow-bin/flowctl json-schema | ./flow-bin/flowctl schemalate typescript --name Catalog --hoist-definitions > flow.d.ts"
     },
     "dependencies": {
         "@emotion/react": "^11.7.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,8 +30,8 @@
         "strictNullChecks": true,
         "skipLibCheck": true,
         "resolveJsonModule": true,
-        "typeRoots": ["src/types", "node_modules/@types", "flow_deps"]
+        "typeRoots": ["src/types", "node_modules/@types"]
     },
-    "include": ["src", "flow_deps"],
-    "exclude": ["node_modules", "build", "scripts"]
+    "include": ["src", "flow_deps/flow.d.ts"],
+    "exclude": ["node_modules", "build", "scripts", "flow_deps/flow-bin"]
 }


### PR DESCRIPTION
### Changes

The file `flow_deps/flow.d.ts` contains Typescript type definitions for all the Flow catalog types. This commit adds a slightly easier way of updating those types to the latest version. This is achieved by adding `fetch-flow.sh`, which downloads the most recent build of `flowctl`, and then calling that in an npm script to re-generate the types.

I also renamed `catalog` to `Catalog`, to use the idiom of types having upper case names. That type seems to not be used anywhere by name, so there were no other code changes.

I removed `flow_deps` from `typeRoots` in `tsconfig`. My understanding is that it wasn't necessary for it to be there in the first place, but please LMK if that's not right. When it was present, it prevented me from putting the `flow-bin/` directory under `flow_deps/` because it expected it to be a typescript module. The `package.json` was changed to make inclusion of `flow.d.ts` explicit, to avoid issues with other files being included in the typescript build accidentally.

### Tests

I manually tested this and confirmed with `diff` that the only change to `flow.d.ts` is the rename from `catalog` to `Catalog`.

### Content: no change

### Screenshots

:framed_picture: 