### PR TITLE
Table pagination fixes

### DIFF
--- a/src/components/capture/create/index.tsx
+++ b/src/components/capture/create/index.tsx
@@ -47,7 +47,7 @@ const CONNECTOR_TAG_QUERY = `
 `;
 const FORM_ID = 'newCaptureForm';
 
-// TODO - need to get this typing to work... too many repeated types
+// TODO (zustand) - need to get this typing to work... too many repeated types
 const selectors = {
     page: {
         captureName: (state: CaptureCreationState) => state.details.data.name,
@@ -324,7 +324,7 @@ function CaptureCreate() {
             let detailHasErrors = false;
             let specHasErrors = false;
 
-            // TODO - this was to make TS/Linting happy
+            // TODO (linting) - this was to make TS/Linting happy
             detailHasErrors = detailErrors ? detailErrors.length > 0 : false;
             specHasErrors = specErrors ? specErrors.length > 0 : false;
 

--- a/src/components/editor/Store.tsx
+++ b/src/components/editor/Store.tsx
@@ -88,7 +88,7 @@ export const ZustandProvider = ({
     );
 };
 
-// TODO (typing) This is brute forcing the types basically and force the functions using this
+// TODO (zustand / typing) This is brute forcing the types basically and force the functions using this
 //  To be WAY too verbose than need be.
 export const useZustandStore = <S extends Object, U>(
     selector: StateSelector<S, U>,

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import ExploreIcon from '@mui/icons-material/Explore';
 import HomeRepairServiceIcon from '@mui/icons-material/HomeRepairService';
-//TODO - These icons are not final
+//TODO (UI / UX) - These icons are not final
 import InputIcon from '@mui/icons-material/Input';
 import StorageIcon from '@mui/icons-material/Storage';
 import { Box, List, Toolbar, useMediaQuery, useTheme } from '@mui/material';

--- a/src/components/tables/Captures/index.tsx
+++ b/src/components/tables/Captures/index.tsx
@@ -70,7 +70,6 @@ function CapturesTable() {
                 renderTableRows={(data) => <Rows data={data} />}
                 setPagination={setPagination}
                 setSearchQuery={setSearchQuery}
-                rowsPerPage={rowsPerPage}
                 sortDirection={sortDirection}
                 setSortDirection={setSortDirection}
                 columnToSort={columnToSort}

--- a/src/components/tables/Connectors/index.tsx
+++ b/src/components/tables/Connectors/index.tsx
@@ -109,7 +109,6 @@ function ConnectorsTable() {
                 renderTableRows={(data) => <Rows data={data} />}
                 setPagination={setPagination}
                 setSearchQuery={setSearchQuery}
-                rowsPerPage={rowsPerPage}
                 sortDirection={sortDirection}
                 setSortDirection={setSortDirection}
                 columnToSort={columnToSort}

--- a/src/components/tables/Connectors/index.tsx
+++ b/src/components/tables/Connectors/index.tsx
@@ -80,6 +80,7 @@ function ConnectorsTable() {
         TABLES.CONNECTORS,
         {
             columns: CONNECTOR_QUERY,
+            count: 'exact',
             filter: (query) => {
                 return defaultTableFilter<Connector>(
                     query,

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -278,7 +278,7 @@ function EntityTable({
                                 renderTableRows(selectData)
                             ) : (
                                 <TableRow>
-                                    <TableCell colSpan={4}>
+                                    <TableCell colSpan={columns.length}>
                                         <Box
                                             sx={{
                                                 display: 'flex',
@@ -321,7 +321,7 @@ function EntityTable({
                             {emptyRows > 0 && (
                                 <TableRow>
                                     <TableCell
-                                        colSpan={4}
+                                        colSpan={columns.length}
                                         sx={{
                                             height: rowHeight * emptyRows,
                                         }}

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -78,6 +78,7 @@ export const getPagination = (currPage: number, size: number) => {
 const rowsPerPageOptions = [10, 25, 50];
 
 // TODO (tables) I think we should switch this to React Table soon
+//   Also - you MUST include a count with your query or else pagination breaks
 function EntityTable({
     columns,
     noExistingDataContentIds,

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -52,7 +52,6 @@ interface Props {
     setSortDirection: (data: any) => void;
     columnToSort: string;
     setColumnToSort: (data: any) => void;
-    rowsPerPage: number;
     header: string;
     filterLabel: string;
     noExistingDataContentIds: {
@@ -68,8 +67,6 @@ interface TableState {
     error?: PostgrestError;
 }
 
-const rowHeight = 57;
-
 export const getPagination = (currPage: number, size: number) => {
     const limit = size;
     const from = currPage ? currPage * limit : 0;
@@ -78,13 +75,14 @@ export const getPagination = (currPage: number, size: number) => {
     return { from, to };
 };
 
+const rowsPerPageOptions = [10, 25, 50];
+
 // TODO (tables) I think we should switch this to React Table soon
 function EntityTable({
     columns,
     noExistingDataContentIds,
     query,
     renderTableRows,
-    rowsPerPage,
     setPagination,
     setSearchQuery,
     sortDirection,
@@ -101,6 +99,7 @@ function EntityTable({
 
     const intl = useIntl();
 
+    const [rowsPerPage, setRowsPerPage] = useState(rowsPerPageOptions[0]);
     const [tableState, setTableState] = useState<TableState>({
         status: TableStatuses.LOADING,
     });
@@ -112,10 +111,6 @@ function EntityTable({
             setTableState({ status: TableStatuses.NO_EXISTING_DATA });
         }
     }, [selectData, isValidating]);
-
-    const emptyRows = selectData
-        ? Math.max(0, (1 + page) * rowsPerPage - selectData.length)
-        : rowsPerPage;
 
     const getEmptyTableHeader = (tableStatus: TableStatuses): string => {
         switch (tableStatus) {
@@ -184,6 +179,12 @@ function EntityTable({
         ) => {
             setPagination(getPagination(newPage, rowsPerPage));
             setPage(newPage);
+        },
+        changeRowsPerPage: (event: ChangeEvent<HTMLInputElement>) => {
+            const newLimit = parseInt(event.target.value, 10);
+            setRowsPerPage(newLimit);
+            setPagination(getPagination(0, newLimit));
+            setPage(0);
         },
     };
 
@@ -318,27 +319,20 @@ function EntityTable({
                                     </TableCell>
                                 </TableRow>
                             )}
-                            {emptyRows > 0 && (
-                                <TableRow>
-                                    <TableCell
-                                        colSpan={columns.length}
-                                        sx={{
-                                            height: rowHeight * emptyRows,
-                                        }}
-                                    />
-                                </TableRow>
-                            )}
                         </TableBody>
 
                         {selectData && useSelectResponse?.count && (
                             <TableFooter>
                                 <TableRow>
                                     <TablePagination
-                                        rowsPerPageOptions={[rowsPerPage]}
+                                        rowsPerPageOptions={rowsPerPageOptions}
                                         count={useSelectResponse.count}
                                         rowsPerPage={rowsPerPage}
                                         page={page}
                                         onPageChange={handlers.changePage}
+                                        onRowsPerPageChange={
+                                            handlers.changeRowsPerPage
+                                        }
                                     />
                                 </TableRow>
                             </TableFooter>

--- a/src/context/Content.tsx
+++ b/src/context/Content.tsx
@@ -2,7 +2,7 @@ import enUSMessages from 'lang/en-US';
 import { IntlProvider } from 'react-intl';
 import { BaseComponentProps } from 'types';
 
-// TODO - Don't hard hardcode to EN
+// TODO (intl) - Don't hard hardcode to EN
 //    When we do we need to pass locale to MUI https://mui.com/guides/localization/
 const ContentProvider = ({ children }: BaseComponentProps) => {
     return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,19 +3,19 @@ import ReactDOM from 'react-dom';
 import App from './app';
 import AppProviders from './context';
 
-export const profilerCallback = (
-    id: any,
-    phase: any,
-    actual: number,
-    base: number,
-    start: any,
-    commit: any,
-    inter: any
-) => {
-    console.log(`Render ${id} in ${actual}`);
-    console.log('  Time > ', { actual, base, commit, start });
-    console.log('  Deet > ', { inter, phase });
-};
+// export const profilerCallback = (
+//     id: any,
+//     phase: any,
+//     actual: number,
+//     base: number,
+//     start: any,
+//     commit: any,
+//     inter: any
+// ) => {
+//     console.log(`Render ${id} in ${actual}`);
+//     console.log('  Time > ', { actual, base, commit, start });
+//     console.log('  Deet > ', { inter, phase });
+// };
 
 ReactDOM.render(
     <React.StrictMode>

--- a/src/pages/error/PageNotFound.tsx
+++ b/src/pages/error/PageNotFound.tsx
@@ -72,7 +72,7 @@ const PageNotFound = () => {
                 <FormattedMessage id="pageNotFound.heading" />
             </Typography>
 
-            {/* TODO: Consider adjusting the focus-visible state of the dashboard link. */}
+            {/* TODO (UI / UX) : Consider adjusting the focus-visible state of the dashboard link. */}
             <Typography align="center" sx={{ mb: 7 }}>
                 <FormattedMessage
                     id="pageNotFound.message"
@@ -94,7 +94,7 @@ const PageNotFound = () => {
                     borderRadius: 5,
                 }}
             >
-                {/* TODO: Extend functionality and styling of custom search navigation bar. */}
+                {/* TODO (UI / UX) : Extend functionality and styling of custom search navigation bar. */}
                 <Paper
                     variant="outlined"
                     sx={{
@@ -103,7 +103,7 @@ const PageNotFound = () => {
                         borderRadius: 5,
                     }}
                 >
-                    {/* TODO: Update and add error handling to the autocomplete functionality. */}
+                    {/* TODO (errors) : Update and add error handling to the autocomplete functionality. */}
                     <Autocomplete
                         options={pages.map((page) => page.name)}
                         fullWidth

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -18,7 +18,7 @@ export const client = <Response, Request = {}>(
     // Setup the headers
     const headersInit: HeadersInit = {};
 
-    // TODO - we'll eventually need this client again. We'll need to pull the auth headers from Supabase-SWR some how.
+    // TODO (REST) - we'll eventually need this client again. We'll need to pull the auth headers from Supabase-SWR some how.
     // const authHeader = auth.getAuthHeader();
     // if (authHeader) {
     //     headersInit.Authorization = authHeader;
@@ -30,10 +30,10 @@ export const client = <Response, Request = {}>(
 
     config.headers = headersInit;
 
-    // TODO: probably need to remove this for production
+    // TODO (REST) : probably need to remove this for production
     const API_ENDPOINT = getAPIPath();
 
-    // TODO Sometimes rest returns the full path so handling that here for now
+    // TODO (REST) Sometimes rest returns the full path so handling that here for now
     const fullEndpoint = /^(http)s?:\/\//i.test(endpoint)
         ? endpoint
         : `${API_ENDPOINT}/${endpoint}`;

--- a/src/services/jsonforms.ts
+++ b/src/services/jsonforms.ts
@@ -184,10 +184,10 @@ const generateUISchema = (
             // traverse properties
             const nextRef: string = `${currentRef}/properties`;
 
-            // TODO this is a dumb check since above it was already done
+            // TODO (linting) this is a dumb check since above it was already done
             if (jsonSchema.properties !== undefined) {
                 Object.keys(jsonSchema.properties).map((propName) => {
-                    // TODO like above this is safe but TS complained
+                    // TODO (linting) like above this is safe but TS complained
                     let value;
                     if (jsonSchema.properties) {
                         value = jsonSchema.properties[propName];

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -45,7 +45,7 @@ export const defaultTableFilter = <Data>(
     searchQuery: string | null,
     columnToSort: keyof Data,
     sortDirection: string,
-    pagination: { from: number; to: number }
+    pagination?: { from: number; to: number }
 ) => {
     let queryBuilder = query;
 
@@ -59,9 +59,13 @@ export const defaultTableFilter = <Data>(
         );
     }
 
-    return queryBuilder
-        .order(columnToSort, {
-            ascending: sortDirection === 'asc',
-        })
-        .range(pagination.from, pagination.to);
+    queryBuilder = queryBuilder.order(columnToSort, {
+        ascending: sortDirection === 'asc',
+    });
+
+    if (pagination) {
+        queryBuilder = queryBuilder.range(pagination.from, pagination.to);
+    }
+
+    return queryBuilder;
 };

--- a/src/utils/store-utils.ts
+++ b/src/utils/store-utils.ts
@@ -1,4 +1,4 @@
-// TODO - add in Immer middleware
+// TODO (zustand) - add in Immer middleware
 // https://github.com/pmndrs/zustand#middleware
 // https://github.com/pmndrs/zustand/blob/main/tests/middlewareTypes.test.tsx
 

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -22,7 +22,7 @@ const goTo = (route?: string, name?: string) => {
     );
 };
 
-// TODO - We use immer here but don't need it. The user metadata is currently just
+// TODO (testing) - We use immer here but don't need it. The user metadata is currently just
 //  any number of keys (according to the types). Hoping that changes in the future.
 const generateMockUserMetadata = (username: string) => {
     return produce(mockDeep<User['user_metadata']>(), (draft) => {


### PR DESCRIPTION
## Changes

Allow users to choose page size on table.
Removed `emptyRows` from tables. When paging this made the table hard to use.
Pagination was broken on the connectors table. Fixed it by adding a count to the query.
Prepare Supabase service to handle no pagination.
Adding details to all the `todo`s in the codebase.

## Tests

Manual

## Issues

## Content

## Screenshots

Pagination selector
![image](https://user-images.githubusercontent.com/270078/165366817-e1072269-8622-4722-8b16-b41008cb7414.png)

