### PR TITLE
Update Files Shown in Details Panel Editor.

### DIFF
--- a/src/components/tables/Captures/Rows.tsx
+++ b/src/components/tables/Captures/Rows.tsx
@@ -133,7 +133,7 @@ function Row({ isSelected, setRow, row, showEntityStatus }: RowProps) {
 
             <DetailsPanel
                 detailsExpanded={detailsExpanded}
-                id={row.last_pub_id}
+                lastPubId={row.last_pub_id}
                 colSpan={tableColumns.length}
                 entityType={ENTITY.CAPTURE}
             />

--- a/src/components/tables/Captures/Rows.tsx
+++ b/src/components/tables/Captures/Rows.tsx
@@ -137,7 +137,7 @@ function Row({ isSelected, setRow, row, showEntityStatus }: RowProps) {
                 lastPubId={row.last_pub_id}
                 colSpan={tableColumns.length}
                 entityType={ENTITY.CAPTURE}
-                omittedSpecType={ENTITY.MATERIALIZATION}
+                specTypes={[ENTITY.CAPTURE, ENTITY.COLLECTION]}
             />
         </>
     );

--- a/src/components/tables/Captures/Rows.tsx
+++ b/src/components/tables/Captures/Rows.tsx
@@ -137,6 +137,7 @@ function Row({ isSelected, setRow, row, showEntityStatus }: RowProps) {
                 lastPubId={row.last_pub_id}
                 colSpan={tableColumns.length}
                 entityType={ENTITY.CAPTURE}
+                omittedSpecType={ENTITY.MATERIALIZATION}
             />
         </>
     );

--- a/src/components/tables/Collections/Rows.tsx
+++ b/src/components/tables/Collections/Rows.tsx
@@ -70,6 +70,7 @@ function Row({ row, showEntityStatus }: RowProps) {
                 detailsExpanded={detailsExpanded}
                 lastPubId={row.last_pub_id}
                 colSpan={tableColumns.length}
+                liveSpecId={row.id}
                 disableLogs
             />
         </>

--- a/src/components/tables/Collections/Rows.tsx
+++ b/src/components/tables/Collections/Rows.tsx
@@ -68,7 +68,7 @@ function Row({ row, showEntityStatus }: RowProps) {
 
             <DetailsPanel
                 detailsExpanded={detailsExpanded}
-                id={row.last_pub_id}
+                lastPubId={row.last_pub_id}
                 colSpan={tableColumns.length}
                 disableLogs
             />

--- a/src/components/tables/Details/DetailsPanel.tsx
+++ b/src/components/tables/Details/DetailsPanel.tsx
@@ -14,7 +14,7 @@ interface Props {
     detailsExpanded: boolean;
     lastPubId: string;
     colSpan: number;
-    omittedSpecType?: ENTITY;
+    specTypes?: ENTITY[];
     liveSpecId?: string;
     disableLogs?: boolean;
     entityType?: ENTITY.CAPTURE | ENTITY.MATERIALIZATION;
@@ -24,7 +24,7 @@ function DetailsPanel({
     detailsExpanded,
     lastPubId,
     colSpan,
-    omittedSpecType,
+    specTypes,
     liveSpecId,
     disableLogs,
     entityType,
@@ -55,7 +55,7 @@ function DetailsPanel({
 
                             <EditorAndLogs
                                 lastPubId={lastPubId}
-                                omittedSpecType={omittedSpecType}
+                                specTypes={specTypes}
                                 liveSpecId={liveSpecId}
                                 disableLogs={disableLogs}
                                 liveSpecEditorStoreName={

--- a/src/components/tables/Details/DetailsPanel.tsx
+++ b/src/components/tables/Details/DetailsPanel.tsx
@@ -14,6 +14,7 @@ interface Props {
     detailsExpanded: boolean;
     lastPubId: string;
     colSpan: number;
+    omittedSpecType?: ENTITY;
     liveSpecId?: string;
     disableLogs?: boolean;
     entityType?: ENTITY.CAPTURE | ENTITY.MATERIALIZATION;
@@ -23,6 +24,7 @@ function DetailsPanel({
     detailsExpanded,
     lastPubId,
     colSpan,
+    omittedSpecType,
     liveSpecId,
     disableLogs,
     entityType,
@@ -53,6 +55,7 @@ function DetailsPanel({
 
                             <EditorAndLogs
                                 lastPubId={lastPubId}
+                                omittedSpecType={omittedSpecType}
                                 liveSpecId={liveSpecId}
                                 disableLogs={disableLogs}
                                 liveSpecEditorStoreName={

--- a/src/components/tables/Details/DetailsPanel.tsx
+++ b/src/components/tables/Details/DetailsPanel.tsx
@@ -14,6 +14,7 @@ interface Props {
     detailsExpanded: boolean;
     lastPubId: string;
     colSpan: number;
+    liveSpecId?: string;
     disableLogs?: boolean;
     entityType?: ENTITY.CAPTURE | ENTITY.MATERIALIZATION;
 }
@@ -22,6 +23,7 @@ function DetailsPanel({
     detailsExpanded,
     lastPubId,
     colSpan,
+    liveSpecId,
     disableLogs,
     entityType,
 }: Props) {
@@ -51,6 +53,7 @@ function DetailsPanel({
 
                             <EditorAndLogs
                                 lastPubId={lastPubId}
+                                liveSpecId={liveSpecId}
                                 disableLogs={disableLogs}
                                 liveSpecEditorStoreName={
                                     LiveSpecEditorStoreNames.GENERAL

--- a/src/components/tables/Details/DetailsPanel.tsx
+++ b/src/components/tables/Details/DetailsPanel.tsx
@@ -12,7 +12,7 @@ import {
 
 interface Props {
     detailsExpanded: boolean;
-    id: string;
+    lastPubId: string;
     colSpan: number;
     disableLogs?: boolean;
     entityType?: ENTITY.CAPTURE | ENTITY.MATERIALIZATION;
@@ -20,7 +20,7 @@ interface Props {
 
 function DetailsPanel({
     detailsExpanded,
-    id,
+    lastPubId,
     colSpan,
     disableLogs,
     entityType,
@@ -50,7 +50,7 @@ function DetailsPanel({
                             )}
 
                             <EditorAndLogs
-                                lastPubId={id}
+                                lastPubId={lastPubId}
                                 disableLogs={disableLogs}
                                 liveSpecEditorStoreName={
                                     LiveSpecEditorStoreNames.GENERAL

--- a/src/components/tables/Details/EditorAndLogs.tsx
+++ b/src/components/tables/Details/EditorAndLogs.tsx
@@ -11,11 +11,13 @@ import usePublicationSpecs, {
 import { LiveSpecEditorStoreNames, UseZustandStore } from 'context/Zustand';
 import { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { ENTITY } from 'types';
 
 interface Props {
     lastPubId: string;
     liveSpecEditorStoreName: LiveSpecEditorStoreNames;
     useZustandStore: UseZustandStore;
+    omittedSpecType?: ENTITY;
     liveSpecId?: string;
     disableLogs?: boolean;
 }
@@ -24,13 +26,15 @@ function EditorAndLogs({
     lastPubId,
     liveSpecEditorStoreName,
     useZustandStore,
+    omittedSpecType,
     liveSpecId,
     disableLogs,
 }: Props) {
-    const { publicationSpecs, error: pubSpecsError } = usePublicationSpecs(
+    const { publicationSpecs, error: pubSpecsError } = usePublicationSpecs({
         lastPubId,
-        liveSpecId
-    );
+        omittedSpecType,
+        liveSpecId,
+    });
     const { publication: publications, error: pubsError } =
         usePublications(lastPubId);
 

--- a/src/components/tables/Details/EditorAndLogs.tsx
+++ b/src/components/tables/Details/EditorAndLogs.tsx
@@ -16,6 +16,7 @@ interface Props {
     lastPubId: string;
     liveSpecEditorStoreName: LiveSpecEditorStoreNames;
     useZustandStore: UseZustandStore;
+    liveSpecId?: string;
     disableLogs?: boolean;
 }
 
@@ -23,10 +24,13 @@ function EditorAndLogs({
     lastPubId,
     liveSpecEditorStoreName,
     useZustandStore,
+    liveSpecId,
     disableLogs,
 }: Props) {
-    const { publicationSpecs, error: pubSpecsError } =
-        usePublicationSpecs(lastPubId);
+    const { publicationSpecs, error: pubSpecsError } = usePublicationSpecs(
+        lastPubId,
+        liveSpecId
+    );
     const { publication: publications, error: pubsError } =
         usePublications(lastPubId);
 

--- a/src/components/tables/Details/EditorAndLogs.tsx
+++ b/src/components/tables/Details/EditorAndLogs.tsx
@@ -17,7 +17,7 @@ interface Props {
     lastPubId: string;
     liveSpecEditorStoreName: LiveSpecEditorStoreNames;
     useZustandStore: UseZustandStore;
-    omittedSpecType?: ENTITY;
+    specTypes?: ENTITY[];
     liveSpecId?: string;
     disableLogs?: boolean;
 }
@@ -26,13 +26,13 @@ function EditorAndLogs({
     lastPubId,
     liveSpecEditorStoreName,
     useZustandStore,
-    omittedSpecType,
+    specTypes,
     liveSpecId,
     disableLogs,
 }: Props) {
     const { publicationSpecs, error: pubSpecsError } = usePublicationSpecs({
         lastPubId,
-        omittedSpecType,
+        specTypes,
         liveSpecId,
     });
     const { publication: publications, error: pubsError } =
@@ -71,7 +71,7 @@ function EditorAndLogs({
                 </Grid>
 
                 <Grid item xs={6}>
-                    {pubsError ? (
+                    {pubsError && !disableLogs ? (
                         <Alert variant="filled" severity="warning">
                             <FormattedMessage id="detailsPanel.logs.notFound" />
                         </Alert>

--- a/src/components/tables/Materializations/Rows.tsx
+++ b/src/components/tables/Materializations/Rows.tsx
@@ -118,7 +118,7 @@ function Row({ isSelected, setRow, row, showEntityStatus }: RowProps) {
 
             <DetailsPanel
                 detailsExpanded={detailsExpanded}
-                id={row.last_pub_id}
+                lastPubId={row.last_pub_id}
                 colSpan={tableColumns.length}
                 entityType={ENTITY.MATERIALIZATION}
             />

--- a/src/components/tables/Materializations/Rows.tsx
+++ b/src/components/tables/Materializations/Rows.tsx
@@ -121,6 +121,7 @@ function Row({ isSelected, setRow, row, showEntityStatus }: RowProps) {
                 lastPubId={row.last_pub_id}
                 colSpan={tableColumns.length}
                 entityType={ENTITY.MATERIALIZATION}
+                omittedSpecType={ENTITY.CAPTURE}
             />
         </>
     );

--- a/src/components/tables/Materializations/Rows.tsx
+++ b/src/components/tables/Materializations/Rows.tsx
@@ -121,7 +121,7 @@ function Row({ isSelected, setRow, row, showEntityStatus }: RowProps) {
                 lastPubId={row.last_pub_id}
                 colSpan={tableColumns.length}
                 entityType={ENTITY.MATERIALIZATION}
-                omittedSpecType={ENTITY.CAPTURE}
+                specTypes={[ENTITY.MATERIALIZATION]}
             />
         </>
     );

--- a/src/hooks/usePublicationSpecs.ts
+++ b/src/hooks/usePublicationSpecs.ts
@@ -4,7 +4,7 @@ import { useQuery, useSelect } from './supabase-swr/';
 
 interface PublicationSpecConfig {
     lastPubId: string | null;
-    omittedSpecType?: ENTITY;
+    specTypes?: ENTITY[];
     liveSpecId?: string;
 }
 
@@ -42,7 +42,7 @@ const defaultResponse: PublicationSpecQuery[] = [];
 
 function usePublicationSpecs({
     lastPubId,
-    omittedSpecType,
+    specTypes,
     liveSpecId,
 }: PublicationSpecConfig) {
     const publicationsQuery = useQuery<PublicationSpecQuery>(
@@ -54,9 +54,10 @@ function usePublicationSpecs({
                     ? query.eq('live_spec_id', liveSpecId)
                     : query
                           .eq('pub_id', lastPubId as string)
-                          .neq(
+                          .filter(
                               'live_specs.spec_type',
-                              omittedSpecType as string
+                              'in',
+                              `(${specTypes})`
                           ),
         },
         [lastPubId, liveSpecId]

--- a/src/hooks/usePublicationSpecs.ts
+++ b/src/hooks/usePublicationSpecs.ts
@@ -44,10 +44,12 @@ function usePublicationSpecs(
                     ? query.eq('live_spec_id', liveSpecId)
                     : query.eq('pub_id', lastPubId as string),
         },
-        [lastPubId]
+        [lastPubId, liveSpecId]
     );
 
-    const { data, error } = useSelect(lastPubId ? publicationsQuery : null);
+    const { data, error } = useSelect(
+        lastPubId || liveSpecId ? publicationsQuery : null
+    );
 
     return {
         publicationSpecs: data ? data.data : [],

--- a/src/hooks/usePublicationSpecs.ts
+++ b/src/hooks/usePublicationSpecs.ts
@@ -31,12 +31,18 @@ const PUB_SPEC_QUERY = `
     )
 `;
 
-function usePublicationSpecs(lastPubId: string | null) {
+function usePublicationSpecs(
+    lastPubId: string | null,
+    liveSpecId: string | undefined
+) {
     const publicationsQuery = useQuery<PublicationSpecQuery>(
         TABLES.PUBLICATION_SPECS,
         {
             columns: PUB_SPEC_QUERY,
-            filter: (query) => query.eq('pub_id', lastPubId as string),
+            filter: (query) =>
+                liveSpecId
+                    ? query.eq('live_spec_id', liveSpecId)
+                    : query.eq('pub_id', lastPubId as string),
         },
         [lastPubId]
     );


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Hide logs-related alert messages in the details panel when the logs are disabled.

1. Display only the collection and capture definitions relevant to a given capture table row in its details panel.

1. Display the single collection definition relevant to a given collection table row in its details panel.

1. Display only the materialization definition relevant to a given materialization table row in its details panel.

**NOTE:** It should be noted that it is possible for a captures details panel editor to contain only the capture definition. This issue will be researched independently.

## Tests

The following approaches to testing were taken:

* Opened a single details panel at a time on the capture, materialization, and collection tables, progressing through an entire 10-item page.

* Opened multiple details panels at a time on the capture, materialization, and collection tables.

## Screenshots

**Capture Table**

<img width="949" alt="pr-screenshot__154__details-panel-file-selector__captures" src="https://user-images.githubusercontent.com/77648584/175394632-6bf147aa-bf2c-403b-9995-a8efae3666e4.PNG">

<br />

**Collection Table**

<img width="948" alt="pr-screenshot__154__details-panel-file-selector__collections" src="https://user-images.githubusercontent.com/77648584/175394176-f2664d01-51de-4eca-9dca-ddf4281e1a36.PNG">

<br />

**Materialization Table**

<img width="949" alt="pr-screenshot__154__details-panel-file-selector__materializations" src="https://user-images.githubusercontent.com/77648584/175394603-e0556c71-5ac5-42e6-9a43-2801eefa9b2e.PNG">

<br />