### PR TITLE
Add custom connector renderer

### DIFF
--- a/src/app/Authenticated.tsx
+++ b/src/app/Authenticated.tsx
@@ -53,6 +53,9 @@ export const routeDetails = {
             title: 'routeTitle.materializationCreate',
             path: 'create',
             fullPath: '/materialization/create',
+            params: {
+                connectorID: 'connectorID',
+            },
         },
     },
     materializations: {

--- a/src/components/ConnectorName.tsx
+++ b/src/components/ConnectorName.tsx
@@ -40,7 +40,12 @@ function ConnectorName({ size = defaultSize, connector, path }: Props) {
                         alt=""
                     />
                 ) : (
-                    <QuestionMarkIcon />
+                    <QuestionMarkIcon
+                        sx={{
+                            height: size,
+                            width: size,
+                        }}
+                    />
                 )}
             </div>
             {connectorName}

--- a/src/components/ConnectorName.tsx
+++ b/src/components/ConnectorName.tsx
@@ -1,10 +1,11 @@
+import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
 import { Stack } from '@mui/material';
 import useConstant from 'use-constant';
 import { getConnectorName } from 'utils/misc-utils';
 
 interface Props {
     size?: number;
-    path: string;
+    path?: string;
     connector: any; // TODO (typing) ConnectorTag
 }
 
@@ -23,13 +24,25 @@ function ConnectorName({ size = defaultSize, connector, path }: Props) {
             sx={{
                 'alignItems': 'center',
                 'justifyContent': 'center',
-                '& > img': {
+                '& > div    ': {
                     mr: 2,
                     flexShrink: 0,
                 },
             }}
         >
-            <img width={size} height={size} src={path} loading="lazy" alt="" />
+            <div style={{ height: size, width: size }}>
+                {path ? (
+                    <img
+                        width={size}
+                        height={size}
+                        src={path}
+                        loading="lazy"
+                        alt=""
+                    />
+                ) : (
+                    <QuestionMarkIcon />
+                )}
+            </div>
             {connectorName}
         </Stack>
     );

--- a/src/components/ConnectorName.tsx
+++ b/src/components/ConnectorName.tsx
@@ -11,11 +11,25 @@ interface Props {
 const defaultSize = 15;
 
 function ConnectorName({ size = defaultSize, connector, path }: Props) {
-    const connectorName = useConstant(() => getConnectorName(connector, false));
+    const connectorName = useConstant(() =>
+        typeof connector === 'string'
+            ? connector
+            : getConnectorName(connector, false)
+    );
 
     return (
-        <Stack direction="row">
-            <img width={size} height={size} src={path} alt="" />
+        <Stack
+            direction="row"
+            sx={{
+                'alignItems': 'center',
+                'justifyContent': 'center',
+                '& > img': {
+                    mr: 2,
+                    flexShrink: 0,
+                },
+            }}
+        >
+            <img width={size} height={size} src={path} loading="lazy" alt="" />
             {connectorName}
         </Stack>
     );

--- a/src/components/capture/create/index.tsx
+++ b/src/components/capture/create/index.tsx
@@ -86,6 +86,7 @@ const notification: Notification = {
 
 function CaptureCreate() {
     useBrowserTitle('browserTitle.captureCreate');
+
     // misc hooks
     const intl = useIntl();
     const navigate = useNavigate();

--- a/src/components/materialization/DetailsForm.tsx
+++ b/src/components/materialization/DetailsForm.tsx
@@ -1,13 +1,15 @@
 import { materialCells } from '@jsonforms/material-renderers';
 import { JsonForms } from '@jsonforms/react';
 import { Alert, Box, Stack, Typography } from '@mui/material';
+import { routeDetails } from 'app/Authenticated';
 import { ConnectorTag } from 'components/materialization/create';
 import useMaterializationCreationStore, {
     CreationFormStatuses,
     CreationState,
 } from 'components/materialization/Store';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useSearchParams } from 'react-router-dom';
 import {
     defaultOptions,
     defaultRenderers,
@@ -29,6 +31,11 @@ const stateSelectors: StoreSelector<CreationState> = {
 
 function NewMaterializationDetails({ connectorTags }: Props) {
     const intl = useIntl();
+    const [searchParams] = useSearchParams();
+    const connectorID = searchParams.get(
+        routeDetails.materialization.create.params.connectorID
+    );
+
     const formData = useMaterializationCreationStore(stateSelectors.formData);
     const setDetails = useMaterializationCreationStore(
         stateSelectors.setDetails
@@ -37,6 +44,17 @@ function NewMaterializationDetails({ connectorTags }: Props) {
         stateSelectors.showValidation
     );
     const status = useMaterializationCreationStore(stateSelectors.status);
+
+    useEffect(() => {
+        if (connectorID) {
+            setDetails({
+                data: {
+                    name: '',
+                    image: connectorID,
+                },
+            });
+        }
+    }, [connectorID, setDetails]);
 
     const schema = useMemo(() => {
         return {

--- a/src/components/tables/Connectors/Rows.tsx
+++ b/src/components/tables/Connectors/Rows.tsx
@@ -98,10 +98,6 @@ function Rows({ data }: Props) {
                                     size="small"
                                     color="success"
                                     disableElevation
-                                    disabled={
-                                        row.connector_tags[0].protocol !==
-                                        'capture'
-                                    }
                                     onClick={() => {
                                         if (
                                             row.connector_tags[0].protocol ===
@@ -109,6 +105,13 @@ function Rows({ data }: Props) {
                                         ) {
                                             navigate(
                                                 `${routeDetails.capture.create.fullPath}?${routeDetails.capture.create.params.connectorID}=${row.connector_tags[0].id}`
+                                            );
+                                        } else if (
+                                            row.connector_tags[0].protocol ===
+                                            'materialization'
+                                        ) {
+                                            navigate(
+                                                `${routeDetails.materialization.create.fullPath}?${routeDetails.materialization.create.params.connectorID}=${row.connector_tags[0].id}`
                                             );
                                         }
                                     }}

--- a/src/components/tables/Connectors/Rows.tsx
+++ b/src/components/tables/Connectors/Rows.tsx
@@ -55,7 +55,7 @@ function Rows({ data }: Props) {
                 return (
                     <TableRow key={`Connector-${row.id}`}>
                         <TableCell style={columnStyling}>
-                            <ConnectorName path="" connector={row} />
+                            <ConnectorName connector={row} />
                         </TableCell>
                         <TableCell style={columnStyling}>
                             <Stack direction="row">{row.image_name}</Stack>

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -224,6 +224,7 @@ function EntityTable({
                         aria-label={intl.formatMessage({
                             id: 'entityTable.title',
                         })}
+                        size="small"
                     >
                         <TableHead>
                             <TableRow

--- a/src/forms/renderers/ConnectorAutoComplete.tsx
+++ b/src/forms/renderers/ConnectorAutoComplete.tsx
@@ -93,36 +93,39 @@ export const ConnectorAutoComplete = (
                 marginTop: 2,
                 borderColor: errors.length > 0 ? 'red' : null,
             }}
-            renderInput={(params) => {
+            renderInput={({ inputProps, InputProps }: any) => {
                 return (
-                    <>
-                        <Box
-                            sx={{
-                                position: 'absolute',
-                                left: 0,
-                                top: 26,
-                            }}
-                        >
-                            <ConnectorName
-                                path="https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg"
-                                connector=""
-                            />
-                        </Box>
+                    <Box
+                        sx={{
+                            '.MuiBox-root + .MuiInput-root > input': {
+                                textIndent: '20px',
+                            },
+                        }}
+                    >
+                        {inputProps.value !== '' ? (
+                            <Box
+                                sx={{
+                                    position: 'absolute',
+                                    left: 0,
+                                    top: 22,
+                                }}
+                            >
+                                <ConnectorName
+                                    path="https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg"
+                                    connector=""
+                                />
+                            </Box>
+                        ) : null}
 
                         <Input
-                            sx={{
-                                '& > input': {
-                                    textIndent: '20px',
-                                },
-                            }}
                             style={{ width: '100%' }}
                             type="text"
-                            inputProps={params.inputProps}
-                            inputRef={params.InputProps.ref}
+                            inputProps={inputProps}
+                            inputRef={InputProps.ref}
                             autoFocus={appliedUiSchemaOptions.focus}
                             disabled={!enabled}
                         />
-                    </>
+                    </Box>
                 );
             }}
             renderOption={(renderOptionProps: any, option) => {

--- a/src/forms/renderers/ConnectorAutoComplete.tsx
+++ b/src/forms/renderers/ConnectorAutoComplete.tsx
@@ -26,9 +26,11 @@ import { EnumCellProps, EnumOption, WithClassname } from '@jsonforms/core';
 import {
     Autocomplete,
     AutocompleteRenderOptionState,
+    Box,
     FilterOptionsState,
     Input,
 } from '@mui/material';
+import ConnectorName from 'components/ConnectorName';
 import merge from 'lodash/merge';
 import React, { ReactNode } from 'react';
 
@@ -61,7 +63,6 @@ export const ConnectorAutoComplete = (
         options,
         config,
         getOptionLabel,
-        renderOption,
         filterOptions,
     } = props;
 
@@ -92,17 +93,48 @@ export const ConnectorAutoComplete = (
                 marginTop: 2,
                 borderColor: errors.length > 0 ? 'red' : null,
             }}
-            renderInput={(params) => (
-                <Input
-                    style={{ width: '100%' }}
-                    type="text"
-                    inputProps={params.inputProps}
-                    inputRef={params.InputProps.ref}
-                    autoFocus={appliedUiSchemaOptions.focus}
-                    disabled={!enabled}
-                />
-            )}
-            renderOption={renderOption}
+            renderInput={(params) => {
+                return (
+                    <>
+                        <Box
+                            sx={{
+                                position: 'absolute',
+                                left: 0,
+                                top: 26,
+                            }}
+                        >
+                            <ConnectorName
+                                path="https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg"
+                                connector=""
+                            />
+                        </Box>
+
+                        <Input
+                            sx={{
+                                '& > input': {
+                                    textIndent: '20px',
+                                },
+                            }}
+                            style={{ width: '100%' }}
+                            type="text"
+                            inputProps={params.inputProps}
+                            inputRef={params.InputProps.ref}
+                            autoFocus={appliedUiSchemaOptions.focus}
+                            disabled={!enabled}
+                        />
+                    </>
+                );
+            }}
+            renderOption={(renderOptionProps: any, option) => {
+                return (
+                    <Box component="li" {...renderOptionProps}>
+                        <ConnectorName
+                            path="https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg"
+                            connector={option.label}
+                        />
+                    </Box>
+                );
+            }}
             filterOptions={filterOptions}
         />
     );

--- a/src/forms/renderers/ConnectorAutoComplete.tsx
+++ b/src/forms/renderers/ConnectorAutoComplete.tsx
@@ -1,0 +1,109 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2020 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { EnumCellProps, EnumOption, WithClassname } from '@jsonforms/core';
+import {
+    Autocomplete,
+    AutocompleteRenderOptionState,
+    FilterOptionsState,
+    Input,
+} from '@mui/material';
+import merge from 'lodash/merge';
+import React, { ReactNode } from 'react';
+
+export interface WithOptionLabel {
+    getOptionLabel?(option: EnumOption): string;
+    renderOption?(
+        props: React.HTMLAttributes<HTMLLIElement>,
+        option: EnumOption,
+        state: AutocompleteRenderOptionState
+    ): ReactNode;
+    filterOptions?(
+        options: EnumOption[],
+        state: FilterOptionsState<EnumOption>
+    ): EnumOption[];
+}
+
+export const ConnectorAutoComplete = (
+    props: EnumCellProps & WithClassname & WithOptionLabel
+) => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const {
+        data,
+        className,
+        id,
+        enabled,
+        errors,
+        uischema,
+        path,
+        handleChange,
+        options,
+        config,
+        getOptionLabel,
+        renderOption,
+        filterOptions,
+    } = props;
+
+    const appliedUiSchemaOptions = merge({}, config, uischema.options);
+    const [inputValue, setInputValue] = React.useState(data ?? '');
+
+    const findOption = options?.find((o) => o.value === data) ?? null;
+    return (
+        <Autocomplete
+            className={className}
+            id={id}
+            disabled={!enabled}
+            value={findOption}
+            onChange={(_event: any, newValue: EnumOption | null) => {
+                handleChange(path, newValue?.value);
+            }}
+            inputValue={inputValue}
+            onInputChange={(_event, newInputValue) => {
+                setInputValue(newInputValue);
+            }}
+            autoHighlight
+            autoSelect
+            autoComplete
+            fullWidth
+            options={options ?? []}
+            getOptionLabel={getOptionLabel ?? ((option) => option.label)}
+            sx={{
+                marginTop: 2,
+                borderColor: errors.length > 0 ? 'red' : null,
+            }}
+            renderInput={(params) => (
+                <Input
+                    style={{ width: '100%' }}
+                    type="text"
+                    inputProps={params.inputProps}
+                    inputRef={params.InputProps.ref}
+                    autoFocus={appliedUiSchemaOptions.focus}
+                    disabled={!enabled}
+                />
+            )}
+            renderOption={renderOption}
+            filterOptions={filterOptions}
+        />
+    );
+};

--- a/src/forms/renderers/ConnectorAutoComplete.tsx
+++ b/src/forms/renderers/ConnectorAutoComplete.tsx
@@ -110,10 +110,7 @@ export const ConnectorAutoComplete = (
                                     top: 22,
                                 }}
                             >
-                                <ConnectorName
-                                    path="https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg"
-                                    connector=""
-                                />
+                                <ConnectorName path="" connector="" />
                             </Box>
                         ) : null}
 
@@ -131,10 +128,7 @@ export const ConnectorAutoComplete = (
             renderOption={(renderOptionProps: any, option) => {
                 return (
                     <Box component="li" {...renderOptionProps}>
-                        <ConnectorName
-                            path="https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg"
-                            connector={option.label}
-                        />
+                        <ConnectorName path="" connector={option.label} />
                     </Box>
                 );
             }}

--- a/src/forms/renderers/Connectors.tsx
+++ b/src/forms/renderers/Connectors.tsx
@@ -1,16 +1,54 @@
-import { RankedTester, rankWith, schemaTypeIs } from '@jsonforms/core';
+import { RankedTester, rankWith, scopeEndsWith } from '@jsonforms/core';
 import { withJsonFormsLayoutProps } from '@jsonforms/react';
-import { Hidden } from '@mui/material';
+import { Autocomplete, TextField } from '@mui/material';
+
+const SCOPE = 'image';
 
 export const connectorTypeTester: RankedTester = rankWith(
     999,
-    schemaTypeIs('null')
+    scopeEndsWith(SCOPE)
 );
 
 // This is blank on purpose. For right now we can just show null settings are nothing
-const ConnectorTypeRenderer = (props: any) => {
-    const { visible } = props;
-    return <Hidden xsUp={!visible}> </Hidden>;
+const ConnectorTypeRenderer = ({
+    handleChange,
+    id,
+    data,
+    path,
+    schema,
+    uischema,
+}: any) => {
+    return (
+        <Autocomplete
+            options={schema.properties.image.oneOf}
+            renderInput={(params) => (
+                <TextField
+                    {...params}
+                    id={id}
+                    label={uischema.label}
+                    required={schema.required.includes(SCOPE)}
+                    inputProps={{
+                        ...params.inputProps,
+                        autoComplete: 'off',
+                    }}
+                />
+            )}
+            value={data}
+            onChange={(e: any) => handleChange(path, e.target.value)}
+            onSelect={(value) => handleChange(path, value)}
+
+            // renderItem={(item: any, isHighlighted: any) => (
+            //     <div
+            //         key={item}
+            //         style={{
+            //             background: isHighlighted ? 'lightgray' : 'white',
+            //         }}
+            //     >
+            //         {item}
+            //     </div>
+            // )}
+        />
+    );
 };
 
 export const ConnectorType = withJsonFormsLayoutProps(ConnectorTypeRenderer);

--- a/src/forms/renderers/Connectors.tsx
+++ b/src/forms/renderers/Connectors.tsx
@@ -1,54 +1,54 @@
-import { RankedTester, rankWith, scopeEndsWith } from '@jsonforms/core';
-import { withJsonFormsLayoutProps } from '@jsonforms/react';
-import { Autocomplete, TextField } from '@mui/material';
+/*
+  The MIT License
+
+  Copyright (c) 2018-2020 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+import {
+    and,
+    ControlProps,
+    isOneOfEnumControl,
+    OwnPropsOfEnum,
+    RankedTester,
+    rankWith,
+    scopeEndsWith,
+} from '@jsonforms/core';
+import { MaterialInputControl } from '@jsonforms/material-renderers';
+import { WithOptionLabel } from '@jsonforms/material-renderers/lib/mui-controls/MuiAutocomplete';
+import { withJsonFormsOneOfEnumProps } from '@jsonforms/react';
+import { ConnectorAutoComplete } from 'forms/renderers/ConnectorAutoComplete';
 
 const SCOPE = 'image';
 
 export const connectorTypeTester: RankedTester = rankWith(
-    999,
-    scopeEndsWith(SCOPE)
+    10,
+    and(isOneOfEnumControl, scopeEndsWith(SCOPE))
 );
 
 // This is blank on purpose. For right now we can just show null settings are nothing
-const ConnectorTypeRenderer = ({
-    handleChange,
-    id,
-    data,
-    path,
-    schema,
-    uischema,
-}: any) => {
-    return (
-        <Autocomplete
-            options={schema.properties.image.oneOf}
-            renderInput={(params) => (
-                <TextField
-                    {...params}
-                    id={id}
-                    label={uischema.label}
-                    required={schema.required.includes(SCOPE)}
-                    inputProps={{
-                        ...params.inputProps,
-                        autoComplete: 'off',
-                    }}
-                />
-            )}
-            value={data}
-            onChange={(e: any) => handleChange(path, e.target.value)}
-            onSelect={(value) => handleChange(path, value)}
-
-            // renderItem={(item: any, isHighlighted: any) => (
-            //     <div
-            //         key={item}
-            //         style={{
-            //             background: isHighlighted ? 'lightgray' : 'white',
-            //         }}
-            //     >
-            //         {item}
-            //     </div>
-            // )}
-        />
-    );
+const ConnectorTypeRenderer = (
+    props: ControlProps & OwnPropsOfEnum & WithOptionLabel
+) => {
+    return <MaterialInputControl {...props} input={ConnectorAutoComplete} />;
 };
 
-export const ConnectorType = withJsonFormsLayoutProps(ConnectorTypeRenderer);
+export const ConnectorType = withJsonFormsOneOfEnumProps(ConnectorTypeRenderer);


### PR DESCRIPTION
## Changes

Add new renderer for `image` schema elements. This first past is focused on getting an image displayed in the drop down and text input.

Added a create link for materializations from the connector tables

Handle a missing connector logo by showing a question mark. Doubt we'll want to keep this when we start having users use the app.

## Tests

Manual

## Issues


## Content

## Screenshots

![image](https://user-images.githubusercontent.com/270078/165604790-0395f198-e83e-4932-8b35-6e24c9b78fd0.png)

![image](https://user-images.githubusercontent.com/270078/165605012-e34d2ed3-3bec-4ad1-b02c-052f006b8b18.png)

![image](https://user-images.githubusercontent.com/270078/165605140-ed9141d8-0d1d-46b4-b39b-f755072695d4.png)
