### PR TITLE
Repair Entry Page Content Cutoff

### DIFF
--- a/src/components/fullPage/Dialog.tsx
+++ b/src/components/fullPage/Dialog.tsx
@@ -11,7 +11,7 @@ function FullPageDialog({ children }: Props) {
         <Box
             sx={{
                 width: '100%',
-                height: '100vh',
+                minHeight: '100vh',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -42,12 +42,8 @@ const Login = () => {
                 </Alert>
             </Snackbar>
             <FullPageDialog>
-                <Box
-                    sx={{
-                        justifyItems: 'center',
-                    }}
-                >
-                    <Typography sx={{ mb: 5 }}>
+                <Box>
+                    <Typography align="center" sx={{ mb: 5 }}>
                         <FormattedMessage id="login.oidc.message" />
                     </Typography>
 

--- a/src/pages/Registration.tsx
+++ b/src/pages/Registration.tsx
@@ -1,8 +1,6 @@
 import {
+    Box,
     Button,
-    Card,
-    CardActions,
-    CardContent,
     Checkbox,
     FormControl,
     FormControlLabel,
@@ -143,14 +141,10 @@ const Registration = () => {
 
     return (
         <FullPageDialog>
-            <Card
-                raised={false}
-                sx={{
-                    background: 'transparent',
-                }}
-            >
-                <CardContent
+            <>
+                <Box
                     sx={{
+                        mb: 5,
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'center',
@@ -160,153 +154,142 @@ const Registration = () => {
                         <FormattedMessage id="register.heading" />
                     </Typography>
 
-                    <Typography sx={{ mb: 1 }}>
-                        <FormattedMessage id="register.main.message" />
-                    </Typography>
-                </CardContent>
+                    <FormattedMessage id="register.main.message" />
+                </Box>
 
-                <CardActions disableSpacing>
-                    <form
-                        onSubmit={handlers.submit}
-                        style={{
-                            width: '100%',
-                            display: 'flex',
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                        }}
+                <form
+                    onSubmit={handlers.submit}
+                    style={{
+                        width: '100%',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    }}
+                >
+                    <TextField
+                        id="full-name"
+                        label={intl.formatMessage({
+                            id: 'register.label.fullName',
+                        })}
+                        value={fullName}
+                        error={errors.fullName}
+                        required
+                        onChange={handlers.updateTextInput(
+                            'fullName',
+                            setFullName
+                        )}
+                        onBlur={handlers.validateTextInput(
+                            'fullName',
+                            fullName,
+                            setFullName
+                        )}
+                        sx={textFieldSx}
+                    />
+
+                    <TextField
+                        id="email"
+                        label={intl.formatMessage({
+                            id: 'register.label.email',
+                        })}
+                        value={email}
+                        error={errors.email}
+                        required
+                        onChange={handlers.updateTextInput('email', setEmail)}
+                        onBlur={handlers.validateTextInput(
+                            'email',
+                            email,
+                            setEmail
+                        )}
+                        sx={textFieldSx}
+                    />
+
+                    <TextField
+                        id="company"
+                        label={intl.formatMessage({
+                            id: 'register.label.company',
+                        })}
+                        value={company}
+                        error={errors.company}
+                        required
+                        onChange={handlers.updateTextInput(
+                            'company',
+                            setCompany
+                        )}
+                        onBlur={handlers.validateTextInput(
+                            'company',
+                            company,
+                            setCompany
+                        )}
+                        sx={textFieldSx}
+                    />
+
+                    <TextField
+                        id="describe-intended-use"
+                        label={intl.formatMessage({
+                            id: 'register.label.intendedUse',
+                        })}
+                        value={useCase}
+                        multiline
+                        minRows={3}
+                        onChange={handlers.updateTextInput(
+                            'useCase',
+                            setUseCase
+                        )}
+                        sx={textFieldSx}
+                    />
+
+                    <FormControl
+                        error={errors.acknowledgedDocuments}
+                        sx={{ mb: 4, mx: 0 }}
                     >
-                        <TextField
-                            id="full-name"
-                            label={intl.formatMessage({
-                                id: 'register.label.fullName',
-                            })}
-                            value={fullName}
-                            error={errors.fullName}
-                            required
-                            onChange={handlers.updateTextInput(
-                                'fullName',
-                                setFullName
-                            )}
-                            onBlur={handlers.validateTextInput(
-                                'fullName',
-                                fullName,
-                                setFullName
-                            )}
-                            sx={textFieldSx}
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    value={acknowledgedDocuments}
+                                    required
+                                />
+                            }
+                            onChange={handlers.updateDocumentAcknowledgement}
+                            onBlur={handlers.validateDocumentAcknowledgement}
+                            label={
+                                <FormattedMessage
+                                    id="register.label.documentAcknowledgement"
+                                    values={{
+                                        privacy: (
+                                            <ExternalLink
+                                                hideIcon
+                                                link={urls.privacyPolicy}
+                                            >
+                                                <FormattedMessage id="register.label.documentAcknowledgement.privacy" />
+                                            </ExternalLink>
+                                        ),
+                                        terms: (
+                                            <ExternalLink
+                                                hideIcon
+                                                link={urls.termsOfService}
+                                            >
+                                                <FormattedMessage id="register.label.documentAcknowledgement.terms" />
+                                            </ExternalLink>
+                                        ),
+                                    }}
+                                />
+                            }
                         />
+                    </FormControl>
 
-                        <TextField
-                            id="email"
-                            label={intl.formatMessage({
-                                id: 'register.label.email',
-                            })}
-                            value={email}
-                            error={errors.email}
-                            required
-                            onChange={handlers.updateTextInput(
-                                'email',
-                                setEmail
-                            )}
-                            onBlur={handlers.validateTextInput(
-                                'email',
-                                email,
-                                setEmail
-                            )}
-                            sx={textFieldSx}
-                        />
+                    <Typography sx={{ mb: 2 }}>
+                        <FormattedMessage id="register.existingAccount" />{' '}
+                        <Link href="/" underline="hover">
+                            <FormattedMessage id="cta.login" />
+                        </Link>
+                    </Typography>
 
-                        <TextField
-                            id="company"
-                            label={intl.formatMessage({
-                                id: 'register.label.company',
-                            })}
-                            value={company}
-                            error={errors.company}
-                            required
-                            onChange={handlers.updateTextInput(
-                                'company',
-                                setCompany
-                            )}
-                            onBlur={handlers.validateTextInput(
-                                'company',
-                                company,
-                                setCompany
-                            )}
-                            sx={textFieldSx}
-                        />
-
-                        <TextField
-                            id="describe-intended-use"
-                            label={intl.formatMessage({
-                                id: 'register.label.intendedUse',
-                            })}
-                            value={useCase}
-                            multiline
-                            minRows={3}
-                            onChange={handlers.updateTextInput(
-                                'useCase',
-                                setUseCase
-                            )}
-                            sx={textFieldSx}
-                        />
-
-                        <FormControl
-                            error={errors.acknowledgedDocuments}
-                            sx={{ mb: 4, mx: 0 }}
-                        >
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        value={acknowledgedDocuments}
-                                        required
-                                    />
-                                }
-                                onChange={
-                                    handlers.updateDocumentAcknowledgement
-                                }
-                                onBlur={
-                                    handlers.validateDocumentAcknowledgement
-                                }
-                                label={
-                                    <FormattedMessage
-                                        id="register.label.documentAcknowledgement"
-                                        values={{
-                                            privacy: (
-                                                <ExternalLink
-                                                    hideIcon
-                                                    link={urls.privacyPolicy}
-                                                >
-                                                    <FormattedMessage id="register.label.documentAcknowledgement.privacy" />
-                                                </ExternalLink>
-                                            ),
-                                            terms: (
-                                                <ExternalLink
-                                                    hideIcon
-                                                    link={urls.termsOfService}
-                                                >
-                                                    <FormattedMessage id="register.label.documentAcknowledgement.terms" />
-                                                </ExternalLink>
-                                            ),
-                                        }}
-                                    />
-                                }
-                            />
-                        </FormControl>
-
-                        <Typography sx={{ mb: 2 }}>
-                            <FormattedMessage id="register.existingAccount" />{' '}
-                            <Link href="/" underline="hover">
-                                <FormattedMessage id="cta.login" />
-                            </Link>
-                        </Typography>
-
-                        <Button type="submit" onClick={handlers.signUp}>
-                            <FormattedMessage id="cta.register" />
-                        </Button>
-                    </form>
-                </CardActions>
-            </Card>
+                    <Button type="submit" onClick={handlers.signUp}>
+                        <FormattedMessage id="cta.register" />
+                    </Button>
+                </form>
+            </>
         </FullPageDialog>
     );
 };


### PR DESCRIPTION
## Changes

Adjusted the styling and composition of application entry-related components to ensure all content is displayed on the page.

## Tests

Only manual testing was performed.

## Screenshots

**Sign In Page | Standard Screen**

<img width="949" alt="pr-screenshot__144__sign-in-page__standard-screen" src="https://user-images.githubusercontent.com/77648584/171405894-120170ac-7271-44b6-8e38-beb845ea86cb.PNG">

<br />

**Sign In Page | Standard Screen | Scrolled**

<img width="948" alt="pr-screenshot__144__sign-in-page__standard-screen-(scrolled)" src="https://user-images.githubusercontent.com/77648584/171405936-bd1927f4-6507-49d8-b9d4-5f1a8ff96574.PNG">

<br />

**Sign In Page | Large Screen**

<img width="1095" alt="pr-screenshot__144__sign-in-page__large-screen" src="https://user-images.githubusercontent.com/77648584/171406014-e6f42101-1bfa-4234-af2f-37e1a1cbd59f.PNG">

<br />

**Registration Page | Standard Screen**

<img width="949" alt="pr-screenshot__144__registration-page__standard-screen" src="https://user-images.githubusercontent.com/77648584/171406150-e9e6d201-6ae0-4f3b-b652-65dea936cf64.PNG">

<br />

**Registration Page | Standard Screen | Scrolled**

<img width="949" alt="pr-screenshot__144__registration-page__standard-screen-(scrolled)" src="https://user-images.githubusercontent.com/77648584/171406190-76e6d1d3-8301-4e6d-9827-e8e2b9f2591f.PNG">

<br />

**Registration Page | Large Screen**

<img width="1171" alt="pr-screenshot__144__registration-page__large-screen" src="https://user-images.githubusercontent.com/77648584/171406218-59c9a25b-022b-4d9a-a2d0-3da0cdae9fb7.PNG">

<br />