### PR TITLE
Color Adjustments 1

### DIFF
--- a/src/components/tables/Collections/Rows.tsx
+++ b/src/components/tables/Collections/Rows.tsx
@@ -5,6 +5,7 @@ import EntityName from 'components/tables/cells/EntityName';
 import ExpandDetails from 'components/tables/cells/ExpandDetails';
 import TimeStamp from 'components/tables/cells/TimeStamp';
 import UserName from 'components/tables/cells/UserName';
+import { tableBorderSx } from 'context/Theme';
 
 interface Props {
     data: LiveSpecsExtQuery[];
@@ -40,7 +41,7 @@ function Rows({ data }: Props) {
                 <TableRow key={`Entity-${row.id}`}>
                     <EntityName name={row.catalog_name} />
 
-                    <TableCell sx={{ minWidth: 100 }}>
+                    <TableCell sx={{ minWidth: 100, ...tableBorderSx }}>
                         {row.spec_type}
                     </TableCell>
 

--- a/src/components/tables/cells/ChipList.tsx
+++ b/src/components/tables/cells/ChipList.tsx
@@ -1,4 +1,5 @@
 import { Box, Chip, styled, TableCell, Tooltip } from '@mui/material';
+import { outlineSx, tableBorderSx } from 'context/Theme';
 
 interface Props {
     strings: string[];
@@ -12,6 +13,7 @@ const chipListHoverStyling = {
 };
 
 export const chipListWrapperStyling = {
+    ...tableBorderSx,
     minWidth: 100,
     maxHeight: 100,
     overflow: 'auto',
@@ -41,6 +43,7 @@ function ChipList({ strings }: Props) {
                                     size="small"
                                     variant="outlined"
                                     sx={{
+                                        ...outlineSx,
                                         'maxWidth': 200,
                                         'whiteSpace': 'nowrap',
                                         'overflow': 'hidden',

--- a/src/components/tables/cells/Connector.tsx
+++ b/src/components/tables/cells/Connector.tsx
@@ -1,5 +1,6 @@
 import { Box, TableCell, Tooltip } from '@mui/material';
 import ConnectorName from 'components/ConnectorName';
+import { tableBorderSx } from 'context/Theme';
 import { OpenGraph } from 'types';
 
 interface Props {
@@ -9,7 +10,12 @@ interface Props {
 
 function Connector({ openGraph, imageTag }: Props) {
     return (
-        <TableCell sx={{ minWidth: 100 }}>
+        <TableCell
+            sx={{
+                ...tableBorderSx,
+                minWidth: 100,
+            }}
+        >
             <Tooltip title={imageTag} placement="bottom-start">
                 <Box>
                     <ConnectorName iconSize={20} connector={openGraph} />

--- a/src/components/tables/cells/EntityName.tsx
+++ b/src/components/tables/cells/EntityName.tsx
@@ -1,5 +1,6 @@
 import { TableCell } from '@mui/material';
 import EntityStatus from 'components/tables/cells/EntityStatus';
+import { tableBorderSx } from 'context/Theme';
 
 interface Props {
     name: string;
@@ -9,6 +10,7 @@ function EntityName({ name }: Props) {
     return (
         <TableCell
             sx={{
+                ...tableBorderSx,
                 minWidth: 256,
             }}
         >

--- a/src/components/tables/cells/MaterializeAction.tsx
+++ b/src/components/tables/cells/MaterializeAction.tsx
@@ -9,12 +9,10 @@ interface Props {
 function MaterializeAction({ onClick, disabled }: Props) {
     return (
         <Button
-            variant="contained"
             size="small"
-            disableElevation
-            sx={{ mr: 1 }}
             disabled={disabled}
             onClick={onClick}
+            sx={{ mr: 1, borderRadius: 5 }}
         >
             <FormattedMessage id="capturesTable.cta.materialize" />
         </Button>

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -99,7 +99,7 @@ const darkMode: PaletteOptions = {
     mode: 'dark',
     primary: {
         main: teal[300],
-        dark: slate[600],
+        dark: teal[500],
     },
     secondary: {
         main: teal[100],

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -1,6 +1,8 @@
 import {
     createTheme,
     PaletteOptions,
+    SxProps,
+    Theme,
     ThemeOptions,
     ThemeProvider as MUIThemeProvider,
 } from '@mui/material';
@@ -115,6 +117,16 @@ export const zIndexIncrement = 5;
 const buttonHoverIndex = zIndexIncrement;
 const chipDeleteIndex = buttonHoverIndex + zIndexIncrement;
 
+// Styles
+export const tableBorderSx: SxProps<Theme> = {
+    borderBottom: `1px solid ${slate[200]}`,
+};
+
+export const outlineSx: SxProps<Theme> = {
+    border: `1px solid ${slate[200]}`,
+};
+
+// Theme
 const themeSettings = createTheme({
     breakpoints: {
         values: {
@@ -163,6 +175,11 @@ const themeSettings = createTheme({
                 sx: {
                     borderRadius: 5,
                 },
+            },
+        },
+        MuiTableCell: {
+            defaultProps: {
+                sx: tableBorderSx,
             },
         },
         MuiTabs: {


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Lighten the hover state of buttons with the _primary_ theme color applied. This adjustment did impact the color of the Account and Help menus.

1. Round the corners of the button in the `MaterializeAction` table cell component.

1. Apply theme colors to the outline of chips within the `ChipList` table cell component and the all cell borders.

**NOTE:** The bottom border for each table cell (or row) has a faint dark grey line persists despite the code changes. At the moment, I am at a loss as to its origin. Whenever the source of that line is found, it should be updated.

## Tests

Only manual testing was performed.

## Screenshots

**Button Hover State**
<img width="292" alt="pr-screenshot__126__button-hover" src="https://user-images.githubusercontent.com/77648584/167922755-ee5df90e-f3e0-45d7-9c8c-228890e1b863.PNG">

<br />

**Account Menu**
<img width="231" alt="pr-screenshot__126__account-menu" src="https://user-images.githubusercontent.com/77648584/167924509-040d64fc-b807-4c74-a0df-b19b4ede97b1.PNG">

<br />

**Help Menu**
<img width="301" alt="pr-screenshot__126__help-menu" src="https://user-images.githubusercontent.com/77648584/167924587-d62147bd-c6fc-4000-bb22-5dec442d78c6.PNG">

<br />

**Table | Captures**
<img width="1384" alt="pr-screenshot__126__table__captures" src="https://user-images.githubusercontent.com/77648584/167924687-d205aa5c-c711-41b9-a151-4618a734a183.PNG">
