### PR TITLE
Table UX and preparing for stats

### DIFF
--- a/src/components/ConnectorIcon.tsx
+++ b/src/components/ConnectorIcon.tsx
@@ -3,7 +3,7 @@ import { Avatar, Box } from '@mui/material';
 
 interface Props {
     size?: number;
-    iconPath: string | undefined;
+    iconPath?: string | null;
 }
 
 const defaultSize = 20;
@@ -15,7 +15,7 @@ function ConnectorIcon({ size = defaultSize, iconPath }: Props) {
                 <Avatar
                     variant="rounded"
                     sx={{
-                        background: 'primary',
+                        background: 'transparent',
                         width: size,
                         height: size,
                     }}

--- a/src/components/logs/Lines.tsx
+++ b/src/components/logs/Lines.tsx
@@ -1,15 +1,17 @@
 import { List, Paper } from '@mui/material';
 import { useLayoutEffect, useRef } from 'react';
 import useStayScrolled from 'react-stay-scrolled';
+import { hasLength } from 'utils/misc-utils';
 import { useLogsContext } from './Context';
 import LogLine from './Line';
 import Spinner from './Spinner';
 
 interface Props {
     height: number;
+    disableSpinner?: boolean;
 }
 
-function LogLines({ height }: Props) {
+function LogLines({ height, disableSpinner }: Props) {
     const { logs } = useLogsContext();
 
     const scrollElementRef = useRef<HTMLDivElement>(null);
@@ -47,7 +49,7 @@ function LogLines({ height }: Props) {
                         lineNumber={index}
                     />
                 ))}
-                <Spinner />
+                {!disableSpinner || !hasLength(logs) ? <Spinner /> : null}
             </List>
         </Paper>
     );

--- a/src/components/logs/index.tsx
+++ b/src/components/logs/index.tsx
@@ -22,8 +22,8 @@ function Logs({ token, height, disableIntervalFetching, fetchAll }: LogProps) {
                 fetchAll={fetchAll}
             >
                 <Stack spacing={2}>
-                    <StoppedAlert />
-                    <LogLines height={heightVal} />
+                    {!disableIntervalFetching ? <StoppedAlert /> : null}
+                    <LogLines height={heightVal} disableSpinner={fetchAll} />
                 </Stack>
             </LogsContextProvider>
         );

--- a/src/components/tables/Captures/Rows.tsx
+++ b/src/components/tables/Captures/Rows.tsx
@@ -7,7 +7,6 @@ import EntityName from 'components/tables/cells/EntityName';
 import OptionsMenu from 'components/tables/cells/OptionsMenu';
 import RowSelect from 'components/tables/cells/RowSelect';
 import TimeStamp from 'components/tables/cells/TimeStamp';
-import UserName from 'components/tables/cells/UserName';
 import DetailsPanel from 'components/tables/Details/DetailsPanel';
 import {
     SelectableTableStore,
@@ -56,10 +55,6 @@ export const tableColumns = [
     {
         field: 'updated_at',
         headerIntlKey: 'entityTable.data.lastPublished',
-    },
-    {
-        field: 'last_pub_user_full_name',
-        headerIntlKey: 'entityTable.data.lastPubUserFullName',
     },
     {
         field: null,
@@ -123,12 +118,6 @@ function Row({ isSelected, setRow, row, showEntityStatus }: RowProps) {
                 <ChipList strings={row.writes_to} />
 
                 <TimeStamp time={row.updated_at} />
-
-                <UserName
-                    avatar={row.last_pub_user_avatar_url}
-                    email={row.last_pub_user_email}
-                    name={row.last_pub_user_full_name}
-                />
 
                 <OptionsMenu
                     detailsExpanded={detailsExpanded}

--- a/src/components/tables/Captures/index.tsx
+++ b/src/components/tables/Captures/index.tsx
@@ -21,9 +21,6 @@ const queryColumns = [
     'title:connector_title->>en-US',
     'id',
     'last_pub_id',
-    'last_pub_user_avatar_url',
-    'last_pub_user_email',
-    'last_pub_user_full_name',
     'spec_type',
     'updated_at',
     'writes_to',
@@ -46,11 +43,7 @@ function CapturesTable() {
             filter: (query) => {
                 return defaultTableFilter<LiveSpecsExtQuery>(
                     query,
-                    [
-                        'catalog_name',
-                        'last_pub_user_full_name',
-                        'connector_title->>en-US',
-                    ],
+                    ['catalog_name', 'connector_title->>en-US'],
                     searchQuery,
                     columnToSort,
                     sortDirection,

--- a/src/components/tables/Collections/Rows.tsx
+++ b/src/components/tables/Collections/Rows.tsx
@@ -4,7 +4,6 @@ import Actions from 'components/tables/cells/Actions';
 import EntityName from 'components/tables/cells/EntityName';
 import ExpandDetails from 'components/tables/cells/ExpandDetails';
 import TimeStamp from 'components/tables/cells/TimeStamp';
-import UserName from 'components/tables/cells/UserName';
 import DetailsPanel from 'components/tables/Details/DetailsPanel';
 import { getEntityTableRowSx } from 'context/Theme';
 import { useState } from 'react';
@@ -30,10 +29,6 @@ export const tableColumns = [
         headerIntlKey: 'entityTable.data.lastPublished',
     },
     {
-        field: 'last_pub_user_full_name',
-        headerIntlKey: 'entityTable.data.lastPubUserFullName',
-    },
-    {
         field: null,
         headerIntlKey: null,
     },
@@ -56,12 +51,6 @@ function Row({ row, showEntityStatus }: RowProps) {
                 />
 
                 <TimeStamp time={row.updated_at} />
-
-                <UserName
-                    avatar={row.last_pub_user_avatar_url}
-                    email={row.last_pub_user_email}
-                    name={row.last_pub_user_full_name}
-                />
 
                 <Actions>
                     <ExpandDetails

--- a/src/components/tables/Collections/index.tsx
+++ b/src/components/tables/Collections/index.tsx
@@ -14,7 +14,13 @@ export interface LiveSpecsQuery {
     id: string;
 }
 
-// const queryColumns = ['id', 'spec_type', 'catalog_name', 'updated_at'];
+const queryColumns = [
+    'id',
+    'spec_type',
+    'catalog_name',
+    'updated_at',
+    'last_pub_id',
+];
 
 function CollectionsTable() {
     const rowsPerPage = 10;
@@ -28,7 +34,7 @@ function CollectionsTable() {
     const liveSpecQuery = useQuery<LiveSpecsQuery>(
         TABLES.LIVE_SPECS_EXT,
         {
-            columns: '*',
+            columns: queryColumns,
             count: 'exact',
             filter: (query) => {
                 return defaultTableFilter<LiveSpecsQuery>(

--- a/src/components/tables/Collections/index.tsx
+++ b/src/components/tables/Collections/index.tsx
@@ -33,7 +33,7 @@ function CollectionsTable() {
             filter: (query) => {
                 return defaultTableFilter<LiveSpecsQuery>(
                     query,
-                    ['catalog_name', 'last_pub_user_full_name'],
+                    ['catalog_name'],
                     searchQuery,
                     columnToSort,
                     sortDirection,

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -1,7 +1,7 @@
 import SearchIcon from '@mui/icons-material/Search';
 import {
     Box,
-    LinearProgress,
+    Skeleton,
     Stack,
     Table,
     TableBody,
@@ -32,6 +32,7 @@ import {
     MouseEvent,
     ReactNode,
     useEffect,
+    useMemo,
     useRef,
     useState,
 } from 'react';
@@ -211,6 +212,42 @@ function EntityTable({
         },
     };
 
+    const loadingRows = useMemo(() => {
+        const loadingRow = columns.map((column, index) => {
+            return (
+                <TableCell key={`loading-${column.field}-${index}`}>
+                    <Skeleton variant="rectangular" />
+                </TableCell>
+            );
+        });
+
+        return (
+            <>
+                <TableRow>{loadingRow}</TableRow>
+                <TableRow sx={{ opacity: '75%' }}>{loadingRow}</TableRow>
+                <TableRow>{loadingRow}</TableRow>
+                <TableRow
+                    sx={{
+                        'opacity': '25%',
+                        '& .MuiTableCell-root': {
+                            borderBottom: 'transparent',
+                        },
+                    }}
+                >
+                    {loadingRow}
+                </TableRow>
+            </>
+        );
+    }, [columns]);
+
+    const dataRows = useMemo(
+        () =>
+            selectData && selectData.length > 0
+                ? renderTableRows(selectData, showEntityStatus)
+                : null,
+        [renderTableRows, selectData, showEntityStatus]
+    );
+
     return (
         <Box data-public>
             <Box sx={{ mx: 2 }}>
@@ -266,107 +303,91 @@ function EntityTable({
                                         theme.palette.background.default,
                                 }}
                             >
-                                <>
-                                    {columns.map((column, index) => {
-                                        return (
-                                            <TableCell
-                                                key={`${column.field}-${index}`}
-                                                sortDirection={
-                                                    columnToSort ===
-                                                    column.field
-                                                        ? sortDirection
-                                                        : false
-                                                }
-                                            >
-                                                {selectData && column.field ? (
-                                                    <TableSortLabel
-                                                        active={
-                                                            columnToSort ===
-                                                            column.field
-                                                        }
-                                                        direction={
-                                                            columnToSort ===
-                                                            column.field
-                                                                ? sortDirection
-                                                                : 'asc'
-                                                        }
-                                                        onClick={handlers.sort(
-                                                            column.field
-                                                        )}
-                                                    >
-                                                        {column.headerIntlKey ? (
-                                                            <FormattedMessage
-                                                                id={
-                                                                    column.headerIntlKey
-                                                                }
-                                                            />
-                                                        ) : null}
-                                                    </TableSortLabel>
-                                                ) : column.headerIntlKey ? (
-                                                    <FormattedMessage
-                                                        id={
-                                                            column.headerIntlKey
-                                                        }
-                                                    />
-                                                ) : null}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </>
+                                {columns.map((column, index) => {
+                                    return (
+                                        <TableCell
+                                            key={`${column.field}-${index}`}
+                                            sortDirection={
+                                                columnToSort === column.field
+                                                    ? sortDirection
+                                                    : false
+                                            }
+                                        >
+                                            {selectData && column.field ? (
+                                                <TableSortLabel
+                                                    active={
+                                                        columnToSort ===
+                                                        column.field
+                                                    }
+                                                    direction={
+                                                        columnToSort ===
+                                                        column.field
+                                                            ? sortDirection
+                                                            : 'asc'
+                                                    }
+                                                    onClick={handlers.sort(
+                                                        column.field
+                                                    )}
+                                                >
+                                                    {column.headerIntlKey ? (
+                                                        <FormattedMessage
+                                                            id={
+                                                                column.headerIntlKey
+                                                            }
+                                                        />
+                                                    ) : null}
+                                                </TableSortLabel>
+                                            ) : column.headerIntlKey ? (
+                                                <FormattedMessage
+                                                    id={column.headerIntlKey}
+                                                />
+                                            ) : null}
+                                        </TableCell>
+                                    );
+                                })}
                             </TableRow>
                         </TableHead>
 
                         <TableBody>
-                            {selectData && selectData.length > 0 ? (
-                                renderTableRows(selectData, showEntityStatus)
+                            {dataRows ? (
+                                dataRows
+                            ) : isValidating ||
+                              tableState.status === TableStatuses.LOADING ? (
+                                loadingRows
                             ) : (
-                                <TableRow>
-                                    <TableCell colSpan={columns.length}>
-                                        <Box
-                                            sx={{
-                                                display: 'flex',
-                                                justifyContent: 'center',
-                                            }}
-                                        >
-                                            <Box width={450}>
-                                                {isValidating ||
-                                                tableState.status ===
-                                                    TableStatuses.LOADING ? (
-                                                    <Box>
-                                                        <LinearProgress />
-                                                    </Box>
-                                                ) : (
-                                                    <>
-                                                        <Typography
-                                                            variant="h6"
-                                                            align="center"
-                                                            sx={{ mb: 2 }}
-                                                        >
-                                                            <FormattedMessage
-                                                                id={getEmptyTableHeader(
-                                                                    tableState.status,
-                                                                    noExistingDataContentIds
-                                                                )}
-                                                            />
-                                                        </Typography>
-                                                        <Typography component="div">
-                                                            {getEmptyTableMessage(
-                                                                tableState.status,
-                                                                noExistingDataContentIds
-                                                            )}
-                                                        </Typography>
-                                                    </>
+                                <TableCell colSpan={columns.length}>
+                                    <Box
+                                        sx={{
+                                            display: 'flex',
+                                            justifyContent: 'center',
+                                        }}
+                                    >
+                                        <Box width={450}>
+                                            <Typography
+                                                variant="h6"
+                                                align="center"
+                                                sx={{ mb: 2 }}
+                                            >
+                                                <FormattedMessage
+                                                    id={getEmptyTableHeader(
+                                                        tableState.status,
+                                                        noExistingDataContentIds
+                                                    )}
+                                                />
+                                            </Typography>
+                                            <Typography component="div">
+                                                {getEmptyTableMessage(
+                                                    tableState.status,
+                                                    noExistingDataContentIds
                                                 )}
-                                            </Box>
+                                            </Typography>
                                         </Box>
-                                    </TableCell>
-                                </TableRow>
+                                    </Box>
+                                </TableCell>
                             )}
                         </TableBody>
 
-                        {selectData &&
-                        selectData.length > 0 &&
-                        useSelectResponse?.count ? (
+                        {dataRows && useSelectResponse?.count ? (
                             <TableFooter>
                                 <TableRow>
                                     <TablePagination

--- a/src/components/tables/EntityTable.tsx
+++ b/src/components/tables/EntityTable.tsx
@@ -76,6 +76,7 @@ export const getPagination = (currPage: number, size: number) => {
     return { from, to };
 };
 
+const emptyRowHeight = 80;
 const rowsPerPageOptions = [10, 25, 50];
 
 // TODO (tables) I think we should switch this to React Table soon
@@ -213,6 +214,7 @@ function EntityTable({
     };
 
     const loadingRows = useMemo(() => {
+        const styling = { height: emptyRowHeight };
         const loadingRow = columns.map((column, index) => {
             return (
                 <TableCell key={`loading-${column.field}-${index}`}>
@@ -223,11 +225,16 @@ function EntityTable({
 
         return (
             <>
-                <TableRow>{loadingRow}</TableRow>
-                <TableRow sx={{ opacity: '75%' }}>{loadingRow}</TableRow>
-                <TableRow>{loadingRow}</TableRow>
+                <TableRow sx={styling}>{loadingRow}</TableRow>
+                <TableRow sx={{ ...styling, opacity: '75%' }}>
+                    {loadingRow}
+                </TableRow>
+                <TableRow sx={{ ...styling, opacity: '50%' }}>
+                    {loadingRow}
+                </TableRow>
                 <TableRow
                     sx={{
+                        ...styling,
                         'opacity': '25%',
                         '& .MuiTableCell-root': {
                             borderBottom: 'transparent',

--- a/src/components/tables/Materializations/Rows.tsx
+++ b/src/components/tables/Materializations/Rows.tsx
@@ -6,7 +6,6 @@ import EntityName from 'components/tables/cells/EntityName';
 import OptionsMenu from 'components/tables/cells/OptionsMenu';
 import RowSelect from 'components/tables/cells/RowSelect';
 import TimeStamp from 'components/tables/cells/TimeStamp';
-import UserName from 'components/tables/cells/UserName';
 import DetailsPanel from 'components/tables/Details/DetailsPanel';
 import { LiveSpecsExtQuery } from 'components/tables/Materializations';
 import {
@@ -55,10 +54,6 @@ export const tableColumns = [
     {
         field: 'updated_at',
         headerIntlKey: 'entityTable.data.lastPublished',
-    },
-    {
-        field: 'last_pub_user_full_name',
-        headerIntlKey: 'entityTable.data.lastPubUserFullName',
     },
     {
         field: null,
@@ -115,12 +110,6 @@ function Row({ isSelected, setRow, row, showEntityStatus }: RowProps) {
                 <ChipList strings={row.reads_from} />
 
                 <TimeStamp time={row.updated_at} />
-
-                <UserName
-                    avatar={row.last_pub_user_avatar_url}
-                    email={row.last_pub_user_email}
-                    name={row.last_pub_user_full_name}
-                />
 
                 <OptionsMenu
                     detailsExpanded={detailsExpanded}

--- a/src/components/tables/Materializations/index.tsx
+++ b/src/components/tables/Materializations/index.tsx
@@ -15,15 +15,11 @@ export interface LiveSpecsExtQuery extends LiveSpecsExtBaseQuery {
 const queryColumns = [
     'catalog_name',
     'connector_id',
-    'connector_image_name',
     'connector_image_tag',
     'image:connector_logo_url->>en-US',
     'title:connector_title->>en-US',
     'id',
     'last_pub_id',
-    'last_pub_user_avatar_url',
-    'last_pub_user_email',
-    'last_pub_user_full_name',
     'reads_from',
     'spec_type',
     'updated_at',
@@ -46,11 +42,7 @@ function MaterializationsTable() {
             filter: (query) => {
                 return defaultTableFilter<LiveSpecsExtQuery>(
                     query,
-                    [
-                        'catalog_name',
-                        'last_pub_user_full_name',
-                        'connector_title->>en-US',
-                    ],
+                    ['catalog_name', 'connector_title->>en-US'],
                     searchQuery,
                     columnToSort,
                     sortDirection,

--- a/src/components/tables/RowActions/Shared/Button.tsx
+++ b/src/components/tables/RowActions/Shared/Button.tsx
@@ -96,7 +96,7 @@ function RowActionButton({
 
             <Dialog
                 open={showProgress}
-                maxWidth="lg"
+                maxWidth="md"
                 sx={{
                     '& .MuiPaper-root.MuiDialog-paper': {
                         backgroundColor: (themes) =>

--- a/src/components/tables/cells/Connector.tsx
+++ b/src/components/tables/cells/Connector.tsx
@@ -1,5 +1,5 @@
 import { Box, TableCell, Tooltip } from '@mui/material';
-import ConnectorName from 'components/ConnectorName';
+import ConnectorIcon from 'components/ConnectorIcon';
 import { tableBorderSx } from 'context/Theme';
 
 interface Props {
@@ -8,7 +8,7 @@ interface Props {
     imageTag: string;
 }
 
-const iconSize = 20;
+const iconSize = 40;
 
 function Connector({ connectorImage, connectorName, imageTag }: Props) {
     return (
@@ -19,13 +19,9 @@ function Connector({ connectorImage, connectorName, imageTag }: Props) {
                 maxWidth: 'min-content',
             }}
         >
-            <Tooltip title={imageTag} placement="bottom-start">
+            <Tooltip title={connectorName ?? imageTag} placement="bottom-start">
                 <Box>
-                    <ConnectorName
-                        iconSize={iconSize}
-                        title={connectorName ?? imageTag}
-                        iconPath={connectorImage}
-                    />
+                    <ConnectorIcon iconPath={connectorImage} size={iconSize} />
                 </Box>
             </Tooltip>
         </TableCell>


### PR DESCRIPTION
## Changes

1. Added a skeleton for the loading of the tables. The rows slowly fade out to communicate to the customer that there is an unknown amount of rows. Also, having elements to look at while it loads can help guide their eye to where the data will be populated.
2. Removed the user information. This is currently not used much as many users only have access to their area of the app. In addition, sometimes we update a customer's data and it looks odd to have us showing up in their UI.
3. No longer show the Connector name in the rows. Instead just show the icon and they can hover to get the name.
4. Do not show the "restart" alert for logs when they are set to fetch all

## Tests

Manual

## Issues

Fixes: https://github.com/estuary/ui/issues/336

## Content

N/A

## Screenshots

Instead of using standard loading bar using skeleton
![image](https://user-images.githubusercontent.com/270078/191347929-6774e8a9-bdfa-46af-9424-dd5fe538ad77.png)

No longer display the user information
![image](https://user-images.githubusercontent.com/270078/191348008-8f6e6495-72bb-4aca-94b5-c3ce8defcdb4.png)

Hover shows the connector name
![image](https://user-images.githubusercontent.com/270078/191348804-52cde176-3dae-494a-aac3-e54eb456d560.png)

If logs are fetching all and not polling by default we don't show alert
![image](https://user-images.githubusercontent.com/270078/191355257-9c3b7e93-daa8-4177-a6e2-97c2ba5a78d4.png)
