### PR TITLE
Allow rendering JSON forms from wacky schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
         "ansicolor": "^1.1.100",
         "date-fns": "^2.28.0",
         "immer": "^9.0.12",
-        "json-refs": "^3.0.15",
         "lodash": "^4.17.21",
         "monaco-editor": "^0.33.0",
         "react": "^17.0.2",

--- a/src/components/materialization/ResourceConfigForm.tsx
+++ b/src/components/materialization/ResourceConfigForm.tsx
@@ -1,4 +1,3 @@
-import { createAjv } from '@jsonforms/core';
 import { materialCells } from '@jsonforms/material-renderers';
 import { JsonForms } from '@jsonforms/react';
 import { StyledEngineProvider } from '@mui/material';
@@ -9,9 +8,12 @@ import useEntityStore, {
     fooSelectors,
     FormStatus,
 } from 'components/shared/Entity/Store';
-import JsonRefs from 'json-refs';
+import {
+    createJSONFormDefaults,
+    setDefaultsValidator,
+} from 'components/shared/Entity/EndpointConfigForm';
 import { isEmpty } from 'lodash';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import {
     defaultOptions,
     defaultRenderers,
@@ -24,8 +26,6 @@ type Props = {
     resourceSchema: any;
 };
 
-const defaultAjv = createAjv({ useDefaults: true });
-
 const stateSelectors: StoreSelector<CreationState> = {
     formData: (state) => state.resourceConfig.data,
     setConfig: (state) => state.setResourceConfig,
@@ -37,63 +37,42 @@ function NewMaterializationResourceConfigForm({ resourceSchema }: Props) {
     const displayValidation = useEntityStore(fooSelectors.displayValidation);
     const status = useEntityStore(fooSelectors.formStateStatus);
 
-    const [deReffedSchema, setDeReffedSchema] = useState<any | null>(null);
-
     // Resolve Refs & Hydrate the object
     //  This will hydrate the default values for us as we don't want JSONForms to
     //  directly update the state object as it caused issues when switching connectors.
     useEffect(() => {
-        async function resolveSchemaRefs(endpointResponse: any) {
-            const processedSchema = await JsonRefs.resolveRefs(
-                endpointResponse
-            );
+        setConfig({
+            data: createJSONFormDefaults(resourceSchema),
+        });
+    }, [resourceSchema, setConfig]);
 
-            const hydrateAndValidate = defaultAjv.compile(
-                processedSchema.resolved
-            );
-            const defaultValues = {};
+    const uiSchema = generateCustomUISchema(resourceSchema);
+    const showValidationVal = showValidation(displayValidation);
 
-            hydrateAndValidate(defaultValues);
+    const handlers = {
+        onChange: (form: any) => {
+            if (!isEmpty(form.data)) {
+                setConfig(form);
+            }
+        },
+    };
 
-            setDeReffedSchema(processedSchema.resolved);
-            setConfig({
-                data: defaultValues,
-            });
-        }
-
-        void resolveSchemaRefs(resourceSchema);
-    }, [resourceSchema, setConfig, setDeReffedSchema]);
-
-    if (deReffedSchema) {
-        const uiSchema = generateCustomUISchema(deReffedSchema);
-        const showValidationVal = showValidation(displayValidation);
-
-        const handlers = {
-            onChange: (form: any) => {
-                if (!isEmpty(form.data)) {
-                    setConfig(form);
-                }
-            },
-        };
-
-        return (
-            <StyledEngineProvider injectFirst>
-                <JsonForms
-                    schema={deReffedSchema}
-                    uischema={uiSchema}
-                    data={formData}
-                    renderers={defaultRenderers}
-                    cells={materialCells}
-                    config={defaultOptions}
-                    readonly={status !== FormStatus.IDLE}
-                    validationMode={showValidationVal}
-                    onChange={handlers.onChange}
-                />
-            </StyledEngineProvider>
-        );
-    } else {
-        return null;
-    }
+    return (
+        <StyledEngineProvider injectFirst>
+            <JsonForms
+                schema={resourceSchema}
+                uischema={uiSchema}
+                data={formData}
+                renderers={defaultRenderers}
+                cells={materialCells}
+                config={defaultOptions}
+                readonly={status !== FormStatus.IDLE}
+                validationMode={showValidationVal}
+                onChange={handlers.onChange}
+                ajv={setDefaultsValidator}
+            />
+        </StyledEngineProvider>
+    );
 }
 
 export default NewMaterializationResourceConfigForm;

--- a/src/components/shared/Entity/EndpointConfigForm.tsx
+++ b/src/components/shared/Entity/EndpointConfigForm.tsx
@@ -6,9 +6,8 @@ import useEntityStore, {
     fooSelectors,
     FormStatus,
 } from 'components/shared/Entity/Store';
-import JsonRefs from 'json-refs';
 import { isEmpty } from 'lodash';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import {
     defaultOptions,
     defaultRenderers,
@@ -20,7 +19,35 @@ type Props = {
     endpointSchema: any;
 };
 
-const defaultAjv = createAjv({ useDefaults: true });
+export const setDefaultsValidator = createAjv({
+    // Causes it to mutate its input to set default values.
+    useDefaults: true,
+    // Don't barf when things aren't quite aligned with the JSON schema spec. Log it instead.
+    strict: 'log',
+    // Skip validation of the schema itself, because many connector schemas won't validate.
+    // Normally, we'd want to just fix the schemas, but this allows the validator to deal with
+    // draft-4 schemas, which normally requires using a separate legacy validator.
+    validateSchema: false,
+    // Disable validations based on `format` keywords in the schema. Ideally, we'd re-enable this at
+    // some point, but there's a few problems with it. One is that many schemas seem to mis-use the
+    // `date-time` format to mean ISO8601 instead of RFC3339. Another is that some schemas seem to
+    // use made-up format strings that we won't recognize.
+    validateFormats: false,
+});
+
+export function createJSONFormDefaults(jsonSchema: any): Object {
+    // We start with an empty object, and then validate it to set any default values.
+    // Note that this requires all parent properties to also specify a `default` in the json
+    // schema.
+    const defaultValues = {};
+    setJSONFormDefaults(jsonSchema, defaultValues);
+    return defaultValues;
+}
+
+function setJSONFormDefaults(jsonSchema: any, formData: any) {
+    const hydrateAndValidate = setDefaultsValidator.compile(jsonSchema);
+    hydrateAndValidate(formData);
+}
 
 function EndpointConfigForm({ endpointSchema }: Props) {
     const setSpec = useEntityStore(fooSelectors.setEndpointConfig);
@@ -28,60 +55,38 @@ function EndpointConfigForm({ endpointSchema }: Props) {
     const displayValidation = useEntityStore(fooSelectors.displayValidation);
     const formStateStatus = useEntityStore(fooSelectors.formStateStatus);
 
-    const [dereffedSchema, setDereffedSchema] = useState<any | null>(null);
-
-    // Resolve Refs & Hydrate the object
-    //  This will hydrate the default values for us as we don't want JSONForms to
-    //  directly update the state object as it caused issues when switching connectors.
     useEffect(() => {
-        async function resolveSchemaRefs(endpointResponse: any) {
-            const processedSchema = await JsonRefs.resolveRefs(
-                endpointResponse
-            );
-            const hydrateAndValidate = defaultAjv.compile(
-                processedSchema.resolved
-            );
-            const defaultValues = {};
-            hydrateAndValidate(defaultValues);
+        setSpec({
+            data: createJSONFormDefaults(endpointSchema),
+        });
+    }, [endpointSchema, setSpec]);
 
-            setDereffedSchema(processedSchema.resolved);
-            setSpec({
-                data: defaultValues,
-            });
-        }
+    const uiSchema = generateCustomUISchema(endpointSchema);
+    const showValidationVal = showValidation(displayValidation);
+    const handlers = {
+        onChange: (form: any) => {
+            if (!isEmpty(form.data)) {
+                setSpec(form);
+            }
+        },
+    };
 
-        void resolveSchemaRefs(endpointSchema);
-    }, [endpointSchema, setSpec, setDereffedSchema]);
-
-    if (dereffedSchema) {
-        const uiSchema = generateCustomUISchema(dereffedSchema);
-        const showValidationVal = showValidation(displayValidation);
-        const handlers = {
-            onChange: (form: any) => {
-                if (!isEmpty(form.data)) {
-                    setSpec(form);
-                }
-            },
-        };
-
-        return (
-            <StyledEngineProvider injectFirst>
-                <JsonForms
-                    schema={dereffedSchema}
-                    uischema={uiSchema}
-                    data={formData}
-                    renderers={defaultRenderers}
-                    cells={materialCells}
-                    config={defaultOptions}
-                    readonly={formStateStatus !== FormStatus.IDLE}
-                    validationMode={showValidationVal}
-                    onChange={handlers.onChange}
-                />
-            </StyledEngineProvider>
-        );
-    } else {
-        return null;
-    }
+    return (
+        <StyledEngineProvider injectFirst>
+            <JsonForms
+                schema={endpointSchema}
+                uischema={uiSchema}
+                data={formData}
+                renderers={defaultRenderers}
+                cells={materialCells}
+                config={defaultOptions}
+                readonly={formStateStatus !== FormStatus.IDLE}
+                validationMode={showValidationVal}
+                onChange={handlers.onChange}
+                ajv={setDefaultsValidator}
+            />
+        </StyledEngineProvider>
+    );
 }
 
 export default EndpointConfigForm;

--- a/src/services/jsonforms.ts
+++ b/src/services/jsonforms.ts
@@ -35,8 +35,8 @@ export const defaultRenderers = [
     { renderer: ConnectorType, tester: connectorTypeTester },
 ];
 
-export const showValidation = (val: any): ValidationMode => {
-    return val ? 'ValidateAndShow' : 'ValidateAndHide';
+export const showValidation = (_val: any): ValidationMode => {
+    return 'ValidateAndShow';
 };
 
 /**


### PR DESCRIPTION
## Changes

Fixes #107 

The EndpointConfigForm and ResourceConfigForm previously would barf
whenever they encountered a non-compliant JSON schema. This commit makes
the AJV validator much more permissive in the schemas that it will
accept.

This also removes the `json-refs` dependency and assumes that all json
schemas are fully self-contained. This property is ensured by the build
process for flow collection schemas. For endpoint and resource schemas,
it seems to also generally hold.

This seems to work to get all of our forms rendering, and so I'm submitting it as a minimal PR just to address #107. There's a number of other less major issues remaining with the forms, and I'll plan on submitting a follow-on PR to address those.

## Tests

I tested manually with all the connectors in TW and it seemed to work ok. IMO we should hold off on automated tests until we have greater certainty that JSON Forms will work for us.

## Content

_Were there any changes to [content](https://github.com/estuary/ui/tree/main/src/lang) that you need to get reviewed?_

None

## Screenshots

![image](https://user-images.githubusercontent.com/4495829/167145457-3c94d5aa-70eb-4905-bed9-455ac71e832e.png)
