### PR TITLE
Update Styling of Page Not Found Error

### DIFF
--- a/src/app/Authenticated.tsx
+++ b/src/app/Authenticated.tsx
@@ -1,9 +1,9 @@
 import { Skeleton } from '@mui/material';
 import AppLayout from 'AppLayout';
+import PageNotFound from 'pages/error/PageNotFound';
 import Home from 'pages/Home';
 import { lazy, Suspense } from 'react';
 import { Route, Routes } from 'react-router';
-import Error from '../pages/Error';
 
 const Admin = lazy(() => import('../pages/Admin'));
 
@@ -46,7 +46,7 @@ const Authenticated = () => {
                     <Route path="admin/*" element={<Admin />} />
                     <Route path="builds" element={<Builds />} />
                 </Route>
-                <Route path="*" element={<Error />} />
+                <Route path="*" element={<PageNotFound />} />
             </Routes>
         </Suspense>
     );

--- a/src/components/header/Topbar.tsx
+++ b/src/components/header/Topbar.tsx
@@ -13,10 +13,11 @@ import Logo from '../navigation/Logo';
 interface TopbarProps extends BaseComponentProps {
     isNavigationOpen: boolean;
     onNavigationToggle?: Function;
+    hideNavigationMenu?: true;
 }
 
 const Topbar = (props: TopbarProps) => {
-    const { onNavigationToggle } = props;
+    const { onNavigationToggle, hideNavigationMenu } = props;
     const intl = useIntl();
     const theme = useTheme();
     const { user } = Auth.useUser();
@@ -44,7 +45,7 @@ const Topbar = (props: TopbarProps) => {
                     px: 1,
                 }}
             >
-                {user ? (
+                {hideNavigationMenu || !user ? null : (
                     <Box
                         sx={{
                             mr: 1,
@@ -60,7 +61,7 @@ const Topbar = (props: TopbarProps) => {
                             <MenuIcon />
                         </IconButton>
                     </Box>
-                ) : null}
+                )}
 
                 <Box
                     sx={{

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -85,6 +85,10 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'home.main.header': `Welcome to Flow!`,
     'home.main.description': `Click the Capture link over on the side navigation to get started.`,
 
+    // Error Page - Page Not Found
+    'pageNotFound.heading': `Sorry, that page cannot be found.`,
+    'pageNotFound.message': `Try searching for a page below or go directly to your {dashboard}.`,
+
     //Rest of the pages go down here. They don't have real pages right now.
     'admin.header': `Administration`,
 

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -6,8 +6,7 @@ import PageContainer from 'components/shared/PageContainer';
 const Error = () => {
     return (
         <PageContainer>
-            {/* TODO: Remove menu icon from this instance of the header component. */}
-            <Topbar isNavigationOpen={false} />
+            <Topbar isNavigationOpen={false} hideNavigationMenu />
             <Typography variant="h5" align="center" sx={{ mb: 2 }}>
                 Sorry, that page cannot be found.
             </Typography>

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -21,9 +21,9 @@ const Error = () => {
 
     const pages: { name: string; route: string }[] = [
         { name: 'Dashboard', route: '/' },
-        { name: 'Captures', route: '/app/captures' },
-        { name: 'Materializations', route: '/app/materializations' },
-        { name: 'Admin', route: '/app/admin' },
+        { name: 'Captures', route: '/captures' },
+        { name: 'Materializations', route: '/materializations' },
+        { name: 'Admin', route: '/admin' },
     ];
 
     const handlers = {

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -1,5 +1,7 @@
 import { ArrowForward } from '@mui/icons-material';
 import {
+    Autocomplete,
+    AutocompleteInputChangeReason,
     Box,
     IconButton,
     InputBase,
@@ -9,14 +11,36 @@ import {
 } from '@mui/material';
 import Topbar from 'components/header/Topbar';
 import PageContainer from 'components/shared/PageContainer';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const Error = () => {
     const navigate = useNavigate();
 
+    const [route, setRoute] = useState<string>('');
+
+    const pages: { name: string; route: string }[] = [
+        { name: 'Dashboard', route: '/' },
+        { name: 'Captures', route: '/app/captures' },
+        { name: 'Materializations', route: '/app/materializations' },
+        { name: 'Admin', route: '/app/admin' },
+    ];
+
     const handlers = {
+        routeSelected: (
+            event: React.SyntheticEvent,
+            value: string,
+            reason: AutocompleteInputChangeReason
+        ) => {
+            if (reason === 'reset') {
+                const selectedRoute =
+                    pages.find(({ name }) => name === value)?.route ?? '/';
+
+                setRoute(selectedRoute);
+            }
+        },
         requestNavigation: () => {
-            navigate('/');
+            navigate(route);
         },
     };
 
@@ -48,29 +72,36 @@ const Error = () => {
                 <Paper
                     variant="outlined"
                     sx={{
-                        'width': 394,
-                        'display': 'flex',
-                        'borderRadius': 5,
-                        '&:focus': {
-                            outlineWidth: 2,
-                            outlineColor: '#000000',
-                            outlineStyle: 'solid',
-                        },
+                        width: 394,
+                        display: 'flex',
+                        borderRadius: 5,
                     }}
                 >
-                    {/* TODO: Add autocomplete functionality to the custom search navigation bar. */}
-                    <InputBase
-                        placeholder="Search Navigation Menu"
-                        size="medium"
+                    {/* TODO: Update and add error handling to the autocomplete functionality. */}
+                    <Autocomplete
+                        options={pages.map((page) => page.name)}
                         fullWidth
-                        sx={{
-                            '.MuiInputBase-input': {
-                                'px': 1.75,
-                                'py': 1.0625,
-                                '&:focus-visible, &:hover': {
-                                    color: '#5660BD',
-                                },
-                            },
+                        onInputChange={handlers.routeSelected}
+                        renderInput={(params) => {
+                            const { InputLabelProps, InputProps, ...rest } =
+                                params;
+
+                            return (
+                                <InputBase
+                                    {...InputProps}
+                                    {...rest}
+                                    placeholder="Search Navigation Menu"
+                                    sx={{
+                                        '.MuiInputBase-input': {
+                                            'px': 1.75,
+                                            'py': 1.0625,
+                                            '&:focus-visible, &:hover': {
+                                                color: '#5660BD',
+                                            },
+                                        },
+                                    }}
+                                />
+                            );
                         }}
                     />
 
@@ -86,6 +117,22 @@ const Error = () => {
                         <ArrowForward />
                     </IconButton>
                 </Paper>
+
+                {/* <InputBase
+                    placeholder="Search Navigation Menu"
+                    size="medium"
+                    fullWidth
+                    type="search"
+                    sx={{
+                        '.MuiInputBase-input': {
+                            'px': 1.75,
+                            'py': 1.0625,
+                            '&:focus-visible, &:hover': {
+                                color: '#5660BD',
+                            },
+                        },
+                    }}
+                /> */}
             </Box>
         </PageContainer>
     );

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -1,15 +1,62 @@
-import { Alert, AlertTitle, Box } from '@mui/material';
+import { ArrowForward } from '@mui/icons-material';
+import { Box, IconButton, InputBase, Paper, Typography } from '@mui/material';
+import Topbar from 'components/header/Topbar';
 import PageContainer from 'components/shared/PageContainer';
-import { NavLink } from 'react-router-dom';
 
 const Error = () => {
     return (
         <PageContainer>
-            <Alert severity="error">
-                <AlertTitle>Error</AlertTitle>
-                <Box>This path does not exist.</Box>
-                <NavLink to="/">Return to homepage</NavLink>
-            </Alert>
+            {/* TODO: Remove menu icon from this instance of the header component. */}
+            <Topbar isNavigationOpen={false} />
+            <Typography variant="h5" align="center" sx={{ mb: 2 }}>
+                Sorry, that page cannot be found.
+            </Typography>
+
+            {/* TODO: Add in-line button that routes to the dashboard page. */}
+            <Typography align="center" sx={{ mb: 7 }}>
+                Try searching for a page below or go directly to your dashboard.
+            </Typography>
+
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    borderRadius: 5,
+                }}
+            >
+                {/* TODO: Extend functionality and styling of custom search navigation bar. */}
+                <Paper
+                    variant="outlined"
+                    sx={{
+                        width: 394,
+                        display: 'flex',
+                        borderRadius: 5,
+                    }}
+                >
+                    <InputBase
+                        placeholder="Search Navigation Menu"
+                        size="medium"
+                        fullWidth
+                        sx={{
+                            '.MuiInputBase-input': {
+                                px: 1.75,
+                                py: 1.0625,
+                            },
+                        }}
+                    />
+                    <IconButton
+                        sx={{
+                            borderTopLeftRadius: 0,
+                            borderTopRightRadius: 9,
+                            borderBottomRightRadius: 9,
+                            borderBottomLeftRadius: 0,
+                        }}
+                    >
+                        <ArrowForward />
+                    </IconButton>
+                </Paper>
+            </Box>
         </PageContainer>
     );
 };

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -117,22 +117,6 @@ const Error = () => {
                         <ArrowForward />
                     </IconButton>
                 </Paper>
-
-                {/* <InputBase
-                    placeholder="Search Navigation Menu"
-                    size="medium"
-                    fullWidth
-                    type="search"
-                    sx={{
-                        '.MuiInputBase-input': {
-                            'px': 1.75,
-                            'py': 1.0625,
-                            '&:focus-visible, &:hover': {
-                                color: '#5660BD',
-                            },
-                        },
-                    }}
-                /> */}
             </Box>
         </PageContainer>
     );

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -9,8 +9,17 @@ import {
 } from '@mui/material';
 import Topbar from 'components/header/Topbar';
 import PageContainer from 'components/shared/PageContainer';
+import { useNavigate } from 'react-router-dom';
 
 const Error = () => {
+    const navigate = useNavigate();
+
+    const handlers = {
+        requestNavigation: () => {
+            navigate('/');
+        },
+    };
+
     return (
         <PageContainer>
             <Topbar isNavigationOpen={false} hideNavigationMenu />
@@ -39,23 +48,34 @@ const Error = () => {
                 <Paper
                     variant="outlined"
                     sx={{
-                        width: 394,
-                        display: 'flex',
-                        borderRadius: 5,
+                        'width': 394,
+                        'display': 'flex',
+                        'borderRadius': 5,
+                        '&:focus': {
+                            outlineWidth: 2,
+                            outlineColor: '#000000',
+                            outlineStyle: 'solid',
+                        },
                     }}
                 >
+                    {/* TODO: Add autocomplete functionality to the custom search navigation bar. */}
                     <InputBase
                         placeholder="Search Navigation Menu"
                         size="medium"
                         fullWidth
                         sx={{
                             '.MuiInputBase-input': {
-                                px: 1.75,
-                                py: 1.0625,
+                                'px': 1.75,
+                                'py': 1.0625,
+                                '&:focus-visible, &:hover': {
+                                    color: '#5660BD',
+                                },
                             },
                         }}
                     />
+
                     <IconButton
+                        onClick={handlers.requestNavigation}
                         sx={{
                             borderTopLeftRadius: 0,
                             borderTopRightRadius: 9,

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -1,5 +1,12 @@
 import { ArrowForward } from '@mui/icons-material';
-import { Box, IconButton, InputBase, Paper, Typography } from '@mui/material';
+import {
+    Box,
+    IconButton,
+    InputBase,
+    Link,
+    Paper,
+    Typography,
+} from '@mui/material';
 import Topbar from 'components/header/Topbar';
 import PageContainer from 'components/shared/PageContainer';
 
@@ -11,9 +18,13 @@ const Error = () => {
                 Sorry, that page cannot be found.
             </Typography>
 
-            {/* TODO: Add in-line button that routes to the dashboard page. */}
+            {/* TODO: Consider adjusting the focus-visible state of the dashboard link. */}
             <Typography align="center" sx={{ mb: 7 }}>
-                Try searching for a page below or go directly to your dashboard.
+                Try searching for a page below or go directly to your{' '}
+                <Link href="/" underline="none">
+                    dashboard
+                </Link>
+                .
             </Typography>
 
             <Box

--- a/src/pages/error/PageNotFound.tsx
+++ b/src/pages/error/PageNotFound.tsx
@@ -14,7 +14,7 @@ import PageContainer from 'components/shared/PageContainer';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const Error = () => {
+const PageNotFound = () => {
     const navigate = useNavigate();
 
     const [route, setRoute] = useState<string>('');
@@ -122,4 +122,4 @@ const Error = () => {
     );
 };
 
-export default Error;
+export default PageNotFound;

--- a/src/pages/error/PageNotFound.tsx
+++ b/src/pages/error/PageNotFound.tsx
@@ -12,6 +12,7 @@ import {
 import Topbar from 'components/header/Topbar';
 import PageContainer from 'components/shared/PageContainer';
 import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
 const PageNotFound = () => {
@@ -47,17 +48,23 @@ const PageNotFound = () => {
     return (
         <PageContainer>
             <Topbar isNavigationOpen={false} hideNavigationMenu />
+
             <Typography variant="h5" align="center" sx={{ mb: 2 }}>
-                Sorry, that page cannot be found.
+                <FormattedMessage id="pageNotFound.heading" />
             </Typography>
 
             {/* TODO: Consider adjusting the focus-visible state of the dashboard link. */}
             <Typography align="center" sx={{ mb: 7 }}>
-                Try searching for a page below or go directly to your{' '}
-                <Link href="/" underline="none">
-                    dashboard
-                </Link>
-                .
+                <FormattedMessage
+                    id="pageNotFound.message"
+                    values={{
+                        dashboard: (
+                            <Link href="/" underline="none">
+                                dashboard
+                            </Link>
+                        ),
+                    }}
+                />
             </Typography>
 
             <Box

--- a/src/pages/error/PageNotFound.tsx
+++ b/src/pages/error/PageNotFound.tsx
@@ -90,7 +90,7 @@ const PageNotFound = () => {
                                 <InputBase
                                     {...InputProps}
                                     {...rest}
-                                    placeholder="Search Navigation Menu"
+                                    placeholder="Search Navigation Options"
                                     sx={{
                                         '.MuiInputBase-input': {
                                             'px': 1.75,


### PR DESCRIPTION
### Changes

The following features are included in this PR:

1. Update the styling of the error page displayed in response to a 404 error in the authenticated application flow.

1. Rename the `Error` component (i.e., _src/pages/Error.tsx_) to `PageNotFound`.

1. Relocate the aforementioned error page to `pages/error`, a subdirectory to house all error pages. The full path for the renamed and relocated file is: _src/pages/error/PageNotFound.tsx_.

**NOTE:** There will be UX updates to this page in the near future.

### Tests

Only manual testing was performed.

### Screenshots

**Page Not Found | Authenticated App Flow**
<img width="612" alt="pr-screenshot__73__auth-flow__404-error-page" src="https://user-images.githubusercontent.com/77648584/162264302-f6d02544-ea5d-46eb-b8d4-cfac11944f22.PNG">
