### PR TITLE
Clear Selected Table Rows when Navigation Changes.

### DIFF
--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -39,6 +39,7 @@ import {
     useState,
 } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useEffectOnce } from 'react-use';
 import {
     SortDirection,
     TableIntlConfig,
@@ -165,6 +166,12 @@ function EntityTable({
             resetRows();
         }
     };
+
+    useEffectOnce(() => {
+        return () => {
+            return resetSelection();
+        };
+    });
 
     const handlers = {
         filterTable: debounce(


### PR DESCRIPTION
## Changes

Clear any selected entity table rows when navigating away from the current page.

## Tests

Selected rows from one entity page (i.e., captures or materializations), switched to the other entity page, then returned to the original entity page and observed that the selection cleared.

Evaluated that existing selection functionality is still intact.

## Issues

Complete: #240 
