### PR TITLE
Connectors Table Temporary Patch

### DIFF
--- a/src/components/tables/Connectors/Rows.tsx
+++ b/src/components/tables/Connectors/Rows.tsx
@@ -47,7 +47,7 @@ function Rows({ data }: Props) {
     return (
         <>
             {data.map((row) => {
-                return (
+                return row.connector_tags.length > 0 ? (
                     <TableRow key={`Connector-${row.id}`}>
                         <TableCell align="left" style={columnStyling}>
                             <ConnectorName
@@ -117,7 +117,7 @@ function Rows({ data }: Props) {
                             </Box>
                         </TableCell>
                     </TableRow>
-                );
+                ) : null;
             })}
         </>
     );


### PR DESCRIPTION
## Changes

Control the connectors table display so that a row is not rendered for connectors without tag information (i.e., no entries within the `connector_tags` table).

**NOTE:** This is a temporary patch. Pending an official UX decision.

## Tests

Only manual testing is performed.
