### PR TITLE
UI Tweaks 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "react-dom": "^17.0.2",
                 "react-error-boundary": "^3.1.4",
                 "react-intl": "^5.25.1",
+                "react-reflex": "^4.0.6",
                 "react-router": "^6.3.0",
                 "react-router-dom": "^6.3.0",
                 "react-use": "^17.3.2",
@@ -10420,6 +10421,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-node-dimensions": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz",
+            "integrity": "sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ=="
+        },
         "node_modules/get-own-enumerable-property-symbols": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -14059,6 +14065,11 @@
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
         },
+        "node_modules/lodash.throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+        },
         "node_modules/lodash.uniq": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -17161,6 +17172,35 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        },
+        "node_modules/react-measure": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.5.2.tgz",
+            "integrity": "sha512-M+rpbTLWJ3FD6FXvYV6YEGvQ5tMayQ3fGrZhRPHrE9bVlBYfDCLuDcgNttYfk8IqfOI03jz6cbpqMRTUclQnaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.2.0",
+                "get-node-dimensions": "^1.2.1",
+                "prop-types": "^15.6.2",
+                "resize-observer-polyfill": "^1.5.0"
+            },
+            "peerDependencies": {
+                "react": ">0.13.0",
+                "react-dom": ">0.13.0"
+            }
+        },
+        "node_modules/react-reflex": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/react-reflex/-/react-reflex-4.0.6.tgz",
+            "integrity": "sha512-nBVQg+EDJ3vKGtiOKCZHaYS8fM/QcHJhVPnat0Ua1DIrzrOI64r8e30HU/ovqDgXVbY5cOTXP4hPRVmWUBfvbQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "lodash.throttle": "^4.1.1",
+                "prop-types": "^15.5.8",
+                "react-measure": "^2.0.2"
+            },
+            "peerDependencies": {
+                "react": "^16.0.0 || ^17.0.0"
+            }
         },
         "node_modules/react-refresh": {
             "version": "0.11.0",
@@ -28774,6 +28814,11 @@
                 "has-symbols": "^1.0.1"
             }
         },
+        "get-node-dimensions": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz",
+            "integrity": "sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ=="
+        },
         "get-own-enumerable-property-symbols": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -31447,6 +31492,11 @@
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
         },
+        "lodash.throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+        },
         "lodash.uniq": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -33665,6 +33715,28 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        },
+        "react-measure": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.5.2.tgz",
+            "integrity": "sha512-M+rpbTLWJ3FD6FXvYV6YEGvQ5tMayQ3fGrZhRPHrE9bVlBYfDCLuDcgNttYfk8IqfOI03jz6cbpqMRTUclQnaA==",
+            "requires": {
+                "@babel/runtime": "^7.2.0",
+                "get-node-dimensions": "^1.2.1",
+                "prop-types": "^15.6.2",
+                "resize-observer-polyfill": "^1.5.0"
+            }
+        },
+        "react-reflex": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/react-reflex/-/react-reflex-4.0.6.tgz",
+            "integrity": "sha512-nBVQg+EDJ3vKGtiOKCZHaYS8fM/QcHJhVPnat0Ua1DIrzrOI64r8e30HU/ovqDgXVbY5cOTXP4hPRVmWUBfvbQ==",
+            "requires": {
+                "@babel/runtime": "^7.0.0",
+                "lodash.throttle": "^4.1.1",
+                "prop-types": "^15.5.8",
+                "react-measure": "^2.0.2"
+            }
         },
         "react-refresh": {
             "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "react-dom": "^17.0.2",
         "react-error-boundary": "^3.1.4",
         "react-intl": "^5.25.1",
+        "react-reflex": "^4.0.6",
         "react-router": "^6.3.0",
         "react-router-dom": "^6.3.0",
         "react-use": "^17.3.2",

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -3,6 +3,7 @@ import FullPageSpinner from 'components/fullPage/Spinner';
 import useBrowserTitle from 'hooks/useBrowserTitle';
 import * as React from 'react';
 import { useEffect } from 'react';
+import 'react-reflex/styles.css';
 import { identifyUser } from 'services/logrocket';
 
 const AuthenticatedApp = React.lazy(

--- a/src/components/capture/Details.tsx
+++ b/src/components/capture/Details.tsx
@@ -1,5 +1,6 @@
-import { Alert, Grid, Typography } from '@mui/material';
+import { Alert, Grid } from '@mui/material';
 import LiveSpecEditor from 'components/editor/LiveSpec';
+import { DEFAULT_TOTAL_HEIGHT } from 'components/editor/MonacoEditor';
 import { EditorStoreState } from 'components/editor/Store';
 import Logs from 'components/Logs';
 import Error from 'components/shared/Error';
@@ -109,9 +110,6 @@ function CaptureDetails({ lastPubId }: Props) {
                 </Grid>
 
                 <Grid item xs={6}>
-                    <Typography variant="h5">
-                        <FormattedMessage id="captureDetails.logs.title" />
-                    </Typography>
                     {pubsError ? (
                         <Alert variant="filled" severity="warning">
                             <FormattedMessage id="captureDetails.logs.notFound" />
@@ -121,6 +119,7 @@ function CaptureDetails({ lastPubId }: Props) {
                             token={pubs.data.logs_token}
                             fetchAll
                             disableIntervalFetching
+                            height={DEFAULT_TOTAL_HEIGHT}
                         />
                     ) : null}
                 </Grid>

--- a/src/components/editor/EditorAndList.tsx
+++ b/src/components/editor/EditorAndList.tsx
@@ -1,46 +1,57 @@
-import { Grid } from '@mui/material';
+import Box from '@mui/material/Box';
 import EditorFileSelector from 'components/editor/FileSelector';
 import MonacoEditor, {
+    DEFAULT_HEIGHT,
+    DEFAULT_TOOLBAR_HEIGHT,
     Props as MonacoEditorProps,
 } from 'components/editor/MonacoEditor';
+import { ReflexContainer, ReflexElement, ReflexSplitter } from 'react-reflex';
 
 export interface Props extends MonacoEditorProps {
     height?: number;
 }
 
-const DEFAULT_TOOLBAR_HEIGHT = 20;
-const DEFAULT_HEIGHT = 330;
+const MIN_RESIZE_WIDTH = 25;
 
 function EditorAndList(props: Props) {
     const { height } = props;
-    const heightVal = height ?? DEFAULT_HEIGHT;
+    const heightVal = (height ?? DEFAULT_HEIGHT) + DEFAULT_TOOLBAR_HEIGHT;
 
     return (
-        <Grid
-            container
+        <Box
             sx={{
                 bgcolor: 'background.paper',
-                height: `${heightVal + DEFAULT_TOOLBAR_HEIGHT}px`,
+                height: `${heightVal}px`,
+                overflow: 'hidden',
                 mb: 2,
             }}
         >
-            <Grid
-                item
-                xs={4}
-                md={3}
-                sx={{
-                    overflow: 'auto',
-                }}
-            >
-                <EditorFileSelector />
-            </Grid>
-            <Grid item xs={8} md={9}>
-                <MonacoEditor
-                    {...props}
-                    toolbarHeight={DEFAULT_TOOLBAR_HEIGHT}
+            <ReflexContainer orientation="vertical">
+                <ReflexElement className="left-pane" minSize={MIN_RESIZE_WIDTH}>
+                    <div className="pane-content" style={{ height: heightVal }}>
+                        <EditorFileSelector />
+                    </div>
+                </ReflexElement>
+
+                <ReflexSplitter
+                    style={{
+                        width: 4,
+                    }}
                 />
-            </Grid>
-        </Grid>
+
+                <ReflexElement
+                    className="right-pane"
+                    minSize={MIN_RESIZE_WIDTH}
+                    style={{
+                        overflow: 'hidden',
+                    }}
+                >
+                    <div className="pane-content">
+                        <MonacoEditor {...props} />
+                    </div>
+                </ReflexElement>
+            </ReflexContainer>
+        </Box>
     );
 }
 

--- a/src/components/editor/FileSelector.tsx
+++ b/src/components/editor/FileSelector.tsx
@@ -77,6 +77,7 @@ function EditorFileSelector() {
                 rows={specs}
                 columns={columns}
                 headerHeight={40}
+                rowCount={specs.length}
                 hideFooter
                 disableColumnSelector
                 onSelectionModelChange={(newSelectionModel) => {
@@ -91,6 +92,9 @@ function EditorFileSelector() {
                 sx={{
                     '& .MuiDataGrid-row ': {
                         cursor: 'pointer',
+                    },
+                    '& .MuiDataGrid-columnSeparator': {
+                        display: 'none',
                     },
                 }}
             />

--- a/src/components/editor/LiveSpec.tsx
+++ b/src/components/editor/LiveSpec.tsx
@@ -11,7 +11,6 @@ function LiveSpecEditor() {
 
     return (
         <EditorAndList
-            height={450}
             disabled={true}
             value={currentCatalog ? currentCatalog.spec : {}}
             path={currentCatalog ? currentCatalog.catalog_name : ''}

--- a/src/components/editor/MonacoEditor.tsx
+++ b/src/components/editor/MonacoEditor.tsx
@@ -20,8 +20,9 @@ export interface Props {
     toolbarHeight?: number;
 }
 
-const DEFAULT_TOOLBAR_HEIGHT = 20;
-const DEFAULT_HEIGHT = 330;
+export const DEFAULT_TOOLBAR_HEIGHT = 20;
+export const DEFAULT_HEIGHT = 330;
+export const DEFAULT_TOTAL_HEIGHT = DEFAULT_TOOLBAR_HEIGHT + DEFAULT_HEIGHT;
 const ICON_SIZE = 15;
 
 function MonacoEditor({
@@ -149,6 +150,9 @@ function MonacoEditor({
                         path={path}
                         options={{
                             readOnly: disabled ? disabled : false,
+                            minimap: {
+                                enabled: false,
+                            },
                         }}
                         onMount={handlers.mount}
                         onChange={

--- a/src/components/materialization/CollectionSelector.tsx
+++ b/src/components/materialization/CollectionSelector.tsx
@@ -65,6 +65,7 @@ function CollectionSelector() {
                     fullWidth
                     onChange={handlers.updateCollections}
                     blurOnSelect={false}
+                    disableCloseOnSelect
                     renderInput={(params) => (
                         <TextField
                             {...params}

--- a/src/components/materialization/create/index.tsx
+++ b/src/components/materialization/create/index.tsx
@@ -297,7 +297,7 @@ function MaterializationCreate() {
 
                 // TODO (typing) MaterializationDef
                 const draftSpec: any = {
-                    bindings: {},
+                    bindings: [],
                     endpoint: {
                         connector: {
                             config: endpointConfig,
@@ -307,11 +307,12 @@ function MaterializationCreate() {
                 };
 
                 Object.keys(resourceConfig).forEach((collectionName) => {
-                    draftSpec.bindings[collectionName] = {
+                    draftSpec.bindings.push({
+                        source: collectionName,
                         resource: {
                             ...resourceConfig[collectionName].data,
                         },
-                    };
+                    });
                 });
 
                 supabaseClient

--- a/src/components/shared/Entity/Header.tsx
+++ b/src/components/shared/Entity/Header.tsx
@@ -1,9 +1,19 @@
-import { Button, Stack, Toolbar, Typography } from '@mui/material';
+import {
+    Button,
+    Collapse,
+    LinearProgress,
+    Stack,
+    Toolbar,
+    Typography,
+} from '@mui/material';
 import { EditorStoreState } from 'components/editor/Store';
 import { DraftSpecQuery } from 'hooks/useDraftSpecs';
+import { useRouteStore } from 'hooks/useRouteStore';
 import { useZustandStore } from 'hooks/useZustand';
 import { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { createStoreSelectors, FormStatus } from 'stores/Create';
+import { getStore } from 'stores/Repo';
 
 interface Props {
     close: (event: any) => void;
@@ -29,39 +39,57 @@ function FooHeader({
         EditorStoreState<DraftSpecQuery>['id']
     >((state) => state.id);
 
+    const entityCreateStore = getStore(useRouteStore());
+    const formStateStatus = entityCreateStore(
+        createStoreSelectors.formState.status
+    );
+
     return (
-        <Toolbar>
-            <Typography variant="h6" noWrap>
-                {heading}
-            </Typography>
-            <Stack
-                direction="row"
-                alignItems="center"
-                sx={{
-                    ml: 'auto',
-                }}
-            >
-                <Button variant="text" onClick={close} color="error">
-                    <FormattedMessage id="cta.cancel" />
-                </Button>
-
-                <Button
-                    onClick={test}
-                    disabled={testDisabled}
-                    form={formId}
-                    type="submit"
-                    color="success"
+        <>
+            <Toolbar>
+                <Typography variant="h6" noWrap>
+                    {heading}
+                </Typography>
+                <Stack
+                    direction="row"
+                    alignItems="center"
+                    sx={{
+                        ml: 'auto',
+                    }}
                 >
-                    <FormattedMessage
-                        id={id ? 'foo.ctas.discoverAgain' : 'foo.ctas.discover'}
-                    />
-                </Button>
+                    <Button variant="text" onClick={close} color="error">
+                        <FormattedMessage id="cta.cancel" />
+                    </Button>
 
-                <Button onClick={save} disabled={saveDisabled} color="success">
-                    <FormattedMessage id="cta.saveEntity" />
-                </Button>
-            </Stack>
-        </Toolbar>
+                    <Button
+                        onClick={test}
+                        disabled={testDisabled}
+                        form={formId}
+                        type="submit"
+                        color="success"
+                    >
+                        <FormattedMessage
+                            id={
+                                id
+                                    ? 'foo.ctas.discoverAgain'
+                                    : 'foo.ctas.discover'
+                            }
+                        />
+                    </Button>
+
+                    <Button
+                        onClick={save}
+                        disabled={saveDisabled}
+                        color="success"
+                    >
+                        <FormattedMessage id="cta.saveEntity" />
+                    </Button>
+                </Stack>
+            </Toolbar>
+            <Collapse in={formStateStatus !== FormStatus.IDLE} unmountOnExit>
+                <LinearProgress />
+            </Collapse>
+        </>
     );
 }
 

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -140,6 +140,12 @@ const Registration: ResolvedIntlConfig['messages'] = {
     'register.existingAccount': `Already have an account?`,
 };
 
+const EntityStatus: ResolvedIntlConfig['messages'] = {
+    'entityStatus.green': `Running`,
+    'entityStatus.yellow': `Alerts`,
+    'entityStatus.red': `Stopped`,
+};
+
 const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.title': `Entity Table`,
 
@@ -348,6 +354,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...Navigation,
     ...ConfirmationDialog,
     ...LogsDialog,
+    ...EntityStatus,
     ...EntityTable,
     ...Home,
     ...PageNotFound,


### PR DESCRIPTION
## Changes

- [x] Allow file selector to be resized
- [x] Add loading indicator to the create workflow
- [x] Keep collections selector open when item is selected
- [x] Fix materializations sending bindings in wrong format

## Tests

Manual

## Issues

Working off Google Doc

## Content

None

## Screenshots

Small loading bar shows when doing something
![image](https://user-images.githubusercontent.com/270078/167704030-0f62139a-5eda-42c8-a23d-69a22841f1e9.png)

You adjust the width with the middle bar
![image](https://user-images.githubusercontent.com/270078/167704106-fb894a83-1897-46b9-9fa0-c035e0e3b7ac.png)

Min width so you don't lose a panel
![image](https://user-images.githubusercontent.com/270078/167704149-72d273b0-e9ce-4f8e-99a3-fc3de4824e99.png)

Removing log title in details to make things line up a bit nicer
![image](https://user-images.githubusercontent.com/270078/167704913-12823c5e-4f5d-4a46-9e51-65e36a68ff7b.png)
![image](https://user-images.githubusercontent.com/270078/167704974-3f04ca2b-f558-4e73-884c-0a06caece749.png)

