### PR TITLE
Add defaults and logging to JsonForms test page

### DIFF
--- a/src/pages/dev/TestJsonForms.tsx
+++ b/src/pages/dev/TestJsonForms.tsx
@@ -14,6 +14,7 @@ import WrapperWithHeader from 'components/shared/Entity/WrapperWithHeader';
 import PageContainer from 'components/shared/PageContainer';
 import { jsonFormsPadding } from 'context/Theme';
 import { useState } from 'react';
+import { setDefaultsValidator } from 'services/ajv';
 import { defaultOptions, defaultRenderers } from 'services/jsonforms';
 
 const TestJsonForms = () => {
@@ -69,6 +70,13 @@ const TestJsonForms = () => {
                                 cells={materialCells}
                                 config={defaultOptions}
                                 validationMode="ValidateAndShow"
+                                onChange={(state) =>
+                                    console.log(
+                                        'This is the new state of the form',
+                                        state
+                                    )
+                                }
+                                ajv={setDefaultsValidator}
                             />
                         </Box>
                     </StyledEngineProvider>


### PR DESCRIPTION
Forcing this into `main` quick to help a developer with their work. This page is not really for users or displayed in production so the impact is low.