### PR TITLE
content - fix mismatched terms

### DIFF
--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -398,7 +398,7 @@ const CaptureCreate: ResolvedIntlConfig['messages'] = {
     'captureCreate.config.source.homepage': `Home`,
     'captureCreate.save.failed': `Capture creation failed. See below for details:`,
     'captureCreate.editor.default': `Before you can edit the capture specification, you must fill out the Connection Configuration section and click "${CTAs['cta.generateCatalog.capture']}." `,
-    'captureCreate.finalReview.instructions': `The following catalog was generated from the details you provided. To make changes, you can enter new values in the form above and click "Discover Endpoint" again. You can also edit the YAML file directly. Click "Save and Publish" to proceed.`,
+    'captureCreate.finalReview.instructions': `The following catalog was generated from the details you provided. To make changes, you can enter new values in the form above and click "${CTAs['cta.generateCatalog.capture']}" again. You can also edit the YAML file directly. Click "${CTAs['cta.saveEntity']}" to proceed.`,
 
     'captureCreate.test.failedErrorTitle': `Configuration Test Failed`,
     'captureCreate.test.serverUnreachable': `Unable to reach server while testing configuration.`,
@@ -433,7 +433,7 @@ const MaterializationCreate: ResolvedIntlConfig['messages'] = {
     'materializationCreate.collections.heading': `Output Collections`,
     'materializationCreate.config.source.doclink': `Connector Help`,
     'materializationCreate.editor.default': `Before you can edit the materialization specification, you must fill out the Connection Configuration section and click "${CTAs['cta.generateCatalog.materialization']}".`,
-    'materializationCreate.finalReview.instructions': `The following catalog was generated from the details you provided. To make changes, you can enter new values in the form above and click "Discover Endpoint" again. You can also edit the YAML file directly. Click "Save and Publish" to proceed.`,
+    'materializationCreate.finalReview.instructions': `The following catalog was generated from the details you provided. To make changes, you can enter new values in the form above and click "${CTAs['cta.generateCatalog.materialization']}" again. You can also edit the YAML file directly. Click "${CTAs['cta.saveEntity']}," to proceed.`,
     'materializationCreate.heading': `New Materialization`,
     'materializationCreate.instructions': `Provide a unique name and specify a destination system for your materialization. Fill in the required details and click "${CTAs['cta.generateCatalog.materialization']}".`,
     'materializationCreate.missingConnectors': `No connectors installed. A materialization connector must be installed before a materialization can be created.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -398,7 +398,7 @@ const CaptureCreate: ResolvedIntlConfig['messages'] = {
     'captureCreate.config.source.homepage': `Home`,
     'captureCreate.save.failed': `Capture creation failed. See below for details:`,
     'captureCreate.editor.default': `Before you can edit the capture specification, you must fill out the Connection Configuration section and click "${CTAs['cta.generateCatalog.capture']}." `,
-    'captureCreate.finalReview.instructions': `The following catalog was generated from the details you provided. To make changes, you can enter new values in the form above and click Regenenerate Catalog, or you can edit the YAML file directly. Click Save and Publish to proceed.`,
+    'captureCreate.finalReview.instructions': `The following catalog was generated from the details you provided. To make changes, you can enter new values in the form above and click "Discover Endpoint" again. You can also edit the YAML file directly. Click "Save and Publish" to proceed.`,
 
     'captureCreate.test.failedErrorTitle': `Configuration Test Failed`,
     'captureCreate.test.serverUnreachable': `Unable to reach server while testing configuration.`,
@@ -433,7 +433,7 @@ const MaterializationCreate: ResolvedIntlConfig['messages'] = {
     'materializationCreate.collections.heading': `Output Collections`,
     'materializationCreate.config.source.doclink': `Connector Help`,
     'materializationCreate.editor.default': `Before you can edit the materialization specification, you must fill out the Connection Configuration section and click "${CTAs['cta.generateCatalog.materialization']}".`,
-    'materializationCreate.finalReview.instructions': `The following catalog was generated from the details you provided. To make changes, you can enter new values in the form above and click Regenenerate Catalog, or you can edit the YAML file directly. Click Save and Publish to proceed.`,
+    'materializationCreate.finalReview.instructions': `The following catalog was generated from the details you provided. To make changes, you can enter new values in the form above and click "Discover Endpoint" again. You can also edit the YAML file directly. Click "Save and Publish" to proceed.`,
     'materializationCreate.heading': `New Materialization`,
     'materializationCreate.instructions': `Provide a unique name and specify a destination system for your materialization. Fill in the required details and click "${CTAs['cta.generateCatalog.materialization']}".`,
     'materializationCreate.missingConnectors': `No connectors installed. A materialization connector must be installed before a materialization can be created.`,


### PR DESCRIPTION
## Changes

Noticed the messaging above the catalog editor after catalog generation is inconsistent with the current button names (there is no "regenerate catalog" button). This is just a quick fix to the content file to address that. 
![image](https://user-images.githubusercontent.com/82397941/183967439-40b2d7b5-e687-40f1-8b8d-d4ed2be3ef48.png)


## Tests

na

## Issues

na

## Content

content fix only, see above 

## Screenshots

_If applicable - please include some screenshots of the new UI_
