### PR TITLE
Changing capture name display and table filter label

### DIFF
--- a/src/components/capture/DetailsForm.tsx
+++ b/src/components/capture/DetailsForm.tsx
@@ -16,6 +16,7 @@ import {
     showValidation,
 } from 'services/jsonforms';
 import { StoreSelector } from 'types';
+import { getConnectorName } from 'utils/misc-utils';
 
 interface Props {
     connectorTags: ConnectorTag[];
@@ -63,10 +64,10 @@ function NewCaptureDetails({ connectorTags }: Props) {
                     }),
                     oneOf:
                         connectorTags.length > 0
-                            ? connectorTags.map((connector: any) => {
+                            ? connectorTags.map((connector) => {
                                   return {
                                       const: connector.id,
-                                      title: connector.connectors.detail,
+                                      title: getConnectorName(connector),
                                   };
                               })
                             : ([] as { title: string; const: string }[]),

--- a/src/components/capture/create/index.tsx
+++ b/src/components/capture/create/index.tsx
@@ -36,11 +36,13 @@ export interface ConnectorTag {
     id: string;
     image_tag: string;
     protocol: string;
+    title: string;
 }
 const CONNECTOR_TAG_QUERY = `
     id, 
     image_tag,
     protocol,
+    endpoint_spec_schema->>title,
     connectors(detail, image_name)
 `;
 const FORM_ID = 'newCaptureForm';
@@ -102,6 +104,8 @@ function CaptureCreate() {
     const { data: connectorTags, error: connectorTagsError } =
         useSelect(tagsQuery);
     const hasConnectors = connectorTags && connectorTags.data.length > 0;
+
+    console.log('c', connectorTags);
 
     // Notification store
     const showNotification = useNotificationStore(

--- a/src/components/capture/create/index.tsx
+++ b/src/components/capture/create/index.tsx
@@ -105,8 +105,6 @@ function CaptureCreate() {
         useSelect(tagsQuery);
     const hasConnectors = connectorTags && connectorTags.data.length > 0;
 
-    console.log('c', connectorTags);
-
     // Notification store
     const showNotification = useNotificationStore(
         selectors.notifications.showNotification

--- a/src/components/tables/Captures/index.tsx
+++ b/src/components/tables/Captures/index.tsx
@@ -76,6 +76,7 @@ function CapturesTable() {
                 columnToSort={columnToSort}
                 setColumnToSort={setColumnToSort}
                 header="captureTable.header"
+                filterLabel="entityTable.filterLabel"
             />
         </Box>
     );

--- a/src/components/tables/Connectors/Rows.tsx
+++ b/src/components/tables/Connectors/Rows.tsx
@@ -24,6 +24,9 @@ function Rows({ data }: Props) {
                     <TableCell style={columnStyling}>
                         {row.image_name}
                     </TableCell>
+                    <TableCell style={columnStyling}>
+                        {row.connector_tags[0].title}
+                    </TableCell>
                     <TableCell style={columnStyling}>{row.detail}</TableCell>
                     <TableCell style={columnStyling}>
                         {row.connector_tags[0].protocol}

--- a/src/components/tables/Connectors/index.tsx
+++ b/src/components/tables/Connectors/index.tsx
@@ -114,6 +114,7 @@ function ConnectorsTable() {
                 columnToSort={columnToSort}
                 setColumnToSort={setColumnToSort}
                 header="connectorTable.title"
+                filterLabel="connectorTable.filterLabel"
             />
         </Box>
     );

--- a/src/components/tables/Connectors/index.tsx
+++ b/src/components/tables/Connectors/index.tsx
@@ -14,6 +14,10 @@ const tableColumns = [
         headerIntlKey: 'connectorTable.data.image_name',
     },
     {
+        field: null,
+        headerIntlKey: 'connectorTable.data.title',
+    },
+    {
         field: 'detail',
         headerIntlKey: 'connectorTable.data.detail',
     },
@@ -41,6 +45,7 @@ export interface Connector {
         protocol: string;
         image_tag: string;
         id: string;
+        title: string;
     }[];
     id: string;
     detail: string;
@@ -57,7 +62,8 @@ const CONNECTOR_QUERY = `
         documentation_url,
         protocol,
         image_tag,
-        id
+        id,
+        endpoint_spec_schema->>title
     )
 `;
 

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -54,6 +54,7 @@ interface Props {
     setColumnToSort: (data: any) => void;
     rowsPerPage: number;
     header: string;
+    filterLabel: string;
     noExistingDataContentIds: {
         header: string;
         message: string;
@@ -91,6 +92,7 @@ function EntityTable({
     columnToSort,
     setColumnToSort,
     header,
+    filterLabel,
 }: Props) {
     const [page, setPage] = useState(0);
 
@@ -203,7 +205,9 @@ function EntityTable({
                         <SearchIcon sx={{ mb: 0.9, mr: 0.5, fontSize: 18 }} />
                         <TextField
                             id="capture-search-box"
-                            label="Filter Namespaces"
+                            label={intl.formatMessage({
+                                id: filterLabel,
+                            })}
                             variant="standard"
                             onChange={handlers.filterTable}
                         />

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -164,6 +164,7 @@ const LogsDialog: ResolvedIntlConfig['messages'] = {
 const AdminPage: ResolvedIntlConfig['messages'] = {
     'connectorTable.title': `Installed ${CommonMessages['terms.connectors']}`,
     'connectorTable.title.aria': `Table of all installed ${CommonMessages['terms.connectors']}`,
+    'connectorTable.data.title': `Name`,
     'connectorTable.data.image_name': `Image`,
     'connectorTable.data.detail': `Details`,
     'connectorTable.data.protocol': `Protocol`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -101,6 +101,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'captureTable.header': `Published Captures`,
     'entityTable.title': `Entity Table`,
 
+    'entityTable.filterLabel': `Filter Namespaces`,
     'entityTable.data.entity': `Name`,
     'entityTable.data.connectorType': `Type`,
     'entityTable.data.lastUpdated': `Last Updated`,
@@ -164,6 +165,7 @@ const LogsDialog: ResolvedIntlConfig['messages'] = {
 const AdminPage: ResolvedIntlConfig['messages'] = {
     'connectorTable.title': `Installed ${CommonMessages['terms.connectors']}`,
     'connectorTable.title.aria': `Table of all installed ${CommonMessages['terms.connectors']}`,
+    'connectorTable.filterLabel': `Filter Name or Detail`,
     'connectorTable.data.title': `Name`,
     'connectorTable.data.image_name': `Image`,
     'connectorTable.data.detail': `Details`,

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -1,8 +1,18 @@
+import { ConnectorTag } from 'components/capture/create';
+
 export const stripPathing = (stringVal: string) => {
     return stringVal.substring(
         stringVal.lastIndexOf('/') + 1,
         stringVal.length
     );
+};
+
+export const getConnectorName = (connectorTag: ConnectorTag) => {
+    if (connectorTag.title) return connectorTag.title;
+    if (connectorTag.connectors.detail) return connectorTag.connectors.detail;
+    if (connectorTag.image_tag) return stripPathing(connectorTag.image_tag);
+
+    throw new Error('Could not figure out Connector Name');
 };
 
 export type DeploymentStatus = 'ACTIVE' | 'INACTIVE';


### PR DESCRIPTION
## Changes

Can now pass in a label to the entity table filter
Using the Schema title as the name for connectors if available
Add Connector title to Admin table

## Tests

Manual

## Issues

Wrapping up: https://github.com/estuary/ui/issues/73

## Content

New label for the filter

## Screenshots

Label for Connector table
![image](https://user-images.githubusercontent.com/270078/164779162-4e26cca8-4da9-4466-8051-cadf05f8532f.png)

Connectors list
![image](https://user-images.githubusercontent.com/270078/164779214-00113195-fa97-4c33-bb66-8f59ac457336.png)

Added Connector Title to admin table
![image](https://user-images.githubusercontent.com/270078/164779762-e07cd891-ecdf-4ebc-91fb-3cb9e0975542.png)
