### PR TITLE
Update Entity Table Filter Label.

### DIFF
--- a/src/components/tables/Captures/index.tsx
+++ b/src/components/tables/Captures/index.tsx
@@ -87,7 +87,7 @@ function CapturesTable() {
                     setColumnToSort={setColumnToSort}
                     header="captureTable.header"
                     headerLink="https://docs.estuary.dev/concepts/#captures"
-                    filterLabel="entityTable.filterLabel"
+                    filterLabel="capturesTable.filterLabel"
                     enableSelection
                     rowSelectorProps={{
                         showMaterialize: true,

--- a/src/components/tables/Collections/index.tsx
+++ b/src/components/tables/Collections/index.tsx
@@ -71,7 +71,7 @@ function CollectionsTable() {
                     setColumnToSort={setColumnToSort}
                     header="collectionsTable.title"
                     headerLink="https://docs.estuary.dev/concepts/#collections"
-                    filterLabel="entityTable.filterLabel"
+                    filterLabel="collectionsTable.filterLabel"
                 />
             </ZustandProvider>
         </Box>

--- a/src/components/tables/Materializations/index.tsx
+++ b/src/components/tables/Materializations/index.tsx
@@ -87,7 +87,7 @@ function MaterializationsTable() {
                     setColumnToSort={setColumnToSort}
                     header="materializationsTable.title"
                     headerLink="https://docs.estuary.dev/concepts/#materializations"
-                    filterLabel="entityTable.filterLabel"
+                    filterLabel="materializationsTable.filterLabel"
                     showEntityStatus={true}
                     enableSelection
                 />

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -184,7 +184,6 @@ const EntityStatus: ResolvedIntlConfig['messages'] = {
 const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.title': `Entity Table`,
 
-    'entityTable.filterLabel': `Filter collections`,
     'entityTable.data.entity': `Name`,
     'entityTable.data.connectorType': `Type`,
     'entityTable.data.lastUpdated': `Last Updated`,
@@ -290,6 +289,7 @@ const Captures: ResolvedIntlConfig['messages'] = {
     'captureTable.header': `Captures`,
     'capturesTable.title': `Your Captures`,
     'capturesTable.cta.new': `New Capture`,
+    'capturesTable.filterLabel': `Filter captures`,
     'capturesTable.disableEnable.confirm': `All items listed below will be {setting}.`,
     'capturesTable.delete.confirm': `All items listed below will be deleted forever. Please review before continuing.`,
     'capturesTable.ctaGroup.aria': `capture table available actions`,
@@ -304,6 +304,7 @@ const Captures: ResolvedIntlConfig['messages'] = {
 const Materializations: ResolvedIntlConfig['messages'] = {
     'materializationsTable.title': `Materializations`,
     'materializationsTable.cta.new': `New Materialization`,
+    'materializationsTable.filterLabel': `Filter materializations`,
     'materializations.message1': `Click "New Materialization" to get started.`,
     'materializations.message2': `You'll be guided through the process of defining, testing, and publishing a {docLink}.`,
     'materializations.message2.docLink': `materialization`,
@@ -313,6 +314,7 @@ const Materializations: ResolvedIntlConfig['messages'] = {
 const Collections: ResolvedIntlConfig['messages'] = {
     'collectionsTable.title': `Collections`,
     'collectionsTable.detailsCTA': `Details`,
+    'collectionsTable.filterLabel': `Filter collections`,
     'collections.message1': `You currently have no collections. Click the Captures icon on the menu bar to get started.`,
     'collections.message2': `Captures connect to outside systems, pull in data, and generate {docLink} within Flow.`,
     'collections.message2.docLink': `collections`,


### PR DESCRIPTION
## Changes

Update the label of the entity table filter `TextField` component so that it reads _Filter [entity type]_ (i.e., _Filter captures_, _Filter collections_, or _Filter materializations_).

## Tests

Viewed each entity table and validated the filter label.

## Issues

#204 

## Content

The filter label on the capture, collection, and materialization tables.

## Screenshots

**Capture Table**

<img width="567" alt="pr-screenshot__151__filter-label__captures" src="https://user-images.githubusercontent.com/77648584/172706296-d6e887cf-c59a-44d8-b5eb-12364fcf2cf7.PNG">

<br />

**Collection Table**

<img width="567" alt="pr-screenshot__151__filter-label__collections" src="https://user-images.githubusercontent.com/77648584/172706316-23cedad6-940e-49a9-8221-0242b5fff6bd.PNG">

<br />

**Materialization Table**

<img width="580" alt="pr-screenshot__151__filter-label__materializations" src="https://user-images.githubusercontent.com/77648584/172706335-01704e46-4ff4-4912-a4cc-537372e7a4f3.PNG">