### PR TITLE
Spacing and Alignment Updates

### DIFF
--- a/src/components/menus/IconMenu.tsx
+++ b/src/components/menus/IconMenu.tsx
@@ -98,7 +98,7 @@ const IconMenu = ({
                             height: 10,
                             position: 'absolute',
                             left: -5,
-                            top: verticalOrigin === 'top' ? '8px' : '',
+                            top: verticalOrigin === 'top' ? '48px' : '',
                             bottom: verticalOrigin === 'bottom' ? '22px' : '',
                             transform: 'translateY(-50%) rotate(45deg)',
                             width: 10,

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -78,38 +78,33 @@ const Navigation = ({ open, width, onNavigationToggle }: Props) => {
                 }}
             >
                 <Box>
-                    <Box sx={{ mb: 16, pl: 1 }}>
-                        <Box
+                    <Box
+                        sx={{
+                            pt: 1,
+                            pb: 0.25,
+                            pl: 1,
+                            display: 'flex',
+                            flexGrow: 1,
+                            alignItems: 'center',
+                        }}
+                    >
+                        <IconButton
+                            aria-label={intl.formatMessage({
+                                id: 'header.openNavigation.ariaLabel',
+                            })}
+                            onClick={openNavigation}
                             sx={{
-                                pt: 1,
-                                pb: 0.25,
-                                display: 'flex',
-                                flexGrow: 1,
-                                alignItems: 'center',
+                                display: 'inline-flex',
+                                justifyContent: 'left',
+                                flexShrink: 0,
                             }}
                         >
-                            <IconButton
-                                aria-label={intl.formatMessage({
-                                    id: 'header.openNavigation.ariaLabel',
-                                })}
-                                onClick={openNavigation}
-                                sx={{
-                                    display: 'inline-flex',
-                                    justifyContent: 'left',
-                                    flexShrink: 0,
-                                }}
-                            >
-                                <MenuIcon />
-                            </IconButton>
+                            <MenuIcon />
+                        </IconButton>
 
-                            <Typography
-                                sx={{ width: 136, ml: 2, flexShrink: 0 }}
-                            >
-                                <FormattedMessage id="mainMenu.label" />
-                            </Typography>
-                        </Box>
-
-                        <UserMenu />
+                        <Typography sx={{ width: 136, ml: 2, flexShrink: 0 }}>
+                            <FormattedMessage id="mainMenu.label" />
+                        </Typography>
                     </Box>
 
                     <List
@@ -150,6 +145,8 @@ const Navigation = ({ open, width, onNavigationToggle }: Props) => {
                 </Box>
 
                 <Box sx={{ pl: 1 }}>
+                    <UserMenu />
+
                     <HelpMenu />
 
                     <Box

--- a/src/components/shared/Entity/CatalogEditor.tsx
+++ b/src/components/shared/Entity/CatalogEditor.tsx
@@ -22,15 +22,11 @@ function CatalogEditor({ messageId }: Props) {
                 header={<FormattedMessage id="foo.catalogEditor.heading" />}
             >
                 <>
-                    <Typography>
+                    <Typography sx={{ mb: 2 }}>
                         <FormattedMessage id={messageId} />
                     </Typography>
-                    <Paper
-                        variant="outlined"
-                        sx={{
-                            padding: 1,
-                        }}
-                    >
+
+                    <Paper variant="outlined" sx={{ p: 1 }}>
                         <DraftSpecEditor />
                     </Paper>
                 </>

--- a/src/components/shared/Entity/DetailsForm.tsx
+++ b/src/components/shared/Entity/DetailsForm.tsx
@@ -156,11 +156,13 @@ function DetailsForm({ connectorTags, messagePrefix, accessGrants }: Props) {
 
     return (
         <>
-            <Typography variant="h5">
+            <Typography variant="h5" sx={{ mb: 1 }}>
                 <FormattedMessage id={`${messagePrefix}.details.heading`} />
             </Typography>
 
-            <FormattedMessage id={`${messagePrefix}.instructions`} />
+            <Typography sx={{ mb: 2 }}>
+                <FormattedMessage id={`${messagePrefix}.instructions`} />
+            </Typography>
 
             <Stack direction="row" spacing={2}>
                 {schema.properties[CONNECTOR_IMAGE_SCOPE].oneOf.length > 0 ? (

--- a/src/components/shared/Entity/Header.tsx
+++ b/src/components/shared/Entity/Header.tsx
@@ -118,7 +118,7 @@ function FooHeader({
             </Toolbar>
 
             <Collapse in={formInProgress(formStateStatus)} unmountOnExit>
-                <LinearProgress />
+                <LinearProgress sx={{ mb: 2 }} />
             </Collapse>
             <ValidationErrorSummary />
         </>

--- a/src/components/shared/Entity/Header.tsx
+++ b/src/components/shared/Entity/Header.tsx
@@ -3,6 +3,8 @@ import {
     Collapse,
     LinearProgress,
     Stack,
+    SxProps,
+    Theme,
     Toolbar,
     Typography,
 } from '@mui/material';
@@ -65,12 +67,15 @@ function FooHeader({
         },
     };
 
+    const buttonSx: SxProps<Theme> = { ml: 1, borderRadius: 5 };
+
     return (
         <>
-            <Toolbar>
+            <Toolbar disableGutters>
                 <Typography variant="h6" noWrap>
                     {heading}
                 </Typography>
+
                 <Stack
                     direction="row"
                     alignItems="center"
@@ -89,7 +94,7 @@ function FooHeader({
                         }
                         form={formId}
                         type="submit"
-                        color="success"
+                        sx={buttonSx}
                     >
                         <FormattedMessage
                             id={
@@ -105,12 +110,13 @@ function FooHeader({
                         disabled={
                             formInProgress(formStateStatus) || saveDisabled
                         }
-                        color="success"
+                        sx={buttonSx}
                     >
                         <FormattedMessage id="cta.saveEntity" />
                     </Button>
                 </Stack>
             </Toolbar>
+
             <Collapse in={formInProgress(formStateStatus)} unmountOnExit>
                 <LinearProgress />
             </Collapse>

--- a/src/components/shared/Entity/LogDialog.tsx
+++ b/src/components/shared/Entity/LogDialog.tsx
@@ -41,7 +41,7 @@ function LogDialog({
                 />
             </DialogContent>
 
-            <DialogActions sx={{ pr: 5 }}>{actionComponent}</DialogActions>
+            <DialogActions sx={{ pr: 3 }}>{actionComponent}</DialogActions>
         </Dialog>
     );
 }

--- a/src/components/shared/Entity/LogDialog.tsx
+++ b/src/components/shared/Entity/LogDialog.tsx
@@ -28,6 +28,7 @@ function LogDialog({
     return (
         <Dialog open={open} maxWidth="lg" fullWidth aria-labelledby={TITLE_ID}>
             <DialogTitle id={TITLE_ID}>{title}</DialogTitle>
+
             <DialogContent
                 sx={{
                     height: logHeight + 25,
@@ -39,7 +40,8 @@ function LogDialog({
                     height={logHeight}
                 />
             </DialogContent>
-            <DialogActions>{actionComponent}</DialogActions>
+
+            <DialogActions sx={{ pr: 5 }}>{actionComponent}</DialogActions>
         </Dialog>
     );
 }

--- a/src/components/shared/Entity/Status.tsx
+++ b/src/components/shared/Entity/Status.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@mui/material';
 import { useRouteStore } from 'hooks/useRouteStore';
 import { FormattedMessage } from 'react-intl';
 import { createStoreSelectors, FormStatus } from 'stores/Create';
@@ -18,7 +19,11 @@ function Status() {
     }
 
     if (messageKey) {
-        return <FormattedMessage id={messageKey} />;
+        return (
+            <Typography sx={{ mr: 1 }}>
+                <FormattedMessage id={messageKey} />
+            </Typography>
+        );
     } else {
         return null;
     }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -33,12 +33,14 @@ const Admin = () => {
             <AccessGrantsTable />
 
             <Box sx={boxStyling}>
-                <Typography variant="h6">
+                <Typography variant="h6" sx={{ mb: 0.5 }}>
                     <FormattedMessage id="admin.accessToken" />
                 </Typography>
-                <Typography>
+
+                <Typography sx={{ mb: 2 }}>
                     <FormattedMessage id="admin.accessToken.message" />
                 </Typography>
+
                 <TextareaAutosize
                     minRows={4}
                     style={{ width: '100%' }}


### PR DESCRIPTION
## Changes

A series of minor spacing and alignment changes to mostly text, button groups, and other small UI elements. The account menu in the navigation pane was repositioned to appear above the help menu.

## Tests

Only manual testing was performed.

## Screenshots

**Creation Page | CTAs, Details Form, & Catalog Editor**
<img width="1316" alt="pr-screenshot__136__spacing-and-alignment__create-page__editor-included" src="https://user-images.githubusercontent.com/77648584/169301552-5b71e003-4c71-4662-ad69-d1fed8dc0918.PNG">
 <br />

**Creation Page | Progress Bar**
<img width="1378" alt="pr-screenshot__136__spacing-and-alignment__capture-progress-bar" src="https://user-images.githubusercontent.com/77648584/169302937-f880fa9a-6646-4b5c-a941-a043014974ca.PNG">

<br />

**Creation Page | Log Dialog | CTAs | Logs Loading**
<img width="905" alt="pr-screenshot__136__spacing-and-alignment__log-dialog-actions__logs-loading" src="https://user-images.githubusercontent.com/77648584/169302982-debc94b2-6cdf-4cc6-ba31-ed2a39c41087.PNG">

<br />

**Creation Page | Log Dialog | CTAs | Logs Loaded**
<img width="904" alt="pr-screenshot__136__spacing-and-alignment__log-dialog-actions__logs-loaded" src="https://user-images.githubusercontent.com/77648584/169303196-1ac165a4-6a0b-4516-a160-bcd453819fc0.PNG">

<br />

**Creation Page | Log Dialog | CTAs | Logs Ended**
<img width="906" alt="pr-screenshot__136__spacing-and-alignment__log-dialog-actions__restart-presented" src="https://user-images.githubusercontent.com/77648584/169303511-bdd92826-4a43-4dd1-8a92-a0c8ddb53d45.PNG">

<br />

**Admin Page | Access Token Section**
<img width="1366" alt="pr-screenshot__136__spacing-and-alignment__admin-page__access-token" src="https://user-images.githubusercontent.com/77648584/169299678-ad891735-7cbe-42ae-bed7-e2eefea31bb2.PNG">

<br />

**Navigation Pane | XL and L Screens | Collapsed**
<img width="76" alt="pr-screenshot__136__spacing-and-alignment__nav-(collapsed)__xl-screen" src="https://user-images.githubusercontent.com/77648584/169304812-83f887fc-236b-4331-b960-ed6cc64d9ff0.PNG">

<br />

**Navigation Pane | XL and L Screens | Expanded**
<img width="206" alt="pr-screenshot__136__spacing-and-alignment__nav-(expanded)__xl-screen" src="https://user-images.githubusercontent.com/77648584/169305309-f328b5e8-ecdb-43f4-b8f5-8e660dd177d1.PNG">

<br />

**Navigation Pane | M Screen | Collapsed**
<img width="79" alt="pr-screenshot__136__spacing-and-alignment__nav-(collapsed)__standard-screen" src="https://user-images.githubusercontent.com/77648584/169306278-b6347225-89ea-45bd-ae6d-a8b96f68365f.PNG">

<br />

**Navigation Pane | M Screen | Expanded**
<img width="198" alt="pr-screenshot__136__spacing-and-alignment__nav-(expanded)__standard-screen" src="https://user-images.githubusercontent.com/77648584/169306324-3b8d5017-a353-4934-ae91-21ef7bb2213e.PNG">

<br />
