### PR TITLE
Reset Entity Table Page Upon Each Filter.

### DIFF
--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -211,6 +211,8 @@ function EntityTable({
 
                 resetSelection();
                 setSearchQuery(hasQuery ? filterQuery : null);
+                setPagination(getPagination(0, rowsPerPage));
+                setPage(0);
             },
             750
         ),


### PR DESCRIPTION
## Changes

Reset the entity table page whenever changes to the filter query string are detected.

## Tests

The following approaches to testing were performed:

1. Switch to a deeper page in the entity table, apply a filter that should have enough query matches to reach the new page, confirm the first page of query matches is presented.

1. Switch to a deeper page in the entity table, apply a filter that should **not** have enough query matches to reach the new page, confirm the first page of query matches is presented.

## Issues

#201 

