### PR TITLE
Use local config-encryption service

### DIFF
--- a/.env.development.local
+++ b/.env.development.local
@@ -5,3 +5,6 @@
 REACT_APP_SUPABASE_URL=http://localhost:5431
 REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs
 REACT_APP_GATEWAY_AUTH_TOKEN_URL=http://localhost:5431/rest/v1/rpc/gateway_auth_token
+
+# Sops Encryption settings
+REACT_APP_ENCRYPTION_URL=http://localhost:8765/v1/encrypt-config


### PR DESCRIPTION
## Changes

Note: hold off merging this until estuary/animated-carnival#39 is merged, so that the local config-encryption service will be available.

When running the UI locally, use a local instance of the
config-encryption service. UI developers may still switch back to the
production config-encryption service when running without a data plane.
But normally, the local config-encryption service is needed, since
developers will not be able to decrypt credentials that were encrypted
using the production service.

## Tests

Tested manually using `./local/start-flow.sh` in animated-carnival. 

## Issues

estuary/animated-carnival#38