### PR TITLE
Add local .env so npm start works OOTB

### DIFF
--- a/.env
+++ b/.env
@@ -2,13 +2,8 @@ EXTEND_ESLINT=true
 
 PORT=3000
 
-# Uncomment me for local development:
-# REACT_APP_SUPABASE_URL=http://localhost:5431
-# REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs
-
-# REACT_APP_GATEWAY_AUTH_TOKEN_URL=http://localhost:5431/rest/v1/rpc/gateway_auth_token
-
-# Comment me for local development:
+# These are the values used for production. When running locally, they are overridden by
+# .env.development.local
 REACT_APP_SUPABASE_URL=https://eyrcnmuzzyriypdajwdk.supabase.co
 REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco
 

--- a/.env.development.local
+++ b/.env.development.local
@@ -1,0 +1,7 @@
+
+# These properties are used when running locally. They match the defaults that you get when running
+# `supabase start` in animated-carnival.
+
+REACT_APP_SUPABASE_URL=http://localhost:5431
+REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs
+REACT_APP_GATEWAY_AUTH_TOKEN_URL=http://localhost:5431/rest/v1/rpc/gateway_auth_token

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 # misc
 .DS_Store
 .env.local
-.env.development.local
 .env.test.local
 .env.production.local
 


### PR DESCRIPTION
Adds `.env.development.local`, which is used to override properties from
`.env` when running `npm start`. The purpose of this is to allow
developers to run `npm start` without needing to modify the `.env` file
to run locally. The approach was taken from:
https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env


## Tests

Works on my machine :wink: 