### PR TITLE
Display Unique Indicator for Disabled Tasks

### DIFF
--- a/src/components/tables/cells/EntityStatus.tsx
+++ b/src/components/tables/cells/EntityStatus.tsx
@@ -1,10 +1,7 @@
 import { Box, Tooltip, Typography } from '@mui/material';
 import { useRouteStore } from 'hooks/useRouteStore';
 import { CSSProperties } from 'react';
-import {
-    shardDetailSelectors,
-    ShardStatusIndicatorText,
-} from 'stores/ShardDetail';
+import { shardDetailSelectors, ShardStatus } from 'stores/ShardDetail';
 
 interface Props {
     name: string;
@@ -15,15 +12,14 @@ function EntityStatus({ name }: Props) {
     const getShardStatusColor = shardDetailStore(
         shardDetailSelectors.getShardStatusColor
     );
-    const getShardStatusIndicatorText = shardDetailStore(
-        shardDetailSelectors.getShardStatusIndicatorText
+    const getShardStatus = shardDetailStore(
+        shardDetailSelectors.getShardStatus
     );
     const evaluateShardProcessingState = shardDetailStore(
         shardDetailSelectors.evaluateShardProcessingState
     );
 
-    const statusIndicators: ShardStatusIndicatorText[] =
-        getShardStatusIndicatorText(name);
+    const shardStatuses: ShardStatus[] = getShardStatus(name);
 
     const taskDisabled: boolean = evaluateShardProcessingState(name);
 
@@ -37,7 +33,7 @@ function EntityStatus({ name }: Props) {
 
     return (
         <Tooltip
-            title={statusIndicators.map((text, index) => (
+            title={shardStatuses.map((status, index) => (
                 <Box
                     key={`${index}-shard-status-tooltip`}
                     sx={{
@@ -59,7 +55,7 @@ function EntityStatus({ name }: Props) {
                         variant="caption"
                         sx={{ display: 'inline-block' }}
                     >
-                        {text}
+                        {status}
                     </Typography>
                 </Box>
             ))}

--- a/src/components/tables/cells/EntityStatus.tsx
+++ b/src/components/tables/cells/EntityStatus.tsx
@@ -1,6 +1,10 @@
 import { Box, Tooltip, Typography } from '@mui/material';
 import { useRouteStore } from 'hooks/useRouteStore';
-import { shardDetailSelectors, ShardStatusIndicator } from 'stores/ShardDetail';
+import { CSSProperties } from 'react';
+import {
+    shardDetailSelectors,
+    ShardStatusIndicatorText,
+} from 'stores/ShardDetail';
 
 interface Props {
     name: string;
@@ -11,19 +15,29 @@ function EntityStatus({ name }: Props) {
     const getShardStatusColor = shardDetailStore(
         shardDetailSelectors.getShardStatusColor
     );
-    const getShardStatusIndicators = shardDetailStore(
-        shardDetailSelectors.getShardStatusIndicators
+    const getShardStatusIndicatorText = shardDetailStore(
+        shardDetailSelectors.getShardStatusIndicatorText
     );
     const evaluateShardProcessingState = shardDetailStore(
         shardDetailSelectors.evaluateShardProcessingState
     );
 
-    const statusIndicators: ShardStatusIndicator[] =
-        getShardStatusIndicators(name);
+    const statusIndicators: ShardStatusIndicatorText[] =
+        getShardStatusIndicatorText(name);
+
+    const taskDisabled: boolean = evaluateShardProcessingState(name);
+
+    const statusIndicatorStyle: CSSProperties = {
+        border: taskDisabled ? `solid 2px ${getShardStatusColor(name)}` : 0,
+        backgroundColor: taskDisabled ? '' : getShardStatusColor(name),
+        borderRadius: 50,
+        display: 'inline-block',
+        verticalAlign: 'middle',
+    };
 
     return (
         <Tooltip
-            title={statusIndicators.map(({ text, color }, index) => (
+            title={statusIndicators.map((text, index) => (
                 <Box
                     key={`${index}-shard-status-tooltip`}
                     sx={{
@@ -32,31 +46,15 @@ function EntityStatus({ name }: Props) {
                         alignItems: 'center',
                     }}
                 >
-                    {text === 'DISABLED' ? (
-                        <span
-                            style={{
-                                height: 12,
-                                width: 12,
-                                border: `solid 2px ${color}`,
-                                borderRadius: 50,
-                                display: 'inline-block',
-                                verticalAlign: 'middle',
-                                marginRight: 4,
-                            }}
-                        />
-                    ) : (
-                        <span
-                            style={{
-                                height: 12,
-                                width: 12,
-                                backgroundColor: color,
-                                borderRadius: 50,
-                                display: 'inline-block',
-                                verticalAlign: 'middle',
-                                marginRight: 4,
-                            }}
-                        />
-                    )}
+                    <span
+                        style={{
+                            height: 12,
+                            width: 12,
+                            marginRight: 4,
+                            ...statusIndicatorStyle,
+                        }}
+                    />
+
                     <Typography
                         variant="caption"
                         sx={{ display: 'inline-block' }}
@@ -67,31 +65,14 @@ function EntityStatus({ name }: Props) {
             ))}
             placement="bottom-start"
         >
-            {evaluateShardProcessingState(name) ? (
-                <span
-                    style={{
-                        height: 16,
-                        width: 16,
-                        border: `solid 2px ${getShardStatusColor(name)}`,
-                        borderRadius: 50,
-                        display: 'inline-block',
-                        verticalAlign: 'middle',
-                        marginRight: 12,
-                    }}
-                />
-            ) : (
-                <span
-                    style={{
-                        height: 16,
-                        width: 16,
-                        backgroundColor: getShardStatusColor(name),
-                        borderRadius: 50,
-                        display: 'inline-block',
-                        verticalAlign: 'middle',
-                        marginRight: 12,
-                    }}
-                />
-            )}
+            <span
+                style={{
+                    height: 16,
+                    width: 16,
+                    marginRight: 12,
+                    ...statusIndicatorStyle,
+                }}
+            />
         </Tooltip>
     );
 }

--- a/src/components/tables/cells/EntityStatus.tsx
+++ b/src/components/tables/cells/EntityStatus.tsx
@@ -14,6 +14,9 @@ function EntityStatus({ name }: Props) {
     const getShardStatusIndicators = shardDetailStore(
         shardDetailSelectors.getShardStatusIndicators
     );
+    const evaluateShardProcessingState = shardDetailStore(
+        shardDetailSelectors.evaluateShardProcessingState
+    );
 
     const statusIndicators: ShardStatusIndicator[] =
         getShardStatusIndicators(name);
@@ -29,18 +32,31 @@ function EntityStatus({ name }: Props) {
                         alignItems: 'center',
                     }}
                 >
-                    <span
-                        style={{
-                            height: 12,
-                            width: 12,
-                            backgroundColor: color,
-                            borderRadius: 50,
-                            display: 'inline-block',
-                            verticalAlign: 'middle',
-                            marginRight: 4,
-                        }}
-                    />
-
+                    {text === 'DISABLED' ? (
+                        <span
+                            style={{
+                                height: 12,
+                                width: 12,
+                                border: `solid 2px ${color}`,
+                                borderRadius: 50,
+                                display: 'inline-block',
+                                verticalAlign: 'middle',
+                                marginRight: 4,
+                            }}
+                        />
+                    ) : (
+                        <span
+                            style={{
+                                height: 12,
+                                width: 12,
+                                backgroundColor: color,
+                                borderRadius: 50,
+                                display: 'inline-block',
+                                verticalAlign: 'middle',
+                                marginRight: 4,
+                            }}
+                        />
+                    )}
                     <Typography
                         variant="caption"
                         sx={{ display: 'inline-block' }}
@@ -51,17 +67,31 @@ function EntityStatus({ name }: Props) {
             ))}
             placement="bottom-start"
         >
-            <span
-                style={{
-                    height: 16,
-                    width: 16,
-                    backgroundColor: getShardStatusColor(name),
-                    borderRadius: 50,
-                    display: 'inline-block',
-                    verticalAlign: 'middle',
-                    marginRight: 12,
-                }}
-            />
+            {evaluateShardProcessingState(name) ? (
+                <span
+                    style={{
+                        height: 16,
+                        width: 16,
+                        border: `solid 2px ${getShardStatusColor(name)}`,
+                        borderRadius: 50,
+                        display: 'inline-block',
+                        verticalAlign: 'middle',
+                        marginRight: 12,
+                    }}
+                />
+            ) : (
+                <span
+                    style={{
+                        height: 16,
+                        width: 16,
+                        backgroundColor: getShardStatusColor(name),
+                        borderRadius: 50,
+                        display: 'inline-block',
+                        verticalAlign: 'middle',
+                        marginRight: 12,
+                    }}
+                />
+            )}
         </Tooltip>
     );
 }

--- a/src/stores/ShardDetail.ts
+++ b/src/stores/ShardDetail.ts
@@ -11,7 +11,7 @@ export type SetShards = (shards: Shard[]) => void;
 // TODO: Follow-up with team. Determine fallback status to display in tooltip.
 type DefaultTooltipMessage = 'No shard status found.';
 
-export type ShardStatusIndicatorText =
+export type ShardStatus =
     | ReplicaStatusCode
     | DefaultTooltipMessage
     | 'DISABLED';
@@ -25,9 +25,7 @@ export interface ShardDetailStore {
     shards: Shard[];
     setShards: SetShards;
     getShardStatusColor: (catalogNamespace: string) => string;
-    getShardStatusIndicatorText: (
-        catalogNamespace: string
-    ) => ShardStatusIndicatorText[];
+    getShardStatus: (catalogNamespace: string) => ShardStatus[];
     getShardDetails: (catalogNamespace: string) => ShardDetails | null;
     evaluateShardProcessingState: (catalogNamespace: string) => boolean;
 }
@@ -102,7 +100,7 @@ export const getInitialState = (
                 return defaultStatusColor;
             }
         },
-        getShardStatusIndicatorText: (catalogNamespace) => {
+        getShardStatus: (catalogNamespace) => {
             const { shards } = get();
 
             if (shards.length > 0) {
@@ -110,9 +108,7 @@ export const getInitialState = (
                     spec.id ? spec.id.includes(catalogNamespace) : undefined
                 );
 
-                let statusIndicator: ShardStatusIndicatorText[] = [
-                    'No shard status found.',
-                ];
+                let statusIndicator: ShardStatus[] = ['No shard status found.'];
 
                 if (selectedShard) {
                     if (selectedShard.spec.disable) {
@@ -171,8 +167,7 @@ export const shardDetailSelectors = {
     shards: (state: ShardDetailStore) => state.shards,
     setShards: (state: ShardDetailStore) => state.setShards,
     getShardStatusColor: (state: ShardDetailStore) => state.getShardStatusColor,
-    getShardStatusIndicatorText: (state: ShardDetailStore) =>
-        state.getShardStatusIndicatorText,
+    getShardStatus: (state: ShardDetailStore) => state.getShardStatus,
     getShardDetails: (state: ShardDetailStore) => state.getShardDetails,
     evaluateShardProcessingState: (state: ShardDetailStore) =>
         state.evaluateShardProcessingState,


### PR DESCRIPTION
## Changes

Display a distinguishable status indicator for disabled tasks.

**NOTE:** Originally, a reasonably thick grey line was used as the status indicator for disabled tasks but it looked out of place amid the circles. I decided to move forward with a hollowed, grey circle for that reason. If a line is preferred, let me know.

## Tests

Only manual testing was performed.

## Screenshots

**Entity Table | Disabled Task**

<img width="1275" alt="pr-screenshot__144__disabled-status-indicator__captures" src="https://user-images.githubusercontent.com/77648584/171430189-a2cc902a-f542-49d5-8e7e-11c5a5f2165c.PNG">

