### PR TITLE
Correct entity table connector title search parameter

### DIFF
--- a/src/components/tables/Captures/index.tsx
+++ b/src/components/tables/Captures/index.tsx
@@ -49,7 +49,7 @@ function CapturesTable() {
                     [
                         'catalog_name',
                         'last_pub_user_full_name',
-                        'title:connector_title->>en-US',
+                        'connector_title->>en-US',
                     ],
                     searchQuery,
                     columnToSort,

--- a/src/components/tables/Materializations/index.tsx
+++ b/src/components/tables/Materializations/index.tsx
@@ -49,7 +49,7 @@ function MaterializationsTable() {
                     [
                         'catalog_name',
                         'last_pub_user_full_name',
-                        'title:connector_title->>en-US',
+                        'connector_title->>en-US',
                     ],
                     searchQuery,
                     columnToSort,


### PR DESCRIPTION
## Changes

Remove the `title:` prefix of the connector title search parameter used to build the `live_specs_ext` query for the captures and materializations tables.

## Tests

Queried the captures and materialization tables by the following attributes: task name, user last name, and connector title. This branch was tested in a production environment so that the logic could be evaluated against a diverse pool of data.

## Issues

#323 

## Screenshots

**Captures Table | Filter by Task Name**

<img width="1917" alt="pr-screenshot__324__table-filter__task-name" src="https://user-images.githubusercontent.com/77648584/189917516-0a4aef18-b240-4f74-b2a1-c273ff90883c.PNG">

<br />

**Captures Table | Filter by User Last Name**

<img width="1922" alt="pr-screenshot__324__table-filter__user-last-name" src="https://user-images.githubusercontent.com/77648584/189917553-e3ef763e-baa4-41de-942d-954c4d6c1dd0.PNG">

<br />

**Captures Table | Filter by Connector Title**

<img width="1920" alt="pr-screenshot__324__table-filter__connector-title" src="https://user-images.githubusercontent.com/77648584/189917582-e689b251-e01f-43f9-a8eb-60b8a0c9e28b.PNG">

<br />

**Materializations Table | Filter by Task Name**

<img width="1920" alt="pr-screenshot__324__table-filter__mat__task-name" src="https://user-images.githubusercontent.com/77648584/189916574-5b73ee0b-8640-465e-a3b6-416fb1e15544.PNG">

<br />

**Materializations Table | Filter by User Last Name**

<img width="1920" alt="pr-screenshot__324__table-filter__mat__user-last-name" src="https://user-images.githubusercontent.com/77648584/189916610-faa5d35d-e599-40c0-b41e-c3eb0e8c3b01.PNG">

<br />

**Materializations Table | Filter by Connector Title**

<img width="1919" alt="pr-screenshot__324__table-filter__mat__connector-title" src="https://user-images.githubusercontent.com/77648584/189916650-50bb12bb-ab3f-4e3b-b284-ac56a89f6bd9.PNG">