### PR TITLE
Add nginx.conf so that page refreshes will work

### DIFF
--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -1,3 +1,8 @@
 FROM nginx:alpine
 
+COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY ./ /usr/share/nginx/html/
+# Delete the nginx.conf file so that we don't serve our config via nginx
+# This is because I don't know an easier way to COPY all files _except_ that one.
+RUN rm /usr/share/nginx/html/nginx.conf
+

--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -1,0 +1,61 @@
+# This config file was taken from the default nginx image by running:
+# $ docker run --rm --detach --name tmp nginx:alpine
+# $ docker cp tmp:/etc/nginx/nginx.conf
+# Any modifications from the default should have comments.
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    # This configuration was added so that users refreshing the page will not get a 404 due to the
+    # react router URLs (e.g. `/captures/create`) not corresponding to an actual resource on the
+    # server. The `try_files` will ensure that we serve index.html if the requested resource is not
+    # found. This was adapted from /etc/nginx/conf.d/default.conf, which was previously brought in
+    # with an `include` directive.
+    server {
+        listen       80;
+        listen  [::]:80;
+        server_name  localhost;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri $uri/ /index.html;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
+}
+
+


### PR DESCRIPTION
## Changes

React-router wasn't playing nicely with the default nginx config.
This adds a config file, based on the default, which has a `try_files`
that falls back to index.html, which is what react-router needs.
With this, you should be able to refresh on any page and stay where
you're at in the UI.