### PR TITLE
Improve Materialization Resource Config Retention and Removal

### DIFF
--- a/src/api/draftSpecs.ts
+++ b/src/api/draftSpecs.ts
@@ -50,12 +50,16 @@ export const generateDraftSpec = (
 
     if (resources) {
         Object.keys(resources).forEach((collectionName) => {
-            draftSpec.bindings.push({
-                source: collectionName,
-                resource: {
-                    ...resources[collectionName].data,
-                },
-            });
+            const resourceConfig = resources[collectionName].data;
+
+            if (Object.keys(resourceConfig).length > 0) {
+                draftSpec.bindings.push({
+                    source: collectionName,
+                    resource: {
+                        ...resourceConfig,
+                    },
+                });
+            }
         });
     }
 

--- a/src/components/collection/ResourceConfigForm.tsx
+++ b/src/components/collection/ResourceConfigForm.tsx
@@ -23,6 +23,9 @@ function NewMaterializationResourceConfigForm({
 }: Props) {
     const useEntityCreateStore = useRouteStore();
 
+    const collections: string[] = useEntityCreateStore(
+        entityCreateStoreSelectors.collections
+    );
     const setConfig = useEntityCreateStore(
         entityCreateStoreSelectors.resourceConfig.set
     );
@@ -38,11 +41,13 @@ function NewMaterializationResourceConfigForm({
     //  This will hydrate the default values for us as we don't want JSONForms to
     //  directly update the state object as it caused issues when switching connectors.
     useEffect(() => {
-        setConfig(collectionName, {
-            data: createJSONFormDefaults(resourceSchema),
-            errors: [],
-        });
-    }, [collectionName, resourceSchema, setConfig]);
+        if (!collections.includes(collectionName)) {
+            setConfig(collectionName, {
+                data: createJSONFormDefaults(resourceSchema),
+                errors: [],
+            });
+        }
+    }, [collectionName, resourceSchema, collections, setConfig]);
 
     const uiSchema = custom_generateDefaultUISchema(resourceSchema);
     const showValidationVal = showValidation(displayValidation);

--- a/src/components/collection/Selector.tsx
+++ b/src/components/collection/Selector.tsx
@@ -16,7 +16,7 @@ function CollectionSelector() {
     const { liveSpecs: collectionData, error } = useLiveSpecs('collection');
 
     const useEntityCreateStore = useRouteStore();
-    const collections = useEntityCreateStore(
+    const collections: string[] = useEntityCreateStore(
         entityCreateStoreSelectors.collections
     );
     const setCollections = useEntityCreateStore(
@@ -29,7 +29,16 @@ function CollectionSelector() {
     const handlers = {
         updateCollections: (event: React.SyntheticEvent, value: any) => {
             setCollections(value);
-            setResourceConfig(value[value.length - 1]);
+
+            if (collections.length > value.length) {
+                const removedCollection = collections.find(
+                    (collection) => !value.includes(collection)
+                );
+
+                setResourceConfig(removedCollection);
+            } else {
+                setResourceConfig(value[value.length - 1]);
+            }
         },
         validateSelection: () => {
             setMissingInput(collections.length === 0);


### PR DESCRIPTION
## Changes

The following changes are included in this PR:

1. Remove the correct resource config data from the _materialization create_ store when a collection is removed from the selector.

1. Evaluate whether a given resource config contains data before adding it to the materialization definition.

1. Limit when resource config data in the _materialization create_ store is defaulted and/or reset.

## Tests

Iterate over the possible collection removal/addition and catalog generation sequences. Sample size of five collections.

Switch connector types after updating resource configurations.

## Issues

#217
