### PR TITLE
Enable Materialization Task Actions

### DIFF
--- a/src/components/tables/Materializations/index.tsx
+++ b/src/components/tables/Materializations/index.tsx
@@ -83,6 +83,10 @@ function MaterializationsTable() {
                 header="materializationsTable.title"
                 headerLink="https://docs.estuary.dev/concepts/#materializations"
                 filterLabel="materializationsTable.filterLabel"
+                rowSelectorProps={{
+                    selectableTableStoreName:
+                        SelectTableStoreNames.MATERIALIZATION,
+                }}
                 showEntityStatus={true}
                 enableSelection
                 selectableTableStoreName={SelectTableStoreNames.MATERIALIZATION}


### PR DESCRIPTION
## Changes

Enable the task action button toolbar on the materializations page.

## Tests

Enabled, disabled, and deleted single and multiple materializations via a task action button.

## Issues

#224 

## Screenshots

**Materialization Table | Task Action Toolbar Enabled**

<img width="1177" alt="pr-screenshot__152__materialization-task-actions" src="https://user-images.githubusercontent.com/77648584/173924338-00ce8257-2fa1-49c4-bc1f-071f95c25bf0.PNG">
