### PR TITLE
Make open graph title optional for capture connectors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
             - name: Get Deps
               run: npm install
 
+            - name: Print Versions
+              run: npm run print-versions
+
             - name: Prettier...ing
               run: npm run format
 
@@ -47,6 +50,9 @@ jobs:
 
             - name: Get Deps
               run: npm install
+
+            - name: Print Versions
+              run: npm run print-versions
 
             - name: Linting
               run: npm run lint
@@ -70,6 +76,9 @@ jobs:
             - name: Get Deps
               run: npm install
 
+            - name: Print Versions
+              run: npm run print-versions
+
             - name: Type Checking
               run: npm run typecheck
 
@@ -90,6 +99,9 @@ jobs:
 
             - name: Get Deps
               run: npm install
+
+            - name: Print Versions
+              run: npm run print-versions
 
             - name: Run jest
               run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
             "devDependencies": {
                 "@testing-library/jest-dom": "^5.16.4",
                 "@testing-library/react": "^12.1.5",
-                "@testing-library/user-event": "^14.4.1",
+                "@testing-library/user-event": "^14.4.3",
                 "@types/auth0-js": "^9.14.6",
                 "@types/lodash": "^4.14.182",
                 "@types/logrocket-react": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,12 @@
                 "typescript": "^4.7.4"
             }
         },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
+            "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+            "dev": true
+        },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -119,28 +125,28 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.18.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-            "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
+            "integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-            "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
+            "integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.18.10",
+                "@babel/generator": "^7.18.13",
                 "@babel/helper-compilation-targets": "^7.18.9",
                 "@babel/helper-module-transforms": "^7.18.9",
                 "@babel/helpers": "^7.18.9",
-                "@babel/parser": "^7.18.10",
+                "@babel/parser": "^7.18.13",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.18.10",
-                "@babel/types": "^7.18.10",
+                "@babel/traverse": "^7.18.13",
+                "@babel/types": "^7.18.13",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -205,11 +211,11 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-            "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
+            "integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
             "dependencies": {
-                "@babel/types": "^7.18.10",
+                "@babel/types": "^7.18.13",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -273,9 +279,9 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
-            "integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz",
+            "integrity": "sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -564,9 +570,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.18.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-            "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
+            "integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1249,9 +1255,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz",
-            "integrity": "sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz",
+            "integrity": "sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.18.9"
@@ -1536,9 +1542,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-constant-elements": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.18.9.tgz",
-            "integrity": "sha512-IrTYh1I3YCEL1trjknnlLKTp5JggjzhKl/d3ibzPc97JhpFcDTr38Jdek/oX4cFbS6By0bXJcOkpRvJ5ZHK2wQ==",
+            "version": "7.18.12",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.18.12.tgz",
+            "integrity": "sha512-Q99U9/ttiu+LMnRU8psd23HhvwXmKWDQIpocm0JKaICcZHnw+mdQbHm6xnSy7dOl8I5PELakYtNBubNQlBXbZw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.18.9"
@@ -1743,9 +1749,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.10.tgz",
-            "integrity": "sha512-j2HQCJuMbi88QftIb5zlRu3c7PU+sXNnscqsrjqegoGiCgXR569pEdben9vly5QHKL2ilYkfnSwu64zsZo/VYQ==",
+            "version": "7.18.12",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
+            "integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-create-class-features-plugin": "^7.18.9",
@@ -1970,18 +1976,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.18.11",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-            "integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
+            "integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.18.10",
+                "@babel/generator": "^7.18.13",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.18.9",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.18.11",
-                "@babel/types": "^7.18.10",
+                "@babel/parser": "^7.18.13",
+                "@babel/types": "^7.18.13",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -1990,9 +1996,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-            "integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+            "integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.18.10",
                 "@babel/helper-validator-identifier": "^7.18.6",
@@ -2132,6 +2138,25 @@
                 "postcss": "^8.2"
             }
         },
+        "node_modules/@csstools/postcss-nested-calc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-nested-calc/-/postcss-nested-calc-1.0.0.tgz",
+            "integrity": "sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==",
+            "dev": true,
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^12 || ^14 || >=16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/csstools"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2"
+            }
+        },
         "node_modules/@csstools/postcss-normalize-display-values": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.1.tgz",
@@ -2190,6 +2215,25 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-1.0.1.tgz",
             "integrity": "sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==",
+            "dev": true,
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^12 || ^14 || >=16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/csstools"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2"
+            }
+        },
+        "node_modules/@csstools/postcss-text-decoration-shorthand": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-1.0.0.tgz",
+            "integrity": "sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -2274,9 +2318,9 @@
             }
         },
         "node_modules/@emotion/babel-plugin": {
-            "version": "11.10.0",
-            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.0.tgz",
-            "integrity": "sha512-xVnpDAAbtxL1dsuSelU5A7BnY/lftws0wUexNJZTPsvX/1tM4GZJbclgODhvW4E+NH7E5VFcH0bBn30NvniPJA==",
+            "version": "11.10.2",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
+            "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/plugin-syntax-jsx": "^7.17.12",
@@ -2296,9 +2340,9 @@
             }
         },
         "node_modules/@emotion/cache": {
-            "version": "11.10.1",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.1.tgz",
-            "integrity": "sha512-uZTj3Yz5D69GE25iFZcIQtibnVCFsc/6+XIozyL3ycgWvEdif2uEw9wlUt6umjLr4Keg9K6xRPHmD8LGi+6p1A==",
+            "version": "11.10.2",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.2.tgz",
+            "integrity": "sha512-GPR4PovENRvYDbCEnDRecPZYJzWdNMsM+Jn+13MC5uImVNbMyKwzv95DUHy5PDcgfPtKoDtfLU6emF1grrbQDg==",
             "dependencies": {
                 "@emotion/memoize": "^0.8.0",
                 "@emotion/sheet": "^1.2.0",
@@ -2977,7 +3021,6 @@
             "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
             "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "jest-get-type": "^28.0.2"
             },
@@ -3445,9 +3488,9 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-            "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+            "version": "0.3.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+            "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3526,15 +3569,15 @@
             }
         },
         "node_modules/@mui/base": {
-            "version": "5.0.0-alpha.92",
-            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.92.tgz",
-            "integrity": "sha512-ZgnSLrTXL4iUdLQhjp01dAOTQPQlnwrqjZRwDT3E6LZXEYn6cMv1MY6LZkWcF/zxrUnyasnsyMAgZ5d8AXS7bA==",
+            "version": "5.0.0-alpha.93",
+            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.93.tgz",
+            "integrity": "sha512-IVUWO0NNlELDc9FD7mM+fWTS1/6n5sJYdIbXpLQ00NjWdVEYmTyRgUAZDlJJJrz+tbF0eeffx0kOsvJvyTZlsA==",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
                 "@emotion/is-prop-valid": "^1.1.3",
                 "@mui/types": "^7.1.5",
                 "@mui/utils": "^5.9.3",
-                "@popperjs/core": "^2.11.5",
+                "@popperjs/core": "^2.11.6",
                 "clsx": "^1.2.1",
                 "prop-types": "^15.8.1",
                 "react-is": "^18.2.0"
@@ -3555,6 +3598,15 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@mui/core-downloads-tracker": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.1.tgz",
+            "integrity": "sha512-zyzLkVSqi+WuxG8UZrrOaWbhHkDK+MlHFjLpL+vqUVU6iSUaDYREu1xoLWEQsWOznT4oT2iEiGZLpQLgkn+WiA==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
             }
         },
         "node_modules/@mui/icons-material": {
@@ -3583,13 +3635,13 @@
             }
         },
         "node_modules/@mui/lab": {
-            "version": "5.0.0-alpha.93",
-            "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.93.tgz",
-            "integrity": "sha512-PGrI6tGwKGpLEv4sG7Jkhh/gqk5SE3KRCY8SKmC7JIOUpHEdPKIPH7kId/UZUd8+NOkr8YsljXmozpWv9PLsBQ==",
+            "version": "5.0.0-alpha.95",
+            "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.95.tgz",
+            "integrity": "sha512-JdJKhn0qJjk0ejtmsiZ/8e08uUzr8MZsASGbmY2VbGC7WlCntgjZrWmhuvQf3hWCtSfuD6tbCdPpz6A2NL5nVQ==",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
-                "@mui/base": "5.0.0-alpha.92",
-                "@mui/system": "^5.9.3",
+                "@mui/base": "5.0.0-alpha.93",
+                "@mui/system": "^5.10.1",
                 "@mui/utils": "^5.9.3",
                 "clsx": "^1.2.1",
                 "prop-types": "^15.8.1",
@@ -3623,13 +3675,14 @@
             }
         },
         "node_modules/@mui/material": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.9.3.tgz",
-            "integrity": "sha512-idDJajnfnDr+2pI6h2tzWtWoZJmVHNk6aSjISirMuVOGy0ugWpsCE+KW4++GS7aTCujXm9+cl5bWAyXvGjiPIQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.1.tgz",
+            "integrity": "sha512-E9fhskX6TwUdAzpL5+yoAzRxb6wY4oBqmBVlgUuLndSwPRYxXoGu+z74NxbDEkxUoHdb7vrDcRTswpB6ykDITQ==",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
-                "@mui/base": "5.0.0-alpha.92",
-                "@mui/system": "^5.9.3",
+                "@mui/base": "5.0.0-alpha.93",
+                "@mui/core-downloads-tracker": "^5.10.1",
+                "@mui/system": "^5.10.1",
                 "@mui/types": "^7.1.5",
                 "@mui/utils": "^5.9.3",
                 "@types/react-transition-group": "^4.4.5",
@@ -3692,9 +3745,9 @@
             }
         },
         "node_modules/@mui/styled-engine": {
-            "version": "5.8.7",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.8.7.tgz",
-            "integrity": "sha512-tVqtowjbYmiRq+qcqXK731L9eWoL9H8xTRhuTgaDGKdch1zlt4I2UwInUe1w2N9N/u3/jHsFbLcl1Un3uOwpQg==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.10.1.tgz",
+            "integrity": "sha512-xiQp6wvSLpMcRCOExbRSvkHf6gIQ/eeK7mx/Re6BtPPYIx6OerPwia+23uVIop/k4Bs5D+w7Rv2yXYJxo5rMSQ==",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
                 "@emotion/cache": "^11.9.3",
@@ -3770,13 +3823,13 @@
             "peer": true
         },
         "node_modules/@mui/system": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.9.3.tgz",
-            "integrity": "sha512-EXQV2POwncstHLYII+G4VSYdEFun1TjBbQSBDK76DbIkug8nPjtjAZ+3Kgk3/NoFIigW+vQ9cDVUZtlbRH6YMQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.10.1.tgz",
+            "integrity": "sha512-Ix8LVAMtVrNtmncK0yc5llHWlZKCm9okbw8QMnWbI5UH+nI9qhtf+Aure4p5ei6dGKdil++lukar/GxCjfzRSg==",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
                 "@mui/private-theming": "^5.9.3",
-                "@mui/styled-engine": "^5.8.7",
+                "@mui/styled-engine": "^5.10.1",
                 "@mui/types": "^7.1.5",
                 "@mui/utils": "^5.9.3",
                 "clsx": "^1.2.1",
@@ -3844,9 +3897,9 @@
             }
         },
         "node_modules/@mui/x-data-grid": {
-            "version": "5.15.1",
-            "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.15.1.tgz",
-            "integrity": "sha512-KTWrXRvhtudhONrjanpmSijgvMfWGiuX83RZxBpVPdiM4h0furLtltpmk++V3inEcGUeEFEj1qfx4ssiTuNJtw==",
+            "version": "5.15.3",
+            "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.15.3.tgz",
+            "integrity": "sha512-W1LrnCyFS/be7sppCf4EDGbwN6UgbdwqW0bW2eGK8Twmc2+upkmetHjvPodHhdtZ9onxrIJkfiPQG0PBzz5eIw==",
             "dependencies": {
                 "@babel/runtime": "^7.18.6",
                 "@mui/utils": "^5.4.1",
@@ -3963,9 +4016,9 @@
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.5",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+            "version": "2.11.6",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -4057,9 +4110,9 @@
             "dev": true
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.24.27",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.27.tgz",
-            "integrity": "sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==",
+            "version": "0.24.28",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
+            "integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==",
             "dev": true
         },
         "node_modules/@sinonjs/commons": {
@@ -4090,9 +4143,9 @@
             }
         },
         "node_modules/@supabase/gotrue-js": {
-            "version": "1.22.21",
-            "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.22.21.tgz",
-            "integrity": "sha512-AhsbBU+5j7BKSqfpLDkEcxy3ruDD+J+dHaYxXGHNWiiIJBYtK2jmNcMYA7M30MYjajnhoILJFC7LtHWl1lWj2Q==",
+            "version": "1.22.22",
+            "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.22.22.tgz",
+            "integrity": "sha512-exbCopLo4tLawKZR25wEdipm+IRVujuqFRR4h2wiXd11YA+N8rfgg/4S4L6BTFHmzV+KMjy0kDF3yMbsjIR/xA==",
             "dependencies": {
                 "cross-fetch": "^3.0.6"
             }
@@ -4123,12 +4176,12 @@
             }
         },
         "node_modules/@supabase/supabase-js": {
-            "version": "1.35.5",
-            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-1.35.5.tgz",
-            "integrity": "sha512-lAHr3Qz64lGGLtWRqnxglE8UmHooE5OrhvTSQBTJEG8Q+gU5wjAd8ilT3cyli4/beaBwF5UFLojCgWmA+EqBew==",
+            "version": "1.35.6",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-1.35.6.tgz",
+            "integrity": "sha512-KDRXRr+kdGwruIUizZPALbe5YccMYFVyZJf1sFWKLncaLYSFiM6iKFnqCrNeQ4JFoZZiICkiTl1FUuai62jVpg==",
             "dependencies": {
                 "@supabase/functions-js": "^1.3.4",
-                "@supabase/gotrue-js": "^1.22.17",
+                "@supabase/gotrue-js": "^1.22.21",
                 "@supabase/postgrest-js": "^0.37.4",
                 "@supabase/realtime-js": "^1.7.4",
                 "@supabase/storage-js": "^1.7.2"
@@ -4396,9 +4449,9 @@
             }
         },
         "node_modules/@testing-library/dom": {
-            "version": "8.16.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.16.1.tgz",
-            "integrity": "sha512-XEV2mBxgv6DKjL3+U3WEUzBgT2CjYksoXGlLrrJXYP8OvRfGkBonvelkorazpFlp8tkEecO06r43vN4DIEyegQ==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.17.1.tgz",
+            "integrity": "sha512-KnH2MnJUzmFNPW6RIKfd+zf2Wue8mEKX0M3cpX6aKl5ZXrJM1/c/Pc8c2xDNYQCnJO48Sm5ITbMXgqTr3h4jxQ==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
@@ -4485,16 +4538,16 @@
             }
         },
         "node_modules/@testing-library/jest-dom": {
-            "version": "5.16.4",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
-            "integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
+            "version": "5.16.5",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
+            "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
             "dev": true,
             "dependencies": {
+                "@adobe/css-tools": "^4.0.1",
                 "@babel/runtime": "^7.9.2",
                 "@types/testing-library__jest-dom": "^5.9.1",
                 "aria-query": "^5.0.0",
                 "chalk": "^3.0.0",
-                "css": "^3.0.0",
                 "css.escape": "^1.5.1",
                 "dom-accessibility-api": "^0.5.6",
                 "lodash": "^4.17.15",
@@ -4592,9 +4645,9 @@
             }
         },
         "node_modules/@testing-library/user-event": {
-            "version": "14.4.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.1.tgz",
-            "integrity": "sha512-Gr20dje1RaNxZ1ehHGPvFkLswfetBQKCfRD/lo6sUJQ52X2TV/QnqUpkjoShfEebrB2KiTPfQkcONwdQiofLhg==",
+            "version": "14.4.3",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+            "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
             "dev": true,
             "engines": {
                 "node": ">=12",
@@ -4667,9 +4720,9 @@
             }
         },
         "node_modules/@types/babel__traverse": {
-            "version": "7.17.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
-            "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
+            "integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.3.0"
@@ -4714,9 +4767,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.4.5",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-            "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+            "version": "8.4.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+            "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -4820,12 +4873,12 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "28.1.6",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-            "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+            "version": "28.1.7",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.7.tgz",
+            "integrity": "sha512-acDN4VHD40V24tgu0iC44jchXavRNVFXQ/E6Z5XNsswgoSO/4NgsXoEYmPUGookKldlZQyIpmrEXsHI9cA3ZTA==",
             "dev": true,
             "dependencies": {
-                "jest-matcher-utils": "^28.0.0",
+                "expect": "^28.0.0",
                 "pretty-format": "^28.0.0"
             }
         },
@@ -4873,9 +4926,9 @@
             "dev": true
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.182",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-            "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+            "version": "4.14.184",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+            "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==",
             "dev": true
         },
         "node_modules/@types/logrocket-react": {
@@ -4900,9 +4953,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.6.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-            "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+            "version": "18.7.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.9.tgz",
+            "integrity": "sha512-0N5Y1XAdcl865nDdjbO0m3T6FdmQ4ijE89/urOHLREyTXbpMWbSafx9y7XIsgWGtwUP2iYTinLyyW3FatAxBLQ==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -4922,9 +4975,9 @@
             "integrity": "sha512-L5eZmzw89eXBKkiqVBcJfU1QGx9y+wurRIEgt0cuLH0hwNtVUxtx+6cu0R2STwWj468sjXyBYPYDtGclUd1kjQ=="
         },
         "node_modules/@types/prettier": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz",
-            "integrity": "sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
+            "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
             "dev": true
         },
         "node_modules/@types/prop-types": {
@@ -5074,9 +5127,9 @@
             }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.10",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
-            "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+            "version": "17.0.11",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
+            "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
             "dev": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -5089,14 +5142,14 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-            "integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.34.0.tgz",
+            "integrity": "sha512-eRfPPcasO39iwjlUAMtjeueRGuIrW3TQ9WseIDl7i5UWuFbf83yYaU7YPs4j8+4CxUMIsj1k+4kV+E+G+6ypDQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.32.0",
-                "@typescript-eslint/type-utils": "5.32.0",
-                "@typescript-eslint/utils": "5.32.0",
+                "@typescript-eslint/scope-manager": "5.34.0",
+                "@typescript-eslint/type-utils": "5.34.0",
+                "@typescript-eslint/utils": "5.34.0",
                 "debug": "^4.3.4",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.2.0",
@@ -5149,12 +5202,12 @@
             }
         },
         "node_modules/@typescript-eslint/experimental-utils": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.32.0.tgz",
-            "integrity": "sha512-/x72MkqLAoOQSOHFxdm17irJ1PNDWtdrMmfacaYniGT26nibak8vxEf9xmoVE+yTYL8N77I2icPtw89Yx6HvNg==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.34.0.tgz",
+            "integrity": "sha512-bXDmphFgoQI4eY7r8Vp0mwrvU9Pic+KxuQPG8uoC33FlZLgsFhv8brhUUyniHEeDhApdg4/5a3qYEZbNGnRQYQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/utils": "5.32.0"
+                "@typescript-eslint/utils": "5.34.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5168,14 +5221,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
-            "integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.34.0.tgz",
+            "integrity": "sha512-SZ3NEnK4usd2CXkoV3jPa/vo1mWX1fqRyIVUQZR4As1vyp4fneknBNJj+OFtV8WAVgGf+rOHMSqQbs2Qn3nFZQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.32.0",
-                "@typescript-eslint/types": "5.32.0",
-                "@typescript-eslint/typescript-estree": "5.32.0",
+                "@typescript-eslint/scope-manager": "5.34.0",
+                "@typescript-eslint/types": "5.34.0",
+                "@typescript-eslint/typescript-estree": "5.34.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -5195,13 +5248,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-            "integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.34.0.tgz",
+            "integrity": "sha512-HNvASMQlah5RsBW6L6c7IJ0vsm+8Sope/wu5sEAf7joJYWNb1LDbJipzmdhdUOnfrDFE6LR1j57x1EYVxrY4ow==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.32.0",
-                "@typescript-eslint/visitor-keys": "5.32.0"
+                "@typescript-eslint/types": "5.34.0",
+                "@typescript-eslint/visitor-keys": "5.34.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5212,12 +5265,12 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-            "integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.34.0.tgz",
+            "integrity": "sha512-Pxlno9bjsQ7hs1pdWRUv9aJijGYPYsHpwMeCQ/Inavhym3/XaKt1ZKAA8FIw4odTBfowBdZJDMxf2aavyMDkLg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/utils": "5.32.0",
+                "@typescript-eslint/utils": "5.34.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -5238,9 +5291,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-            "integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.34.0.tgz",
+            "integrity": "sha512-49fm3xbbUPuzBIOcy2CDpYWqy/X7VBkxVN+DC21e0zIm3+61Z0NZi6J9mqPmSW1BDVk9FIOvuCFyUPjXz93sjA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5251,13 +5304,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-            "integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.34.0.tgz",
+            "integrity": "sha512-mXHAqapJJDVzxauEkfJI96j3D10sd567LlqroyCeJaHnu42sDbjxotGb3XFtGPYKPD9IyLjhsoULML1oI3M86A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.32.0",
-                "@typescript-eslint/visitor-keys": "5.32.0",
+                "@typescript-eslint/types": "5.34.0",
+                "@typescript-eslint/visitor-keys": "5.34.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -5305,15 +5358,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-            "integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.34.0.tgz",
+            "integrity": "sha512-kWRYybU4Rn++7lm9yu8pbuydRyQsHRoBDIo11k7eqBWTldN4xUdVUMCsHBiE7aoEkFzrUEaZy3iH477vr4xHAQ==",
             "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.32.0",
-                "@typescript-eslint/types": "5.32.0",
-                "@typescript-eslint/typescript-estree": "5.32.0",
+                "@typescript-eslint/scope-manager": "5.34.0",
+                "@typescript-eslint/types": "5.34.0",
+                "@typescript-eslint/typescript-estree": "5.34.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             },
@@ -5351,12 +5404,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-            "integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.34.0.tgz",
+            "integrity": "sha512-O1moYjOSrab0a2fUvFpsJe0QHtvTC+cR+ovYpgKrAVXzqQyc74mv76TgY6z+aEtjQE2vgZux3CQVtGryqdcOAw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.32.0",
+                "@typescript-eslint/types": "5.34.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -6023,18 +6076,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/atob": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true,
-            "bin": {
-                "atob": "bin/atob.js"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
             }
         },
         "node_modules/attr-accept": {
@@ -7029,9 +7070,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001374",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-            "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+            "version": "1.0.30001381",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+            "integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7440,9 +7481,9 @@
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "node_modules/colord": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
-            "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+            "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
             "dev": true
         },
         "node_modules/colorette": {
@@ -7776,17 +7817,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/css": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.6.0"
-            }
-        },
         "node_modules/css-blank-pseudo": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz",
@@ -8086,19 +8116,10 @@
             "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
             "dev": true
         },
-        "node_modules/css/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/cssdb": {
-            "version": "6.6.3",
-            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.6.3.tgz",
-            "integrity": "sha512-7GDvDSmE+20+WcSMhP17Q1EVWUrLlbxxpMDqG731n8P99JhnQZHR9YvtjPvEHfjFUjvQJvdpKCjlKOX+xe4UVA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.0.0.tgz",
+            "integrity": "sha512-HmRYATZ4Gf8naf6sZmwKEyf7MXAC0ZxjsamtNNgmuWpQgoO973zsE/1JMIohEYsSi5e3n7vQauCLv7TWSrOlrw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -8118,9 +8139,9 @@
             }
         },
         "node_modules/cssnano": {
-            "version": "5.1.12",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.12.tgz",
-            "integrity": "sha512-TgvArbEZu0lk/dvg2ja+B7kYoD7BBCmn3+k58xD0qjrGHsFzXY/wKTo9M5egcUCabPol05e/PVoIu79s2JN4WQ==",
+            "version": "5.1.13",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.13.tgz",
+            "integrity": "sha512-S2SL2ekdEz6w6a2epXn4CmMKU4K3KpcyXLKfAYc9UQQqJRkD/2eLUG0vJ3Db/9OvO5GuAdgXw3pFbR6abqghDQ==",
             "dev": true,
             "dependencies": {
                 "cssnano-preset-default": "^5.2.12",
@@ -8252,7 +8273,7 @@
         "node_modules/data-plane-gateway": {
             "version": "0.0.0",
             "resolved": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-Di3sQ3XnwWmsYxYuYyKzc3r49hNbw5J7I5whmLhXaQeJmzlvIeWCbmvCY+T9navAdMR5iGjWZIsRHBhuZ/ipig==",
+            "integrity": "sha512-fC4rM61BxdA7aZmD4m8bqgpxx/zwNpeAS8GLJeo4nk1UCem0GGQBQx+4oB6uL9XN2LjPuFzg2PJTqQ0V2IOntg==",
             "license": "MIT"
         },
         "node_modules/data-urls": {
@@ -8305,9 +8326,9 @@
             }
         },
         "node_modules/date-fns": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
-            "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==",
+            "version": "2.29.2",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.2.tgz",
+            "integrity": "sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA==",
             "engines": {
                 "node": ">=0.11"
             },
@@ -8338,19 +8359,10 @@
             }
         },
         "node_modules/decimal.js": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-            "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.0.tgz",
+            "integrity": "sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg==",
             "dev": true
-        },
-        "node_modules/decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10"
-            }
         },
         "node_modules/dedent": {
             "version": "0.7.0",
@@ -8777,9 +8789,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.211",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-            "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A=="
+            "version": "1.4.225",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+            "integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw=="
         },
         "node_modules/elliptic": {
             "version": "6.5.4",
@@ -9107,9 +9119,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-            "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+            "version": "8.22.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
+            "integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
             "dev": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.3.0",
@@ -9308,16 +9320,20 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-            "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+            "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
             "dev": true,
             "dependencies": {
-                "debug": "^3.2.7",
-                "find-up": "^2.1.0"
+                "debug": "^3.2.7"
             },
             "engines": {
                 "node": ">=4"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-module-utils/node_modules/debug": {
@@ -9327,73 +9343,6 @@
             "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
-            }
-        },
-        "node_modules/eslint-module-utils/node_modules/find-up": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/eslint-module-utils/node_modules/locate-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/eslint-module-utils/node_modules/p-limit": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-            "dev": true,
-            "dependencies": {
-                "p-try": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/eslint-module-utils/node_modules/p-locate": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/eslint-module-utils/node_modules/p-try": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/eslint-module-utils/node_modules/path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/eslint-plugin-flowtype": {
@@ -9469,9 +9418,9 @@
             "dev": true
         },
         "node_modules/eslint-plugin-jest": {
-            "version": "26.7.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.7.0.tgz",
-            "integrity": "sha512-/YNitdfG3o3cC6juZziAdkk6nfJt01jXVfj4AgaYVLs7bupHzRDL5K+eipdzhDXtQsiqaX1TzfwSuRlEgeln1A==",
+            "version": "26.8.7",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.8.7.tgz",
+            "integrity": "sha512-nJJVv3VY6ZZvJGDMC8h1jN/TIGT4We1JkNn1lvstPURicr/eZPVnlFULQ4W2qL9ByCuCr1hPmlBOc2aZ1ktw4Q==",
             "dev": true,
             "dependencies": {
                 "@typescript-eslint/utils": "^5.10.0"
@@ -9996,7 +9945,6 @@
             "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
             "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@jest/expect-utils": "^28.1.3",
                 "jest-get-type": "^28.0.2",
@@ -10127,9 +10075,9 @@
             }
         },
         "node_modules/ext/node_modules/type": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/type/-/type-2.7.1.tgz",
-            "integrity": "sha512-rLp+w60+leZDK0J0r1Q+ZVAEoRjBs/qxEeHhfizjG9dHfv0cpfWDPI8U/qiNPQdEw5Tlb+yOo54jnFQw8yGOZA=="
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+            "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -10418,9 +10366,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-            "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
             "dev": true
         },
         "node_modules/follow-redirects": {
@@ -13842,9 +13790,9 @@
             }
         },
         "node_modules/jest-localstorage-mock": {
-            "version": "2.4.21",
-            "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.21.tgz",
-            "integrity": "sha512-IBXPBufnfPyr4VkoQeJ+zlfWlG84P0KbL4ejcV9j3xNI0v6OWznQlH6Ke9xjSarleR11090oSeWADSUow0PmFw==",
+            "version": "2.4.22",
+            "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.22.tgz",
+            "integrity": "sha512-60PWSDFQOS5v7JzSmYLM3dPLg0JLl+2Vc4lIEz/rj2yrXJzegsFLn7anwc5IL0WzJbBa/Las064CHbFg491/DQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.16.0"
@@ -15150,9 +15098,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "4.8.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
-            "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-4.9.0.tgz",
+            "integrity": "sha512-RgaqEOZLkVO+ViN3KkN44XJt9g7+wMveUv59sVLaTxONcUPc8ZpfqOCeLphVBZyih2dgkvZ0Ap1CNcokvY7Uyw==",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
@@ -15437,13 +15385,13 @@
             }
         },
         "node_modules/jsx-ast-utils": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
-            "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+            "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
             "dev": true,
             "dependencies": {
                 "array-includes": "^3.1.5",
-                "object.assign": "^4.1.2"
+                "object.assign": "^4.1.3"
             },
             "engines": {
                 "node": ">=4.0"
@@ -15914,9 +15862,9 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "7.13.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.2.tgz",
-            "integrity": "sha512-VJL3nIpA79TodY/ctmZEfhASgqekbT574/c4j3jn4bKXbSCnTTCH/KltZyvL2GlV+tGSMtsWyem8DCX7qKTMBA==",
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+            "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
             "engines": {
                 "node": ">=12"
             }
@@ -16541,14 +16489,14 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "has-symbols": "^1.0.1",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "has-symbols": "^1.0.3",
                 "object-keys": "^1.1.1"
             },
             "engines": {
@@ -17151,9 +17099,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.16",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+            "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
             "dev": true,
             "funding": [
                 {
@@ -18165,57 +18113,59 @@
             }
         },
         "node_modules/postcss-preset-env": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.7.2.tgz",
-            "integrity": "sha512-1q0ih7EDsZmCb/FMDRvosna7Gsbdx8CvYO5hYT120hcp2ZAuOHpSzibujZ4JpIUcAC02PG6b+eftxqjTFh5BNA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.0.tgz",
+            "integrity": "sha512-leqiqLOellpLKfbHkD06E04P6d9ZQ24mat6hu4NSqun7WG0UhspHR5Myiv/510qouCjoo4+YJtNOqg5xHaFnCA==",
             "dev": true,
             "dependencies": {
-                "@csstools/postcss-cascade-layers": "^1.0.4",
-                "@csstools/postcss-color-function": "^1.1.0",
-                "@csstools/postcss-font-format-keywords": "^1.0.0",
-                "@csstools/postcss-hwb-function": "^1.0.1",
-                "@csstools/postcss-ic-unit": "^1.0.0",
-                "@csstools/postcss-is-pseudo-class": "^2.0.6",
-                "@csstools/postcss-normalize-display-values": "^1.0.0",
-                "@csstools/postcss-oklab-function": "^1.1.0",
+                "@csstools/postcss-cascade-layers": "^1.0.5",
+                "@csstools/postcss-color-function": "^1.1.1",
+                "@csstools/postcss-font-format-keywords": "^1.0.1",
+                "@csstools/postcss-hwb-function": "^1.0.2",
+                "@csstools/postcss-ic-unit": "^1.0.1",
+                "@csstools/postcss-is-pseudo-class": "^2.0.7",
+                "@csstools/postcss-nested-calc": "^1.0.0",
+                "@csstools/postcss-normalize-display-values": "^1.0.1",
+                "@csstools/postcss-oklab-function": "^1.1.1",
                 "@csstools/postcss-progressive-custom-properties": "^1.3.0",
-                "@csstools/postcss-stepped-value-functions": "^1.0.0",
-                "@csstools/postcss-trigonometric-functions": "^1.0.1",
-                "@csstools/postcss-unset-value": "^1.0.1",
-                "autoprefixer": "^10.4.7",
-                "browserslist": "^4.21.0",
+                "@csstools/postcss-stepped-value-functions": "^1.0.1",
+                "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
+                "@csstools/postcss-trigonometric-functions": "^1.0.2",
+                "@csstools/postcss-unset-value": "^1.0.2",
+                "autoprefixer": "^10.4.8",
+                "browserslist": "^4.21.3",
                 "css-blank-pseudo": "^3.0.3",
                 "css-has-pseudo": "^3.0.4",
                 "css-prefers-color-scheme": "^6.0.3",
-                "cssdb": "^6.6.3",
-                "postcss-attribute-case-insensitive": "^5.0.1",
+                "cssdb": "^7.0.0",
+                "postcss-attribute-case-insensitive": "^5.0.2",
                 "postcss-clamp": "^4.1.0",
-                "postcss-color-functional-notation": "^4.2.3",
+                "postcss-color-functional-notation": "^4.2.4",
                 "postcss-color-hex-alpha": "^8.0.4",
-                "postcss-color-rebeccapurple": "^7.1.0",
+                "postcss-color-rebeccapurple": "^7.1.1",
                 "postcss-custom-media": "^8.0.2",
                 "postcss-custom-properties": "^12.1.8",
                 "postcss-custom-selectors": "^6.0.3",
-                "postcss-dir-pseudo-class": "^6.0.4",
-                "postcss-double-position-gradients": "^3.1.1",
+                "postcss-dir-pseudo-class": "^6.0.5",
+                "postcss-double-position-gradients": "^3.1.2",
                 "postcss-env-function": "^4.0.6",
                 "postcss-focus-visible": "^6.0.4",
                 "postcss-focus-within": "^5.0.4",
                 "postcss-font-variant": "^5.0.0",
-                "postcss-gap-properties": "^3.0.3",
-                "postcss-image-set-function": "^4.0.6",
+                "postcss-gap-properties": "^3.0.5",
+                "postcss-image-set-function": "^4.0.7",
                 "postcss-initial": "^4.0.1",
-                "postcss-lab-function": "^4.2.0",
+                "postcss-lab-function": "^4.2.1",
                 "postcss-logical": "^5.0.4",
                 "postcss-media-minmax": "^5.0.0",
-                "postcss-nesting": "^10.1.9",
+                "postcss-nesting": "^10.1.10",
                 "postcss-opacity-percentage": "^1.1.2",
-                "postcss-overflow-shorthand": "^3.0.3",
+                "postcss-overflow-shorthand": "^3.0.4",
                 "postcss-page-break": "^3.0.4",
-                "postcss-place": "^7.0.4",
-                "postcss-pseudo-class-any-link": "^7.1.5",
+                "postcss-place": "^7.0.5",
+                "postcss-pseudo-class-any-link": "^7.1.6",
                 "postcss-replace-overflow-wrap": "^4.0.0",
-                "postcss-selector-not": "^6.0.0",
+                "postcss-selector-not": "^6.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -18625,6 +18575,12 @@
             "engines": {
                 "node": ">=0.4.x"
             }
+        },
+        "node_modules/querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "dev": true
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -20855,9 +20811,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.77.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-            "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+            "version": "2.78.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+            "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -21582,17 +21538,6 @@
                 "webpack": "^5.0.0"
             }
         },
-        "node_modules/source-map-resolve": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-            "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-            "dev": true,
-            "dependencies": {
-                "atob": "^2.1.2",
-                "decode-uri-component": "^0.2.0"
-            }
-        },
         "node_modules/source-map-support": {
             "version": "0.5.13",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -21644,9 +21589,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-            "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+            "version": "3.0.12",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
             "dev": true
         },
         "node_modules/spdy": {
@@ -22272,9 +22217,9 @@
             "dev": true
         },
         "node_modules/tailwindcss": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.7.tgz",
-            "integrity": "sha512-r7mgumZ3k0InfVPpGWcX8X/Ut4xBfv+1O/+C73ar/m01LxGVzWvPxF/w6xIUPEztrCoz7axfx0SMdh8FH8ZvRQ==",
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.8.tgz",
+            "integrity": "sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==",
             "dev": true,
             "dependencies": {
                 "arg": "^5.0.2",
@@ -22415,16 +22360,16 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-            "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.5.tgz",
+            "integrity": "sha512-AOEDLDxD2zylUGf/wxHxklEkOe2/r+seuyOWujejFrIxHf11brA1/dWQNIgXa1c6/Wkxgu7zvv0JhOWfc2ELEA==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.7",
+                "@jridgewell/trace-mapping": "^0.3.14",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
-                "terser": "^5.7.2"
+                "terser": "^5.14.1"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -22616,23 +22561,24 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-            "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.0.tgz",
+            "integrity": "sha512-IVX6AagLelGwl6F0E+hoRpXzuD192cZhAcmT7/eoLr0PnsB1wv2E5c+A2O+V8xth9FlL2p0OstFsWn0bZpVn4w==",
             "dev": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
-                "universalify": "^0.1.2"
+                "universalify": "^0.2.0",
+                "url-parse": "^1.5.3"
             },
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/tough-cookie/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
             "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
@@ -22965,6 +22911,16 @@
                 "querystring": "0.2.0"
             }
         },
+        "node_modules/url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "dev": true,
+            "dependencies": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
         "node_modules/url/node_modules/punycode": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -23274,9 +23230,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.9.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.9.3.tgz",
-            "integrity": "sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.10.0.tgz",
+            "integrity": "sha512-7dezwAs+k6yXVFZ+MaL8VnE+APobiO3zvpp3rBHe/HmWQ+avwh0Q3d0xxacOiBybZZ3syTZw9HXzpa3YNbAZDQ==",
             "dev": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
@@ -24006,9 +23962,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/write-file-atomic": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
-            "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -24016,7 +23972,7 @@
                 "signal-exit": "^3.0.7"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/ws": {
@@ -24166,9 +24122,9 @@
             }
         },
         "node_modules/zustand": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.0.0.tgz",
-            "integrity": "sha512-OrsfQTnRXF1LZ9/vR/IqN9ws5EXUhb149xmPjErZnUrkgxS/gAHGy2dPNIVkVvoxrVe1sIydn4JjF0dYHmGeeQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.1.tgz",
+            "integrity": "sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==",
             "dependencies": {
                 "use-sync-external-store": "1.2.0"
             },
@@ -24190,6 +24146,12 @@
         }
     },
     "dependencies": {
+        "@adobe/css-tools": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
+            "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+            "dev": true
+        },
         "@ampproject/remapping": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -24219,25 +24181,25 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.18.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-            "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ=="
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
+            "integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw=="
         },
         "@babel/core": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-            "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
+            "integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.18.10",
+                "@babel/generator": "^7.18.13",
                 "@babel/helper-compilation-targets": "^7.18.9",
                 "@babel/helper-module-transforms": "^7.18.9",
                 "@babel/helpers": "^7.18.9",
-                "@babel/parser": "^7.18.10",
+                "@babel/parser": "^7.18.13",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.18.10",
-                "@babel/types": "^7.18.10",
+                "@babel/traverse": "^7.18.13",
+                "@babel/types": "^7.18.13",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -24281,11 +24243,11 @@
             }
         },
         "@babel/generator": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-            "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
+            "integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
             "requires": {
-                "@babel/types": "^7.18.10",
+                "@babel/types": "^7.18.13",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -24333,9 +24295,9 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
-            "integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz",
+            "integrity": "sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -24546,9 +24508,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.18.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-            "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ=="
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
+            "integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg=="
         },
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
             "version": "7.18.6",
@@ -24994,9 +24956,9 @@
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz",
-            "integrity": "sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz",
+            "integrity": "sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.18.9"
@@ -25173,9 +25135,9 @@
             }
         },
         "@babel/plugin-transform-react-constant-elements": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.18.9.tgz",
-            "integrity": "sha512-IrTYh1I3YCEL1trjknnlLKTp5JggjzhKl/d3ibzPc97JhpFcDTr38Jdek/oX4cFbS6By0bXJcOkpRvJ5ZHK2wQ==",
+            "version": "7.18.12",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.18.12.tgz",
+            "integrity": "sha512-Q99U9/ttiu+LMnRU8psd23HhvwXmKWDQIpocm0JKaICcZHnw+mdQbHm6xnSy7dOl8I5PELakYtNBubNQlBXbZw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.18.9"
@@ -25302,9 +25264,9 @@
             }
         },
         "@babel/plugin-transform-typescript": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.10.tgz",
-            "integrity": "sha512-j2HQCJuMbi88QftIb5zlRu3c7PU+sXNnscqsrjqegoGiCgXR569pEdben9vly5QHKL2ilYkfnSwu64zsZo/VYQ==",
+            "version": "7.18.12",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
+            "integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
             "dev": true,
             "requires": {
                 "@babel/helper-create-class-features-plugin": "^7.18.9",
@@ -25481,26 +25443,26 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.18.11",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-            "integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
+            "integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.18.10",
+                "@babel/generator": "^7.18.13",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.18.9",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.18.11",
-                "@babel/types": "^7.18.10",
+                "@babel/parser": "^7.18.13",
+                "@babel/types": "^7.18.13",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-            "integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+            "version": "7.18.13",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+            "integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
             "requires": {
                 "@babel/helper-string-parser": "^7.18.10",
                 "@babel/helper-validator-identifier": "^7.18.6",
@@ -25577,6 +25539,15 @@
                 "postcss-selector-parser": "^6.0.10"
             }
         },
+        "@csstools/postcss-nested-calc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-nested-calc/-/postcss-nested-calc-1.0.0.tgz",
+            "integrity": "sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            }
+        },
         "@csstools/postcss-normalize-display-values": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.1.tgz",
@@ -25609,6 +25580,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-1.0.1.tgz",
             "integrity": "sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            }
+        },
+        "@csstools/postcss-text-decoration-shorthand": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-1.0.0.tgz",
+            "integrity": "sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
@@ -25651,9 +25631,9 @@
             }
         },
         "@emotion/babel-plugin": {
-            "version": "11.10.0",
-            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.0.tgz",
-            "integrity": "sha512-xVnpDAAbtxL1dsuSelU5A7BnY/lftws0wUexNJZTPsvX/1tM4GZJbclgODhvW4E+NH7E5VFcH0bBn30NvniPJA==",
+            "version": "11.10.2",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
+            "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
             "requires": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/plugin-syntax-jsx": "^7.17.12",
@@ -25670,9 +25650,9 @@
             }
         },
         "@emotion/cache": {
-            "version": "11.10.1",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.1.tgz",
-            "integrity": "sha512-uZTj3Yz5D69GE25iFZcIQtibnVCFsc/6+XIozyL3ycgWvEdif2uEw9wlUt6umjLr4Keg9K6xRPHmD8LGi+6p1A==",
+            "version": "11.10.2",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.2.tgz",
+            "integrity": "sha512-GPR4PovENRvYDbCEnDRecPZYJzWdNMsM+Jn+13MC5uImVNbMyKwzv95DUHy5PDcgfPtKoDtfLU6emF1grrbQDg==",
             "requires": {
                 "@emotion/memoize": "^0.8.0",
                 "@emotion/sheet": "^1.2.0",
@@ -26204,7 +26184,6 @@
             "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
             "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "jest-get-type": "^28.0.2"
             }
@@ -26567,9 +26546,9 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-            "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+            "version": "0.3.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+            "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -26627,19 +26606,24 @@
             }
         },
         "@mui/base": {
-            "version": "5.0.0-alpha.92",
-            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.92.tgz",
-            "integrity": "sha512-ZgnSLrTXL4iUdLQhjp01dAOTQPQlnwrqjZRwDT3E6LZXEYn6cMv1MY6LZkWcF/zxrUnyasnsyMAgZ5d8AXS7bA==",
+            "version": "5.0.0-alpha.93",
+            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.93.tgz",
+            "integrity": "sha512-IVUWO0NNlELDc9FD7mM+fWTS1/6n5sJYdIbXpLQ00NjWdVEYmTyRgUAZDlJJJrz+tbF0eeffx0kOsvJvyTZlsA==",
             "requires": {
                 "@babel/runtime": "^7.17.2",
                 "@emotion/is-prop-valid": "^1.1.3",
                 "@mui/types": "^7.1.5",
                 "@mui/utils": "^5.9.3",
-                "@popperjs/core": "^2.11.5",
+                "@popperjs/core": "^2.11.6",
                 "clsx": "^1.2.1",
                 "prop-types": "^15.8.1",
                 "react-is": "^18.2.0"
             }
+        },
+        "@mui/core-downloads-tracker": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.1.tgz",
+            "integrity": "sha512-zyzLkVSqi+WuxG8UZrrOaWbhHkDK+MlHFjLpL+vqUVU6iSUaDYREu1xoLWEQsWOznT4oT2iEiGZLpQLgkn+WiA=="
         },
         "@mui/icons-material": {
             "version": "5.8.4",
@@ -26650,13 +26634,13 @@
             }
         },
         "@mui/lab": {
-            "version": "5.0.0-alpha.93",
-            "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.93.tgz",
-            "integrity": "sha512-PGrI6tGwKGpLEv4sG7Jkhh/gqk5SE3KRCY8SKmC7JIOUpHEdPKIPH7kId/UZUd8+NOkr8YsljXmozpWv9PLsBQ==",
+            "version": "5.0.0-alpha.95",
+            "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.95.tgz",
+            "integrity": "sha512-JdJKhn0qJjk0ejtmsiZ/8e08uUzr8MZsASGbmY2VbGC7WlCntgjZrWmhuvQf3hWCtSfuD6tbCdPpz6A2NL5nVQ==",
             "requires": {
                 "@babel/runtime": "^7.17.2",
-                "@mui/base": "5.0.0-alpha.92",
-                "@mui/system": "^5.9.3",
+                "@mui/base": "5.0.0-alpha.93",
+                "@mui/system": "^5.10.1",
                 "@mui/utils": "^5.9.3",
                 "clsx": "^1.2.1",
                 "prop-types": "^15.8.1",
@@ -26664,13 +26648,14 @@
             }
         },
         "@mui/material": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.9.3.tgz",
-            "integrity": "sha512-idDJajnfnDr+2pI6h2tzWtWoZJmVHNk6aSjISirMuVOGy0ugWpsCE+KW4++GS7aTCujXm9+cl5bWAyXvGjiPIQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.1.tgz",
+            "integrity": "sha512-E9fhskX6TwUdAzpL5+yoAzRxb6wY4oBqmBVlgUuLndSwPRYxXoGu+z74NxbDEkxUoHdb7vrDcRTswpB6ykDITQ==",
             "requires": {
                 "@babel/runtime": "^7.17.2",
-                "@mui/base": "5.0.0-alpha.92",
-                "@mui/system": "^5.9.3",
+                "@mui/base": "5.0.0-alpha.93",
+                "@mui/core-downloads-tracker": "^5.10.1",
+                "@mui/system": "^5.10.1",
                 "@mui/types": "^7.1.5",
                 "@mui/utils": "^5.9.3",
                 "@types/react-transition-group": "^4.4.5",
@@ -26692,9 +26677,9 @@
             }
         },
         "@mui/styled-engine": {
-            "version": "5.8.7",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.8.7.tgz",
-            "integrity": "sha512-tVqtowjbYmiRq+qcqXK731L9eWoL9H8xTRhuTgaDGKdch1zlt4I2UwInUe1w2N9N/u3/jHsFbLcl1Un3uOwpQg==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.10.1.tgz",
+            "integrity": "sha512-xiQp6wvSLpMcRCOExbRSvkHf6gIQ/eeK7mx/Re6BtPPYIx6OerPwia+23uVIop/k4Bs5D+w7Rv2yXYJxo5rMSQ==",
             "requires": {
                 "@babel/runtime": "^7.17.2",
                 "@emotion/cache": "^11.9.3",
@@ -26736,13 +26721,13 @@
             }
         },
         "@mui/system": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.9.3.tgz",
-            "integrity": "sha512-EXQV2POwncstHLYII+G4VSYdEFun1TjBbQSBDK76DbIkug8nPjtjAZ+3Kgk3/NoFIigW+vQ9cDVUZtlbRH6YMQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.10.1.tgz",
+            "integrity": "sha512-Ix8LVAMtVrNtmncK0yc5llHWlZKCm9okbw8QMnWbI5UH+nI9qhtf+Aure4p5ei6dGKdil++lukar/GxCjfzRSg==",
             "requires": {
                 "@babel/runtime": "^7.17.2",
                 "@mui/private-theming": "^5.9.3",
-                "@mui/styled-engine": "^5.8.7",
+                "@mui/styled-engine": "^5.10.1",
                 "@mui/types": "^7.1.5",
                 "@mui/utils": "^5.9.3",
                 "clsx": "^1.2.1",
@@ -26769,9 +26754,9 @@
             }
         },
         "@mui/x-data-grid": {
-            "version": "5.15.1",
-            "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.15.1.tgz",
-            "integrity": "sha512-KTWrXRvhtudhONrjanpmSijgvMfWGiuX83RZxBpVPdiM4h0furLtltpmk++V3inEcGUeEFEj1qfx4ssiTuNJtw==",
+            "version": "5.15.3",
+            "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.15.3.tgz",
+            "integrity": "sha512-W1LrnCyFS/be7sppCf4EDGbwN6UgbdwqW0bW2eGK8Twmc2+upkmetHjvPodHhdtZ9onxrIJkfiPQG0PBzz5eIw==",
             "requires": {
                 "@babel/runtime": "^7.18.6",
                 "@mui/utils": "^5.4.1",
@@ -26832,9 +26817,9 @@
             }
         },
         "@popperjs/core": {
-            "version": "2.11.5",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+            "version": "2.11.6",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
         },
         "@rollup/plugin-babel": {
             "version": "5.3.1",
@@ -26896,9 +26881,9 @@
             "dev": true
         },
         "@sinclair/typebox": {
-            "version": "0.24.27",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.27.tgz",
-            "integrity": "sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==",
+            "version": "0.24.28",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
+            "integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==",
             "dev": true
         },
         "@sinonjs/commons": {
@@ -26929,9 +26914,9 @@
             }
         },
         "@supabase/gotrue-js": {
-            "version": "1.22.21",
-            "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.22.21.tgz",
-            "integrity": "sha512-AhsbBU+5j7BKSqfpLDkEcxy3ruDD+J+dHaYxXGHNWiiIJBYtK2jmNcMYA7M30MYjajnhoILJFC7LtHWl1lWj2Q==",
+            "version": "1.22.22",
+            "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.22.22.tgz",
+            "integrity": "sha512-exbCopLo4tLawKZR25wEdipm+IRVujuqFRR4h2wiXd11YA+N8rfgg/4S4L6BTFHmzV+KMjy0kDF3yMbsjIR/xA==",
             "requires": {
                 "cross-fetch": "^3.0.6"
             }
@@ -26962,12 +26947,12 @@
             }
         },
         "@supabase/supabase-js": {
-            "version": "1.35.5",
-            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-1.35.5.tgz",
-            "integrity": "sha512-lAHr3Qz64lGGLtWRqnxglE8UmHooE5OrhvTSQBTJEG8Q+gU5wjAd8ilT3cyli4/beaBwF5UFLojCgWmA+EqBew==",
+            "version": "1.35.6",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-1.35.6.tgz",
+            "integrity": "sha512-KDRXRr+kdGwruIUizZPALbe5YccMYFVyZJf1sFWKLncaLYSFiM6iKFnqCrNeQ4JFoZZiICkiTl1FUuai62jVpg==",
             "requires": {
                 "@supabase/functions-js": "^1.3.4",
-                "@supabase/gotrue-js": "^1.22.17",
+                "@supabase/gotrue-js": "^1.22.21",
                 "@supabase/postgrest-js": "^0.37.4",
                 "@supabase/realtime-js": "^1.7.4",
                 "@supabase/storage-js": "^1.7.2"
@@ -27127,9 +27112,9 @@
             }
         },
         "@testing-library/dom": {
-            "version": "8.16.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.16.1.tgz",
-            "integrity": "sha512-XEV2mBxgv6DKjL3+U3WEUzBgT2CjYksoXGlLrrJXYP8OvRfGkBonvelkorazpFlp8tkEecO06r43vN4DIEyegQ==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.17.1.tgz",
+            "integrity": "sha512-KnH2MnJUzmFNPW6RIKfd+zf2Wue8mEKX0M3cpX6aKl5ZXrJM1/c/Pc8c2xDNYQCnJO48Sm5ITbMXgqTr3h4jxQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
@@ -27194,16 +27179,16 @@
             }
         },
         "@testing-library/jest-dom": {
-            "version": "5.16.4",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
-            "integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
+            "version": "5.16.5",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
+            "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
             "dev": true,
             "requires": {
+                "@adobe/css-tools": "^4.0.1",
                 "@babel/runtime": "^7.9.2",
                 "@types/testing-library__jest-dom": "^5.9.1",
                 "aria-query": "^5.0.0",
                 "chalk": "^3.0.0",
-                "css": "^3.0.0",
                 "css.escape": "^1.5.1",
                 "dom-accessibility-api": "^0.5.6",
                 "lodash": "^4.17.15",
@@ -27273,9 +27258,9 @@
             }
         },
         "@testing-library/user-event": {
-            "version": "14.4.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.1.tgz",
-            "integrity": "sha512-Gr20dje1RaNxZ1ehHGPvFkLswfetBQKCfRD/lo6sUJQ52X2TV/QnqUpkjoShfEebrB2KiTPfQkcONwdQiofLhg==",
+            "version": "14.4.3",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+            "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
             "dev": true,
             "requires": {}
         },
@@ -27336,9 +27321,9 @@
             }
         },
         "@types/babel__traverse": {
-            "version": "7.17.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
-            "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
+            "integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.3.0"
@@ -27383,9 +27368,9 @@
             }
         },
         "@types/eslint": {
-            "version": "8.4.5",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-            "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+            "version": "8.4.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+            "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -27489,12 +27474,12 @@
             }
         },
         "@types/jest": {
-            "version": "28.1.6",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-            "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+            "version": "28.1.7",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.7.tgz",
+            "integrity": "sha512-acDN4VHD40V24tgu0iC44jchXavRNVFXQ/E6Z5XNsswgoSO/4NgsXoEYmPUGookKldlZQyIpmrEXsHI9cA3ZTA==",
             "dev": true,
             "requires": {
-                "jest-matcher-utils": "^28.0.0",
+                "expect": "^28.0.0",
                 "pretty-format": "^28.0.0"
             },
             "dependencies": {
@@ -27535,9 +27520,9 @@
             "dev": true
         },
         "@types/lodash": {
-            "version": "4.14.182",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-            "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+            "version": "4.14.184",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+            "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==",
             "dev": true
         },
         "@types/logrocket-react": {
@@ -27564,9 +27549,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.6.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-            "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+            "version": "18.7.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.9.tgz",
+            "integrity": "sha512-0N5Y1XAdcl865nDdjbO0m3T6FdmQ4ijE89/urOHLREyTXbpMWbSafx9y7XIsgWGtwUP2iYTinLyyW3FatAxBLQ==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -27586,9 +27571,9 @@
             "integrity": "sha512-L5eZmzw89eXBKkiqVBcJfU1QGx9y+wurRIEgt0cuLH0hwNtVUxtx+6cu0R2STwWj468sjXyBYPYDtGclUd1kjQ=="
         },
         "@types/prettier": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz",
-            "integrity": "sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
+            "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
             "dev": true
         },
         "@types/prop-types": {
@@ -27738,9 +27723,9 @@
             }
         },
         "@types/yargs": {
-            "version": "17.0.10",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
-            "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+            "version": "17.0.11",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
+            "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -27753,14 +27738,14 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-            "integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.34.0.tgz",
+            "integrity": "sha512-eRfPPcasO39iwjlUAMtjeueRGuIrW3TQ9WseIDl7i5UWuFbf83yYaU7YPs4j8+4CxUMIsj1k+4kV+E+G+6ypDQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.32.0",
-                "@typescript-eslint/type-utils": "5.32.0",
-                "@typescript-eslint/utils": "5.32.0",
+                "@typescript-eslint/scope-manager": "5.34.0",
+                "@typescript-eslint/type-utils": "5.34.0",
+                "@typescript-eslint/utils": "5.34.0",
                 "debug": "^4.3.4",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.2.0",
@@ -27790,61 +27775,61 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.32.0.tgz",
-            "integrity": "sha512-/x72MkqLAoOQSOHFxdm17irJ1PNDWtdrMmfacaYniGT26nibak8vxEf9xmoVE+yTYL8N77I2icPtw89Yx6HvNg==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.34.0.tgz",
+            "integrity": "sha512-bXDmphFgoQI4eY7r8Vp0mwrvU9Pic+KxuQPG8uoC33FlZLgsFhv8brhUUyniHEeDhApdg4/5a3qYEZbNGnRQYQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.32.0"
+                "@typescript-eslint/utils": "5.34.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
-            "integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.34.0.tgz",
+            "integrity": "sha512-SZ3NEnK4usd2CXkoV3jPa/vo1mWX1fqRyIVUQZR4As1vyp4fneknBNJj+OFtV8WAVgGf+rOHMSqQbs2Qn3nFZQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.32.0",
-                "@typescript-eslint/types": "5.32.0",
-                "@typescript-eslint/typescript-estree": "5.32.0",
+                "@typescript-eslint/scope-manager": "5.34.0",
+                "@typescript-eslint/types": "5.34.0",
+                "@typescript-eslint/typescript-estree": "5.34.0",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-            "integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.34.0.tgz",
+            "integrity": "sha512-HNvASMQlah5RsBW6L6c7IJ0vsm+8Sope/wu5sEAf7joJYWNb1LDbJipzmdhdUOnfrDFE6LR1j57x1EYVxrY4ow==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.32.0",
-                "@typescript-eslint/visitor-keys": "5.32.0"
+                "@typescript-eslint/types": "5.34.0",
+                "@typescript-eslint/visitor-keys": "5.34.0"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-            "integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.34.0.tgz",
+            "integrity": "sha512-Pxlno9bjsQ7hs1pdWRUv9aJijGYPYsHpwMeCQ/Inavhym3/XaKt1ZKAA8FIw4odTBfowBdZJDMxf2aavyMDkLg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.32.0",
+                "@typescript-eslint/utils": "5.34.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-            "integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.34.0.tgz",
+            "integrity": "sha512-49fm3xbbUPuzBIOcy2CDpYWqy/X7VBkxVN+DC21e0zIm3+61Z0NZi6J9mqPmSW1BDVk9FIOvuCFyUPjXz93sjA==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-            "integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.34.0.tgz",
+            "integrity": "sha512-mXHAqapJJDVzxauEkfJI96j3D10sd567LlqroyCeJaHnu42sDbjxotGb3XFtGPYKPD9IyLjhsoULML1oI3M86A==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.32.0",
-                "@typescript-eslint/visitor-keys": "5.32.0",
+                "@typescript-eslint/types": "5.34.0",
+                "@typescript-eslint/visitor-keys": "5.34.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -27873,15 +27858,15 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-            "integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.34.0.tgz",
+            "integrity": "sha512-kWRYybU4Rn++7lm9yu8pbuydRyQsHRoBDIo11k7eqBWTldN4xUdVUMCsHBiE7aoEkFzrUEaZy3iH477vr4xHAQ==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.32.0",
-                "@typescript-eslint/types": "5.32.0",
-                "@typescript-eslint/typescript-estree": "5.32.0",
+                "@typescript-eslint/scope-manager": "5.34.0",
+                "@typescript-eslint/types": "5.34.0",
+                "@typescript-eslint/typescript-estree": "5.34.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             },
@@ -27905,12 +27890,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-            "integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.34.0.tgz",
+            "integrity": "sha512-O1moYjOSrab0a2fUvFpsJe0QHtvTC+cR+ovYpgKrAVXzqQyc74mv76TgY6z+aEtjQE2vgZux3CQVtGryqdcOAw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.32.0",
+                "@typescript-eslint/types": "5.34.0",
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
@@ -28446,12 +28431,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-            "dev": true
-        },
-        "atob": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
         "attr-accept": {
@@ -29198,9 +29177,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001374",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-            "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw=="
+            "version": "1.0.30001381",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+            "integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w=="
         },
         "case-sensitive-paths-webpack-plugin": {
             "version": "2.4.0",
@@ -29507,9 +29486,9 @@
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "colord": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
-            "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+            "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
             "dev": true
         },
         "colorette": {
@@ -29793,25 +29772,6 @@
             "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
             "dev": true
         },
-        "css": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-            "dev": true,
-            "requires": {
-                "inherits": "^2.0.4",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.6.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
         "css-blank-pseudo": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz",
@@ -30007,9 +29967,9 @@
             "dev": true
         },
         "cssdb": {
-            "version": "6.6.3",
-            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.6.3.tgz",
-            "integrity": "sha512-7GDvDSmE+20+WcSMhP17Q1EVWUrLlbxxpMDqG731n8P99JhnQZHR9YvtjPvEHfjFUjvQJvdpKCjlKOX+xe4UVA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.0.0.tgz",
+            "integrity": "sha512-HmRYATZ4Gf8naf6sZmwKEyf7MXAC0ZxjsamtNNgmuWpQgoO973zsE/1JMIohEYsSi5e3n7vQauCLv7TWSrOlrw==",
             "dev": true
         },
         "cssesc": {
@@ -30019,9 +29979,9 @@
             "dev": true
         },
         "cssnano": {
-            "version": "5.1.12",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.12.tgz",
-            "integrity": "sha512-TgvArbEZu0lk/dvg2ja+B7kYoD7BBCmn3+k58xD0qjrGHsFzXY/wKTo9M5egcUCabPol05e/PVoIu79s2JN4WQ==",
+            "version": "5.1.13",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.13.tgz",
+            "integrity": "sha512-S2SL2ekdEz6w6a2epXn4CmMKU4K3KpcyXLKfAYc9UQQqJRkD/2eLUG0vJ3Db/9OvO5GuAdgXw3pFbR6abqghDQ==",
             "dev": true,
             "requires": {
                 "cssnano-preset-default": "^5.2.12",
@@ -30127,7 +30087,7 @@
         },
         "data-plane-gateway": {
             "version": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-Di3sQ3XnwWmsYxYuYyKzc3r49hNbw5J7I5whmLhXaQeJmzlvIeWCbmvCY+T9navAdMR5iGjWZIsRHBhuZ/ipig=="
+            "integrity": "sha512-fC4rM61BxdA7aZmD4m8bqgpxx/zwNpeAS8GLJeo4nk1UCem0GGQBQx+4oB6uL9XN2LjPuFzg2PJTqQ0V2IOntg=="
         },
         "data-urls": {
             "version": "2.0.0",
@@ -30169,9 +30129,9 @@
             }
         },
         "date-fns": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
-            "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw=="
+            "version": "2.29.2",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.2.tgz",
+            "integrity": "sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA=="
         },
         "dayjs": {
             "version": "1.10.6",
@@ -30187,15 +30147,9 @@
             }
         },
         "decimal.js": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-            "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
-            "dev": true
-        },
-        "decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.0.tgz",
+            "integrity": "sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg==",
             "dev": true
         },
         "dedent": {
@@ -30534,9 +30488,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.211",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-            "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A=="
+            "version": "1.4.225",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+            "integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw=="
         },
         "elliptic": {
             "version": "6.5.4",
@@ -30801,9 +30755,9 @@
             }
         },
         "eslint": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-            "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+            "version": "8.22.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
+            "integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
             "dev": true,
             "requires": {
                 "@eslint/eslintrc": "^1.3.0",
@@ -31034,13 +30988,12 @@
             }
         },
         "eslint-module-utils": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-            "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+            "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
             "dev": true,
             "requires": {
-                "debug": "^3.2.7",
-                "find-up": "^2.1.0"
+                "debug": "^3.2.7"
             },
             "dependencies": {
                 "debug": {
@@ -31051,55 +31004,6 @@
                     "requires": {
                         "ms": "^2.1.1"
                     }
-                },
-                "find-up": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^2.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-                    "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^1.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-                    "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^1.1.0"
-                    }
-                },
-                "p-try": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-                    "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-                    "dev": true
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-                    "dev": true
                 }
             }
         },
@@ -31161,9 +31065,9 @@
             }
         },
         "eslint-plugin-jest": {
-            "version": "26.7.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.7.0.tgz",
-            "integrity": "sha512-/YNitdfG3o3cC6juZziAdkk6nfJt01jXVfj4AgaYVLs7bupHzRDL5K+eipdzhDXtQsiqaX1TzfwSuRlEgeln1A==",
+            "version": "26.8.7",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.8.7.tgz",
+            "integrity": "sha512-nJJVv3VY6ZZvJGDMC8h1jN/TIGT4We1JkNn1lvstPURicr/eZPVnlFULQ4W2qL9ByCuCr1hPmlBOc2aZ1ktw4Q==",
             "dev": true,
             "requires": {
                 "@typescript-eslint/utils": "^5.10.0"
@@ -31442,7 +31346,6 @@
             "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
             "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@jest/expect-utils": "^28.1.3",
                 "jest-get-type": "^28.0.2",
@@ -31549,9 +31452,9 @@
             },
             "dependencies": {
                 "type": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/type/-/type-2.7.1.tgz",
-                    "integrity": "sha512-rLp+w60+leZDK0J0r1Q+ZVAEoRjBs/qxEeHhfizjG9dHfv0cpfWDPI8U/qiNPQdEw5Tlb+yOo54jnFQw8yGOZA=="
+                    "version": "2.7.2",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+                    "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
                 }
             }
         },
@@ -31792,9 +31695,9 @@
             }
         },
         "flatted": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-            "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
             "dev": true
         },
         "follow-redirects": {
@@ -34336,9 +34239,9 @@
             }
         },
         "jest-localstorage-mock": {
-            "version": "2.4.21",
-            "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.21.tgz",
-            "integrity": "sha512-IBXPBufnfPyr4VkoQeJ+zlfWlG84P0KbL4ejcV9j3xNI0v6OWznQlH6Ke9xjSarleR11090oSeWADSUow0PmFw==",
+            "version": "2.4.22",
+            "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.22.tgz",
+            "integrity": "sha512-60PWSDFQOS5v7JzSmYLM3dPLg0JLl+2Vc4lIEz/rj2yrXJzegsFLn7anwc5IL0WzJbBa/Las064CHbFg491/DQ==",
             "dev": true
         },
         "jest-matcher-utils": {
@@ -35312,9 +35215,9 @@
             }
         },
         "jose": {
-            "version": "4.8.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
-            "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g=="
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-4.9.0.tgz",
+            "integrity": "sha512-RgaqEOZLkVO+ViN3KkN44XJt9g7+wMveUv59sVLaTxONcUPc8ZpfqOCeLphVBZyih2dgkvZ0Ap1CNcokvY7Uyw=="
         },
         "js-cookie": {
             "version": "2.2.1",
@@ -35540,13 +35443,13 @@
             }
         },
         "jsx-ast-utils": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
-            "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+            "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
             "dev": true,
             "requires": {
                 "array-includes": "^3.1.5",
-                "object.assign": "^4.1.2"
+                "object.assign": "^4.1.3"
             }
         },
         "kind-of": {
@@ -35903,9 +35806,9 @@
             }
         },
         "lru-cache": {
-            "version": "7.13.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.2.tgz",
-            "integrity": "sha512-VJL3nIpA79TodY/ctmZEfhASgqekbT574/c4j3jn4bKXbSCnTTCH/KltZyvL2GlV+tGSMtsWyem8DCX7qKTMBA=="
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+            "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ=="
         },
         "lz-string": {
             "version": "1.4.4",
@@ -36365,14 +36268,14 @@
             "dev": true
         },
         "object.assign": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
             "dev": true,
             "requires": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "has-symbols": "^1.0.1",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "has-symbols": "^1.0.3",
                 "object-keys": "^1.1.1"
             }
         },
@@ -36817,9 +36720,9 @@
             }
         },
         "postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.16",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+            "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.3.4",
@@ -37385,57 +37288,59 @@
             }
         },
         "postcss-preset-env": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.7.2.tgz",
-            "integrity": "sha512-1q0ih7EDsZmCb/FMDRvosna7Gsbdx8CvYO5hYT120hcp2ZAuOHpSzibujZ4JpIUcAC02PG6b+eftxqjTFh5BNA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.0.tgz",
+            "integrity": "sha512-leqiqLOellpLKfbHkD06E04P6d9ZQ24mat6hu4NSqun7WG0UhspHR5Myiv/510qouCjoo4+YJtNOqg5xHaFnCA==",
             "dev": true,
             "requires": {
-                "@csstools/postcss-cascade-layers": "^1.0.4",
-                "@csstools/postcss-color-function": "^1.1.0",
-                "@csstools/postcss-font-format-keywords": "^1.0.0",
-                "@csstools/postcss-hwb-function": "^1.0.1",
-                "@csstools/postcss-ic-unit": "^1.0.0",
-                "@csstools/postcss-is-pseudo-class": "^2.0.6",
-                "@csstools/postcss-normalize-display-values": "^1.0.0",
-                "@csstools/postcss-oklab-function": "^1.1.0",
+                "@csstools/postcss-cascade-layers": "^1.0.5",
+                "@csstools/postcss-color-function": "^1.1.1",
+                "@csstools/postcss-font-format-keywords": "^1.0.1",
+                "@csstools/postcss-hwb-function": "^1.0.2",
+                "@csstools/postcss-ic-unit": "^1.0.1",
+                "@csstools/postcss-is-pseudo-class": "^2.0.7",
+                "@csstools/postcss-nested-calc": "^1.0.0",
+                "@csstools/postcss-normalize-display-values": "^1.0.1",
+                "@csstools/postcss-oklab-function": "^1.1.1",
                 "@csstools/postcss-progressive-custom-properties": "^1.3.0",
-                "@csstools/postcss-stepped-value-functions": "^1.0.0",
-                "@csstools/postcss-trigonometric-functions": "^1.0.1",
-                "@csstools/postcss-unset-value": "^1.0.1",
-                "autoprefixer": "^10.4.7",
-                "browserslist": "^4.21.0",
+                "@csstools/postcss-stepped-value-functions": "^1.0.1",
+                "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
+                "@csstools/postcss-trigonometric-functions": "^1.0.2",
+                "@csstools/postcss-unset-value": "^1.0.2",
+                "autoprefixer": "^10.4.8",
+                "browserslist": "^4.21.3",
                 "css-blank-pseudo": "^3.0.3",
                 "css-has-pseudo": "^3.0.4",
                 "css-prefers-color-scheme": "^6.0.3",
-                "cssdb": "^6.6.3",
-                "postcss-attribute-case-insensitive": "^5.0.1",
+                "cssdb": "^7.0.0",
+                "postcss-attribute-case-insensitive": "^5.0.2",
                 "postcss-clamp": "^4.1.0",
-                "postcss-color-functional-notation": "^4.2.3",
+                "postcss-color-functional-notation": "^4.2.4",
                 "postcss-color-hex-alpha": "^8.0.4",
-                "postcss-color-rebeccapurple": "^7.1.0",
+                "postcss-color-rebeccapurple": "^7.1.1",
                 "postcss-custom-media": "^8.0.2",
                 "postcss-custom-properties": "^12.1.8",
                 "postcss-custom-selectors": "^6.0.3",
-                "postcss-dir-pseudo-class": "^6.0.4",
-                "postcss-double-position-gradients": "^3.1.1",
+                "postcss-dir-pseudo-class": "^6.0.5",
+                "postcss-double-position-gradients": "^3.1.2",
                 "postcss-env-function": "^4.0.6",
                 "postcss-focus-visible": "^6.0.4",
                 "postcss-focus-within": "^5.0.4",
                 "postcss-font-variant": "^5.0.0",
-                "postcss-gap-properties": "^3.0.3",
-                "postcss-image-set-function": "^4.0.6",
+                "postcss-gap-properties": "^3.0.5",
+                "postcss-image-set-function": "^4.0.7",
                 "postcss-initial": "^4.0.1",
-                "postcss-lab-function": "^4.2.0",
+                "postcss-lab-function": "^4.2.1",
                 "postcss-logical": "^5.0.4",
                 "postcss-media-minmax": "^5.0.0",
-                "postcss-nesting": "^10.1.9",
+                "postcss-nesting": "^10.1.10",
                 "postcss-opacity-percentage": "^1.1.2",
-                "postcss-overflow-shorthand": "^3.0.3",
+                "postcss-overflow-shorthand": "^3.0.4",
                 "postcss-page-break": "^3.0.4",
-                "postcss-place": "^7.0.4",
-                "postcss-pseudo-class-any-link": "^7.1.5",
+                "postcss-place": "^7.0.5",
+                "postcss-pseudo-class-any-link": "^7.1.6",
                 "postcss-replace-overflow-wrap": "^4.0.0",
-                "postcss-selector-not": "^6.0.0",
+                "postcss-selector-not": "^6.0.1",
                 "postcss-value-parser": "^4.2.0"
             }
         },
@@ -37727,6 +37632,12 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
             "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
             "dev": true
         },
         "queue-microtask": {
@@ -39428,9 +39339,9 @@
             }
         },
         "rollup": {
-            "version": "2.77.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-            "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+            "version": "2.78.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+            "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -39991,16 +39902,6 @@
                 "source-map-js": "^1.0.1"
             }
         },
-        "source-map-resolve": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-            "dev": true,
-            "requires": {
-                "atob": "^2.1.2",
-                "decode-uri-component": "^0.2.0"
-            }
-        },
         "source-map-support": {
             "version": "0.5.13",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -40051,9 +39952,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-            "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+            "version": "3.0.12",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
             "dev": true
         },
         "spdy": {
@@ -40546,9 +40447,9 @@
             "dev": true
         },
         "tailwindcss": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.7.tgz",
-            "integrity": "sha512-r7mgumZ3k0InfVPpGWcX8X/Ut4xBfv+1O/+C73ar/m01LxGVzWvPxF/w6xIUPEztrCoz7axfx0SMdh8FH8ZvRQ==",
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.8.tgz",
+            "integrity": "sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==",
             "dev": true,
             "requires": {
                 "arg": "^5.0.2",
@@ -40674,16 +40575,16 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-            "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.5.tgz",
+            "integrity": "sha512-AOEDLDxD2zylUGf/wxHxklEkOe2/r+seuyOWujejFrIxHf11brA1/dWQNIgXa1c6/Wkxgu7zvv0JhOWfc2ELEA==",
             "dev": true,
             "requires": {
-                "@jridgewell/trace-mapping": "^0.3.7",
+                "@jridgewell/trace-mapping": "^0.3.14",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
-                "terser": "^5.7.2"
+                "terser": "^5.14.1"
             },
             "dependencies": {
                 "has-flag": {
@@ -40801,20 +40702,21 @@
             "dev": true
         },
         "tough-cookie": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-            "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.0.tgz",
+            "integrity": "sha512-IVX6AagLelGwl6F0E+hoRpXzuD192cZhAcmT7/eoLr0PnsB1wv2E5c+A2O+V8xth9FlL2p0OstFsWn0bZpVn4w==",
             "dev": true,
             "requires": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
-                "universalify": "^0.1.2"
+                "universalify": "^0.2.0",
+                "url-parse": "^1.5.3"
             },
             "dependencies": {
                 "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+                    "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
                     "dev": true
                 }
             }
@@ -41073,6 +40975,16 @@
                 }
             }
         },
+        "url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "dev": true,
+            "requires": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
         "use-constant": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/use-constant/-/use-constant-1.1.1.tgz",
@@ -41329,9 +41241,9 @@
             }
         },
         "webpack-dev-server": {
-            "version": "4.9.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.9.3.tgz",
-            "integrity": "sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.10.0.tgz",
+            "integrity": "sha512-7dezwAs+k6yXVFZ+MaL8VnE+APobiO3zvpp3rBHe/HmWQ+avwh0Q3d0xxacOiBybZZ3syTZw9HXzpa3YNbAZDQ==",
             "dev": true,
             "requires": {
                 "@types/bonjour": "^3.5.9",
@@ -41928,9 +41840,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "write-file-atomic": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
-            "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
             "dev": true,
             "peer": true,
             "requires": {
@@ -42043,9 +41955,9 @@
             "dev": true
         },
         "zustand": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.0.0.tgz",
-            "integrity": "sha512-OrsfQTnRXF1LZ9/vR/IqN9ws5EXUhb149xmPjErZnUrkgxS/gAHGy2dPNIVkVvoxrVe1sIydn4JjF0dYHmGeeQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.1.tgz",
+            "integrity": "sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==",
             "requires": {
                 "use-sync-external-store": "1.2.0"
             }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "devDependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^14.4.1",
+        "@testing-library/user-event": "^14.4.3",
         "@types/auth0-js": "^9.14.6",
         "@types/lodash": "^4.14.182",
         "@types/logrocket-react": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "index.js",
     "private": true,
     "scripts": {
+        "print-versions": "tsc --version && eslint --version && prettier --version",
         "start": "set WDS_SOCKET_PORT=0 && react-app-rewired start",
         "build": "react-app-rewired build",
         "test": "react-app-rewired test",

--- a/src/components/menus/__tests__/UserMenu.tsx
+++ b/src/components/menus/__tests__/UserMenu.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { UserEvent } from '@testing-library/user-event/dist/types/setup';
+import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 import UserMenu from 'components/menus/UserMenu';
 import { act, customRender, screen, waitFor } from 'utils/test-utils';
 

--- a/src/components/tables/Captures/index.tsx
+++ b/src/components/tables/Captures/index.tsx
@@ -15,7 +15,7 @@ const queryColumns = [
     'catalog_name',
     'connector_image_name',
     'connector_image_tag',
-    'connector_open_graph->en-US->>image',
+    'spec->endpoint->connector->image',
     'connector_open_graph->en-US->>title',
     'id',
     'last_pub_id',

--- a/src/components/tables/cells/Connector.tsx
+++ b/src/components/tables/cells/Connector.tsx
@@ -3,12 +3,16 @@ import ConnectorName from 'components/ConnectorName';
 import { tableBorderSx } from 'context/Theme';
 
 interface Props {
-    connectorName: string;
+    connectorName: string | null;
     connectorImage: string;
     imageTag: string;
 }
 
 function Connector({ connectorImage, connectorName, imageTag }: Props) {
+    // It's possible for the connectorName property to be null, since that comes from the open graph
+    // document. But the connectorImage should always be non-null as it comes from the capture's
+    // live spec. We use the image as a fallback in case the open graph title is unavailable.
+    const name = connectorName !== null ? connectorName : connectorImage;
     return (
         <TableCell
             sx={{
@@ -20,7 +24,7 @@ function Connector({ connectorImage, connectorName, imageTag }: Props) {
                 <Box>
                     <ConnectorName
                         iconSize={20}
-                        connector={connectorName}
+                        connector={name}
                         iconPath={connectorImage}
                     />
                 </Box>

--- a/src/services/jsonforms.ts
+++ b/src/services/jsonforms.ts
@@ -252,7 +252,7 @@ const wrapInLayoutIfNecessary = (
         return verticalLayout;
     }
 
-    return uischema as Layout;
+    return uischema;
 };
 
 /**
@@ -410,7 +410,7 @@ const generateUISchema = (
             const nextRef: string = `${currentRef}/properties`;
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            layout.elements = Object.keys(jsonSchema.properties!).map(
+            layout.elements = Object.keys(jsonSchema.properties).map(
                 (propName) => {
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     let value: JsonSchema = jsonSchema.properties![propName];


### PR DESCRIPTION
## Changes

Previously, the open graph title was used exclusively as the display
name of a connector on the captures table page, which relies on the
assumption that open graph data will always be present for every capture
displayed in the UI. This assumption is not always valid, since we have
the ability to use custom images via the CLI. The result is that the
captures page would show as totally blank when any capture used a
connector that didn't have an open graph title.

This commit updates the capture rows to fallback to using the connector
image if the open graph title is not present. It also updates the query
to retrieve the image directly from the capture spec instead of the open
graph. The result is that the captures table can now render when a
capture uses a connector that isn't present in the database.

## Tests

I only tested this manually. Please let me know if there's a better way.

## Issues

This partially addresses #245. If the approach seems reasonable, then I'll put up a follow-on PR to apply the same fix to the materializations table.

## Content

n/a

## Screenshots

Note the first capture, which uses the image name instead of the open graph title.

![image](https://user-images.githubusercontent.com/4495829/185962588-ad3eab81-9fbf-41b7-86cb-0db8a5603cf5.png)

