### PR TITLE
UX Tweaks 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
                 "monaco-editor": "^0.33.0",
                 "notistack": "^2.0.5",
                 "path-list-to-tree": "^1.1.1",
-                "prettier-plugin-organize-imports": "^3.1.1",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "react-error-boundary": "^3.1.4",
@@ -75,6 +74,7 @@
                 "lint-staged": "^12.5.0",
                 "node-polyfill-webpack-plugin": "^1.1.4",
                 "prettier": "^2.7.1",
+                "prettier-plugin-organize-imports": "^3.1.1",
                 "react-app-rewired": "^2.2.1",
                 "react-scripts": "5.0.0",
                 "tsc-files": "^1.1.3",
@@ -19746,6 +19746,7 @@
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
             "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -19760,6 +19761,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.1.1.tgz",
             "integrity": "sha512-6bHIQzybqA644h0WGUW3gpWEVbMBvzui5wCMRBi7qA++d5ov2xjjfDk8pxJJ/ardfZrGAwizKMq/fQMFdJ+0Zw==",
+            "dev": true,
             "peerDependencies": {
                 "@volar/vue-typescript": ">=0.40.2",
                 "prettier": ">=2.0",
@@ -24222,6 +24224,7 @@
             "version": "4.8.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
             "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+            "devOptional": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -40084,12 +40087,14 @@
         "prettier": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "dev": true
         },
         "prettier-plugin-organize-imports": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.1.1.tgz",
             "integrity": "sha512-6bHIQzybqA644h0WGUW3gpWEVbMBvzui5wCMRBi7qA++d5ov2xjjfDk8pxJJ/ardfZrGAwizKMq/fQMFdJ+0Zw==",
+            "dev": true,
             "requires": {}
         },
         "pretty-bytes": {
@@ -43538,7 +43543,8 @@
         "typescript": {
             "version": "4.8.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+            "devOptional": true
         },
         "ua-parser-js": {
             "version": "0.7.31",

--- a/src/app/Authenticated.tsx
+++ b/src/app/Authenticated.tsx
@@ -266,7 +266,13 @@ const Authenticated = () => {
                         {!isProduction ? (
                             <Route
                                 path="test/jsonforms"
-                                element={<TestJsonForms />}
+                                element={
+                                    <EntityContextProvider
+                                        value={ENTITY.CAPTURE}
+                                    >
+                                        <TestJsonForms />
+                                    </EntityContextProvider>
+                                }
                             />
                         ) : null}
 

--- a/src/components/ConnectorTiles.tsx
+++ b/src/components/ConnectorTiles.tsx
@@ -16,8 +16,8 @@ import ConnectorCard from 'components/connectors/Card';
 import ConnectorToolbar from 'components/ConnectorToolbar';
 import useEntityCreateNavigate from 'components/shared/Entity/hooks/useEntityCreateNavigate';
 import {
-    darkGlassBkgColor,
-    darkGlassBkgColorIntensified,
+    semiTransparentBackground,
+    semiTransparentBackgroundIntensified,
     slate,
 } from 'context/Theme';
 import { useQuery, useSelect } from 'hooks/supabase-swr';
@@ -75,15 +75,13 @@ function Tile({ children }: TileProps) {
                 'height': '100%',
                 'borderRadius': 5,
                 'background': (theme) =>
-                    theme.palette.mode === 'dark'
-                        ? darkGlassBkgColor
-                        : slate[50],
+                    semiTransparentBackground[theme.palette.mode],
                 'padding': 1,
                 '&:hover': {
                     background: (theme) =>
-                        theme.palette.mode === 'dark'
-                            ? darkGlassBkgColorIntensified
-                            : 'rgba(172, 199, 220, 0.45)',
+                        semiTransparentBackgroundIntensified[
+                            theme.palette.mode
+                        ],
                 },
             }}
         >
@@ -289,9 +287,7 @@ function ConnectorTiles({
                             flexDirection: 'column',
                             justifyContent: 'center',
                             background:
-                                theme.palette.mode === 'dark'
-                                    ? darkGlassBkgColor
-                                    : slate[50],
+                                semiTransparentBackground[theme.palette.mode],
                             padding: 1,
                         }}
                     >

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -9,9 +9,8 @@ import {
     Toolbar,
 } from '@mui/material';
 import {
-    darkGlassBkgColor,
-    darkGlassBkgColorIntensified,
-    slate,
+    semiTransparentBackground,
+    semiTransparentBackgroundIntensified,
 } from 'context/Theme';
 import { ConnectorWithTagDetailQuery } from 'hooks/useConnectorWithTagDetail';
 import { debounce } from 'lodash';
@@ -49,7 +48,7 @@ const inputProps: Partial<FilledInputProps> = {
     sx: {
         borderRadius: 5,
         backgroundColor: (theme) =>
-            theme.palette.mode === 'dark' ? darkGlassBkgColor : slate[50],
+            semiTransparentBackgroundIntensified[theme.palette.mode],
     },
 };
 
@@ -62,9 +61,7 @@ const toolbarSectionSx: SxProps<Theme> = {
     },
     '& .MuiFilledInput-root:hover, .MuiFilledInput-root.Mui-focused': {
         backgroundColor: (theme) =>
-            theme.palette.mode === 'dark'
-                ? darkGlassBkgColorIntensified
-                : 'rgba(80, 114, 235, 0.09)',
+            semiTransparentBackground[theme.palette.mode],
     },
 };
 

--- a/src/components/capture/Create.tsx
+++ b/src/components/capture/Create.tsx
@@ -8,7 +8,7 @@ import {
 import EntitySaveButton from 'components/shared/Entity/Actions/SaveButton';
 import EntityTestButton from 'components/shared/Entity/Actions/TestButton';
 import EntityCreate from 'components/shared/Entity/Create';
-import FooHeader from 'components/shared/Entity/Header';
+import EntityToolbar from 'components/shared/Entity/Header';
 import ValidationErrorSummary from 'components/shared/Entity/ValidationErrorSummary/capture';
 import PageContainer from 'components/shared/PageContainer';
 import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
@@ -16,7 +16,6 @@ import { useClient } from 'hooks/supabase-swr';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import LogRocket from 'logrocket';
 import { useEffect } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 import {
@@ -86,11 +85,8 @@ function CaptureCreate() {
 
     // Form State Store
     const messagePrefix = useFormStateStore_messagePrefix();
-
     const setFormState = useFormStateStore_setFormState();
-
     const resetFormState = useFormStateStore_resetState();
-
     const exitWhenLogsClose = useFormStateStore_exitWhenLogsClose();
 
     // Reset the catalog if the connector changes
@@ -197,11 +193,15 @@ function CaptureCreate() {
                 connectorType={entityType}
                 promptDataLoss={detailsFormChanged() || endpointConfigChanged()}
                 resetState={resetState}
-                Header={
-                    <FooHeader
-                        heading={
-                            <FormattedMessage id={`${messagePrefix}.heading`} />
+                errorSummary={
+                    <ValidationErrorSummary
+                        errorsExist={
+                            detailsFormErrorsExist || endpointConfigErrorsExist
                         }
+                    />
+                }
+                toolbar={
+                    <EntityToolbar
                         GenerateButton={
                             <CaptureGenerateButton
                                 disabled={!hasConnectors}
@@ -224,14 +224,6 @@ function CaptureCreate() {
                                 disabled={!draftId}
                                 materialize={handlers.materializeCollections}
                                 logEvent={CustomEvents.CAPTURE_CREATE}
-                            />
-                        }
-                        ErrorSummary={
-                            <ValidationErrorSummary
-                                errorsExist={
-                                    detailsFormErrorsExist ||
-                                    endpointConfigErrorsExist
-                                }
                             />
                         }
                     />

--- a/src/components/capture/Edit.tsx
+++ b/src/components/capture/Edit.tsx
@@ -9,7 +9,7 @@ import {
 import EntitySaveButton from 'components/shared/Entity/Actions/SaveButton';
 import EntityTestButton from 'components/shared/Entity/Actions/TestButton';
 import EntityEdit from 'components/shared/Entity/Edit';
-import FooHeader from 'components/shared/Entity/Header';
+import EntityToolbar from 'components/shared/Entity/Header';
 import ValidationErrorSummary from 'components/shared/Entity/ValidationErrorSummary/capture';
 import PageContainer from 'components/shared/PageContainer';
 import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
@@ -17,7 +17,6 @@ import { useClient } from 'hooks/supabase-swr';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 // import LogRocket from 'logrocket';
 import { useEffect } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 // import { startSubscription, TABLES } from 'services/supabase';
@@ -35,7 +34,6 @@ import {
 import {
     FormStatus,
     useFormStateStore_exitWhenLogsClose,
-    useFormStateStore_messagePrefix,
     useFormStateStore_resetState,
     useFormStateStore_setFormState,
 } from 'stores/FormState';
@@ -81,12 +79,8 @@ function CaptureEdit() {
     const endpointConfigChanged = useEndpointConfigStore_changed();
 
     // Form State Store
-    const messagePrefix = useFormStateStore_messagePrefix();
-
     const setFormState = useFormStateStore_setFormState();
-
     const resetFormState = useFormStateStore_resetState();
-
     const exitWhenLogsClose = useFormStateStore_exitWhenLogsClose();
 
     // Reset the catalog if the connector changes
@@ -189,11 +183,15 @@ function CaptureEdit() {
                 entityType={entityType}
                 promptDataLoss={detailsFormChanged() || endpointConfigChanged()}
                 resetState={resetState}
-                Header={
-                    <FooHeader
-                        heading={
-                            <FormattedMessage id={`${messagePrefix}.heading`} />
+                errorSummary={
+                    <ValidationErrorSummary
+                        errorsExist={
+                            detailsFormErrorsExist || endpointConfigErrorsExist
                         }
+                    />
+                }
+                toolbar={
+                    <EntityToolbar
                         TestButton={
                             <EntityTestButton
                                 closeLogs={handlers.closeLogs}
@@ -209,14 +207,6 @@ function CaptureEdit() {
                                 disabled={!draftId}
                                 materialize={handlers.materializeCollections}
                                 logEvent={CustomEvents.CAPTURE_EDIT}
-                            />
-                        }
-                        ErrorSummary={
-                            <ValidationErrorSummary
-                                errorsExist={
-                                    detailsFormErrorsExist ||
-                                    endpointConfigErrorsExist
-                                }
                             />
                         }
                     />

--- a/src/components/collection/Config.tsx
+++ b/src/components/collection/Config.tsx
@@ -1,7 +1,7 @@
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import { Alert, AlertTitle } from '@mui/material';
 import MessageWithLink from 'components/content/MessageWithLink';
 import BindingsMultiEditor from 'components/editor/Bindings';
+import AlertBox from 'components/shared/AlertBox';
 import WrapperWithHeader from 'components/shared/Entity/WrapperWithHeader';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -42,13 +42,15 @@ function CollectionConfig({ readOnly = false }: Props) {
             }
         >
             {resourceConfigHydrationErrorsExist ? (
-                <Alert severity="error">
-                    <AlertTitle>
+                <AlertBox
+                    severity="error"
+                    title={
                         <FormattedMessage id="workflows.error.initFormSection" />
-
-                        <MessageWithLink messageID="error.message" />
-                    </AlertTitle>
-                </Alert>
+                    }
+                    short
+                >
+                    <MessageWithLink messageID="error.message" />
+                </AlertBox>
             ) : (
                 <BindingsMultiEditor readOnly={readOnly} />
             )}

--- a/src/components/collection/DataPreview/index.tsx
+++ b/src/components/collection/DataPreview/index.tsx
@@ -1,7 +1,8 @@
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { LoadingButton } from '@mui/lab';
-import { Alert, AlertTitle, Stack, Typography } from '@mui/material';
+import { AlertTitle, Box, Stack, Typography } from '@mui/material';
 import ListView from 'components/collection/DataPreview/ListView';
+import AlertBox from 'components/shared/AlertBox';
 import { useJournalData, useJournalsForCollection } from 'hooks/useJournalData';
 import { useLiveSpecs_spec } from 'hooks/useLiveSpecs';
 import { useMemo } from 'react';
@@ -92,34 +93,42 @@ export function DataPreview({ collectionName }: Props) {
             </Stack>
 
             {!hasLength(journalsData?.journals) ? (
-                <Alert severity="warning" sx={{ mb: 3 }}>
-                    <AlertTitle>
-                        <FormattedMessage id="collectionsPreview.notFound.title" />
-                    </AlertTitle>
-                    <FormattedMessage id="collectionsPreview.notFound.message" />
-                </Alert>
+                <Box sx={{ mb: 3 }}>
+                    <AlertBox severity="warning">
+                        <AlertTitle>
+                            <FormattedMessage id="collectionsPreview.notFound.title" />
+                        </AlertTitle>
+                        <FormattedMessage id="collectionsPreview.notFound.message" />
+                    </AlertBox>
+                </Box>
             ) : journalData.data?.tooManyBytes &&
               journalData.data.documents.length === 0 ? (
-                <Alert severity="warning" sx={{ mb: 3 }}>
-                    <AlertTitle>
-                        <FormattedMessage id="collectionsPreview.tooManyBytesAndNoDocuments.title" />
-                    </AlertTitle>
-                    <FormattedMessage id="collectionsPreview.tooManyBytesAndNoDocuments.message" />
-                </Alert>
+                <Box sx={{ mb: 3 }}>
+                    <AlertBox severity="warning">
+                        <AlertTitle>
+                            <FormattedMessage id="collectionsPreview.tooManyBytesAndNoDocuments.title" />
+                        </AlertTitle>
+                        <FormattedMessage id="collectionsPreview.tooManyBytesAndNoDocuments.message" />
+                    </AlertBox>
+                </Box>
             ) : journalData.data?.tooFewDocuments ? (
-                <Alert severity="warning" sx={{ mb: 3 }}>
-                    <AlertTitle>
-                        <FormattedMessage id="collectionsPreview.tooFewDocuments.title" />
-                    </AlertTitle>
-                    <FormattedMessage id="collectionsPreview.tooFewDocuments.message" />
-                </Alert>
+                <Box sx={{ mb: 3 }}>
+                    <AlertBox severity="warning">
+                        <AlertTitle>
+                            <FormattedMessage id="collectionsPreview.tooFewDocuments.title" />
+                        </AlertTitle>
+                        <FormattedMessage id="collectionsPreview.tooFewDocuments.message" />
+                    </AlertBox>
+                </Box>
             ) : journalData.data?.tooManyBytes ? (
-                <Alert severity="warning" sx={{ mb: 3 }}>
-                    <AlertTitle>
-                        <FormattedMessage id="collectionsPreview.tooManyBytes.title" />
-                    </AlertTitle>
-                    <FormattedMessage id="collectionsPreview.tooManyBytes.message" />
-                </Alert>
+                <Box sx={{ mb: 3 }}>
+                    <AlertBox severity="warning">
+                        <AlertTitle>
+                            <FormattedMessage id="collectionsPreview.tooManyBytes.title" />
+                        </AlertTitle>
+                        <FormattedMessage id="collectionsPreview.tooManyBytes.message" />
+                    </AlertBox>
+                </Box>
             ) : (
                 <ListView journalData={journalData} spec={spec} />
             )}

--- a/src/components/connectors/Card.tsx
+++ b/src/components/connectors/Card.tsx
@@ -3,9 +3,8 @@ import { Box, Button, Grid, Paper, Stack, Typography } from '@mui/material';
 import { imageBackgroundSx } from 'components/ConnectorTiles';
 import ExternalLink from 'components/shared/ExternalLink';
 import {
-    darkGlassBkgColor,
-    darkGlassBkgColorIntensified,
-    slate,
+    semiTransparentBackground,
+    semiTransparentBackgroundIntensified,
 } from 'context/Theme';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import { BaseComponentProps, EntityWithCreateWorkflow } from 'types';
@@ -20,16 +19,12 @@ function Tile({ children }: TileProps) {
                 'maxWidth': 500,
                 'flexGrow': 1,
                 'background': (theme) =>
-                    theme.palette.mode === 'dark'
-                        ? darkGlassBkgColor
-                        : slate[50],
+                    semiTransparentBackgroundIntensified[theme.palette.mode],
                 'padding': 1,
                 'height': '100%',
                 '&:hover': {
                     background: (theme) =>
-                        theme.palette.mode === 'dark'
-                            ? darkGlassBkgColorIntensified
-                            : 'rgba(172, 199, 220, 0.45)',
+                        semiTransparentBackground[theme.palette.mode],
                 },
             }}
         >

--- a/src/components/editor/Bindings/SelectorEmpty.tsx
+++ b/src/components/editor/Bindings/SelectorEmpty.tsx
@@ -1,14 +1,17 @@
-import { Alert, AlertTitle } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import { FormattedMessage } from 'react-intl';
 
 function SelectorEmpty() {
     return (
-        <Alert severity="info">
-            <AlertTitle>
+        <AlertBox
+            severity="info"
+            short
+            title={
                 <FormattedMessage id="entityCreate.bindingsConfig.noRowsTitle" />
-            </AlertTitle>
+            }
+        >
             <FormattedMessage id="entityCreate.bindingsConfig.noRows" />
-        </Alert>
+        </AlertBox>
     );
 }
 

--- a/src/components/fullPage/Dialog.tsx
+++ b/src/components/fullPage/Dialog.tsx
@@ -1,9 +1,6 @@
 import { Box, Paper, useTheme } from '@mui/material';
 import CompanyLogo from 'components/graphics/CompanyLogo';
-import {
-    darkGlassBkgWithoutBlur,
-    lightGlassBkgWithoutBlur,
-} from 'context/Theme';
+import { glassBkgWithoutBlur } from 'context/Theme';
 import { ReactNode } from 'react';
 
 interface Props {
@@ -13,10 +10,7 @@ interface Props {
 function FullPageDialog({ children }: Props) {
     const theme = useTheme();
 
-    const dialogBackground =
-        theme.palette.mode === 'dark'
-            ? darkGlassBkgWithoutBlur
-            : lightGlassBkgWithoutBlur;
+    const dialogBackground = glassBkgWithoutBlur[theme.palette.mode];
 
     return (
         <Box

--- a/src/components/fullPage/Error.tsx
+++ b/src/components/fullPage/Error.tsx
@@ -1,11 +1,5 @@
-import {
-    Alert,
-    AlertTitle,
-    Backdrop,
-    Box,
-    List,
-    ListItem,
-} from '@mui/material';
+import { Backdrop, Box, List, ListItem } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import { FormattedMessage } from 'react-intl';
 import { BaseError } from 'types';
 
@@ -19,10 +13,10 @@ function FullPageError({ errors }: Props) {
             open={true}
         >
             <Box sx={{ width: '100%' }}>
-                <Alert severity="error">
-                    <AlertTitle>
-                        <FormattedMessage id="fullpage.error" />
-                    </AlertTitle>
+                <AlertBox
+                    severity="error"
+                    title={<FormattedMessage id="fullpage.error" />}
+                >
                     {errors.length > 0 ? (
                         <List dense>
                             {errors.map((error, index: number) => {
@@ -35,7 +29,7 @@ function FullPageError({ errors }: Props) {
                             })}
                         </List>
                     ) : null}
-                </Alert>
+                </AlertBox>
             </Box>
         </Backdrop>
     );

--- a/src/components/login/MagicLinkInputs.tsx
+++ b/src/components/login/MagicLinkInputs.tsx
@@ -1,8 +1,9 @@
 import { JsonSchema } from '@jsonforms/core';
 import { materialCells } from '@jsonforms/material-renderers';
 import { JsonForms } from '@jsonforms/react';
-import { Alert, Button, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import { ApiError } from '@supabase/supabase-js';
+import AlertBox from 'components/shared/AlertBox';
 import { isEmpty } from 'lodash';
 import { useSnackbar, VariantType } from 'notistack';
 import React, { useState } from 'react';
@@ -94,14 +95,15 @@ const MagicLinkInputs = ({ onSubmit, schema, uiSchema }: Props) => {
     return (
         <>
             {submitError ? (
-                <Alert
-                    severity="error"
+                <Box
                     sx={{
                         mb: 5,
                     }}
                 >
-                    <Typography>{submitError.message}</Typography>
-                </Alert>
+                    <AlertBox severity="error" short>
+                        <Typography>{submitError.message}</Typography>
+                    </AlertBox>
+                </Box>
             ) : null}
 
             <form

--- a/src/components/login/Notifications.tsx
+++ b/src/components/login/Notifications.tsx
@@ -1,4 +1,5 @@
-import { Alert, Snackbar } from '@mui/material';
+import { Snackbar } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import { FormattedMessage } from 'react-intl';
 
 interface Props {
@@ -16,9 +17,9 @@ function LoginNotifications({ notificationMessage }: Props) {
                 }}
                 autoHideDuration={10000}
             >
-                <Alert severity="error">
+                <AlertBox severity="error" short>
                     <FormattedMessage id={notificationMessage} />
-                </Alert>
+                </AlertBox>
             </Snackbar>
         );
     } else {

--- a/src/components/logs/Context.tsx
+++ b/src/components/logs/Context.tsx
@@ -42,7 +42,7 @@ const LogsContextProvider = ({
     const timeoutRef = useRef<number | undefined>();
     const interval = useRef(DEFAULT_POLLING_INTERVAL / 2);
     const emptyResponses = useRef(
-        disableIntervalFetching ? MAX_EMPTY_CALLS : 0
+        fetchAll || disableIntervalFetching ? MAX_EMPTY_CALLS : 0
     );
 
     // Publics
@@ -100,6 +100,7 @@ const LogsContextProvider = ({
                         }
 
                         if (
+                            !fetchAll &&
                             !disableIntervalFetching &&
                             MAX_EMPTY_CALLS >= emptyResponses.current
                         ) {

--- a/src/components/logs/StoppedAlert.tsx
+++ b/src/components/logs/StoppedAlert.tsx
@@ -1,4 +1,5 @@
-import { Alert, Button, Collapse } from '@mui/material';
+import { Button, Collapse } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import { LINK_BUTTON_STYLING } from 'context/Theme';
 import { FormattedMessage } from 'react-intl';
 import { useLogsContext } from './Context';
@@ -8,7 +9,7 @@ function StoppedAlert() {
 
     return (
         <Collapse in={stopped}>
-            <Alert severity="warning">
+            <AlertBox severity="info" short>
                 <FormattedMessage
                     id={
                         networkFailure
@@ -27,7 +28,7 @@ function StoppedAlert() {
                         ),
                     }}
                 />
-            </Alert>
+            </AlertBox>
         </Collapse>
     );
 }

--- a/src/components/materialization/Create.tsx
+++ b/src/components/materialization/Create.tsx
@@ -7,12 +7,11 @@ import MaterializeGenerateButton from 'components/materialization/GenerateButton
 import EntitySaveButton from 'components/shared/Entity/Actions/SaveButton';
 import EntityTestButton from 'components/shared/Entity/Actions/TestButton';
 import EntityCreate from 'components/shared/Entity/Create';
-import FooHeader from 'components/shared/Entity/Header';
+import EntityToolbar from 'components/shared/Entity/Header';
 import ValidationErrorSummary from 'components/shared/Entity/ValidationErrorSummary/materialization';
 import PageContainer from 'components/shared/PageContainer';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import { useEffect } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 import {
@@ -29,7 +28,6 @@ import {
 import {
     FormStatus,
     useFormStateStore_exitWhenLogsClose,
-    useFormStateStore_messagePrefix,
     useFormStateStore_resetState,
     useFormStateStore_setFormState,
 } from 'stores/FormState';
@@ -62,12 +60,8 @@ function MaterializationCreate() {
     const endpointConfigChanged = useEndpointConfigStore_changed();
 
     // Form State Store
-    const messagePrefix = useFormStateStore_messagePrefix();
-
     const setFormState = useFormStateStore_setFormState();
-
     const resetFormState = useFormStateStore_resetState();
-
     const exitWhenLogsClose = useFormStateStore_exitWhenLogsClose();
 
     // Resource Config Store
@@ -139,8 +133,16 @@ function MaterializationCreate() {
                         detailsFormChanged()
                     }
                     resetState={resetState}
-                    Header={
-                        <FooHeader
+                    errorSummary={
+                        <ValidationErrorSummary
+                            errorsExist={
+                                detailsFormErrorsExist ||
+                                endpointConfigErrorsExist
+                            }
+                        />
+                    }
+                    toolbar={
+                        <EntityToolbar
                             GenerateButton={
                                 <MaterializeGenerateButton
                                     disabled={!hasConnectors}
@@ -162,19 +164,6 @@ function MaterializationCreate() {
                                     closeLogs={handlers.closeLogs}
                                     logEvent={
                                         CustomEvents.MATERIALIZATION_CREATE
-                                    }
-                                />
-                            }
-                            heading={
-                                <FormattedMessage
-                                    id={`${messagePrefix}.heading`}
-                                />
-                            }
-                            ErrorSummary={
-                                <ValidationErrorSummary
-                                    errorsExist={
-                                        detailsFormErrorsExist ||
-                                        endpointConfigErrorsExist
                                     }
                                 />
                             }

--- a/src/components/materialization/Edit.tsx
+++ b/src/components/materialization/Edit.tsx
@@ -8,13 +8,12 @@ import MaterializeGenerateButton from 'components/materialization/EditGenerateBu
 import EntitySaveButton from 'components/shared/Entity/Actions/SaveButton';
 import EntityTestButton from 'components/shared/Entity/Actions/TestButton';
 import EntityEdit from 'components/shared/Entity/Edit';
-import FooHeader from 'components/shared/Entity/Header';
+import EntityToolbar from 'components/shared/Entity/Header';
 import ValidationErrorSummary from 'components/shared/Entity/ValidationErrorSummary/materialization';
 import PageContainer from 'components/shared/PageContainer';
 import { useClient } from 'hooks/supabase-swr';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import { useEffect } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 import {
@@ -31,7 +30,6 @@ import {
 import {
     FormStatus,
     useFormStateStore_exitWhenLogsClose,
-    useFormStateStore_messagePrefix,
     useFormStateStore_resetState,
     useFormStateStore_setFormState,
 } from 'stores/FormState';
@@ -64,12 +62,8 @@ function MaterializationEdit() {
     const endpointConfigChanged = useEndpointConfigStore_changed();
 
     // Form State Store
-    const messagePrefix = useFormStateStore_messagePrefix();
-
     const setFormState = useFormStateStore_setFormState();
-
     const resetFormState = useFormStateStore_resetState();
-
     const exitWhenLogsClose = useFormStateStore_exitWhenLogsClose();
 
     // Resource Config Store
@@ -153,8 +147,16 @@ function MaterializationEdit() {
                     }}
                     resetState={resetState}
                     callFailed={helpers.callFailed}
-                    Header={
-                        <FooHeader
+                    errorSummary={
+                        <ValidationErrorSummary
+                            errorsExist={
+                                detailsFormErrorsExist ||
+                                endpointConfigErrorsExist
+                            }
+                        />
+                    }
+                    toolbar={
+                        <EntityToolbar
                             GenerateButton={
                                 <MaterializeGenerateButton
                                     disabled={!hasConnectors}
@@ -175,19 +177,6 @@ function MaterializationEdit() {
                                     callFailed={helpers.callFailed}
                                     closeLogs={handlers.closeLogs}
                                     logEvent={CustomEvents.MATERIALIZATION_EDIT}
-                                />
-                            }
-                            heading={
-                                <FormattedMessage
-                                    id={`${messagePrefix}.heading`}
-                                />
-                            }
-                            ErrorSummary={
-                                <ValidationErrorSummary
-                                    errorsExist={
-                                        detailsFormErrorsExist ||
-                                        endpointConfigErrorsExist
-                                    }
                                 />
                             }
                         />

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -21,7 +21,7 @@ import {
 import MuiDrawer from '@mui/material/Drawer';
 import { authenticatedRoutes } from 'app/Authenticated';
 import ModeSwitch from 'components/navigation/ModeSwitch';
-import { darkGlassBkgWithBlur, lightGlassBkgWithBlur } from 'context/Theme';
+import { glassBkgWithBlur } from 'context/Theme';
 import { useIntl } from 'react-intl';
 import ListItemLink from './ListItemLink';
 
@@ -47,10 +47,7 @@ const Navigation = ({ open, width, onNavigationToggle }: NavigationProps) => {
         onNavigationToggle(false);
     };
 
-    const paperBackground =
-        theme.palette.mode === 'dark'
-            ? darkGlassBkgWithBlur
-            : lightGlassBkgWithBlur;
+    const paperBackground = glassBkgWithBlur[theme.palette.mode];
 
     return (
         <MuiDrawer

--- a/src/components/navigation/TopBar.tsx
+++ b/src/components/navigation/TopBar.tsx
@@ -5,11 +5,7 @@ import CompanyLogo from 'components/graphics/CompanyLogo';
 import HelpMenu from 'components/menus/HelpMenu';
 import UserMenu from 'components/menus/UserMenu';
 import PageTitle, { PageTitleProps } from 'components/navigation/PageTitle';
-import {
-    darkGlassBkgWithBlur,
-    lightGlassBkgWithBlur,
-    zIndexIncrement,
-} from 'context/Theme';
+import { glassBkgWithBlur, zIndexIncrement } from 'context/Theme';
 
 interface Props {
     pageTitleProps?: PageTitleProps;
@@ -21,10 +17,7 @@ const Topbar = ({ pageTitleProps }: Props) => {
         color: theme.palette.text.primary,
     };
 
-    const paperBackground =
-        theme.palette.mode === 'dark'
-            ? darkGlassBkgWithBlur
-            : lightGlassBkgWithBlur;
+    const paperBackground = glassBkgWithBlur[theme.palette.mode];
 
     return (
         <MuiAppBar

--- a/src/components/shared/AlertBox.tsx
+++ b/src/components/shared/AlertBox.tsx
@@ -2,8 +2,14 @@ import DangerousOutlinedIcon from '@mui/icons-material/DangerousOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
 import TaskAltOutlinedIcon from '@mui/icons-material/TaskAltOutlined';
-import { Alert, AlertColor, AlertTitle, Typography } from '@mui/material';
-import { alertTextPrimary } from 'context/Theme';
+import {
+    Alert,
+    AlertColor,
+    AlertTitle,
+    Theme,
+    Typography,
+} from '@mui/material';
+import { alertBackground, alertTextPrimary } from 'context/Theme';
 import { ReactNode, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { BaseComponentProps } from 'types';
@@ -14,17 +20,6 @@ interface Props extends BaseComponentProps {
     hideIcon?: boolean;
     title?: string | ReactNode;
 }
-
-const SHORT_ICON_STYLING = {
-    color: 'white',
-};
-
-const ICON_STYLING = {
-    ...SHORT_ICON_STYLING,
-    fontSize: '2.5em',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-};
 
 const SHARED_STYLING = {
     borderRadius: 4,
@@ -41,7 +36,16 @@ const HEADER_MESSAGE = {
 
 function AlertBox({ short, severity, hideIcon, title, children }: Props) {
     const iconComponentStyling = useMemo(
-        () => (!short ? ICON_STYLING : undefined),
+        () =>
+            !short
+                ? {
+                      color: (theme: Theme) =>
+                          alertTextPrimary[theme.palette.mode],
+                      fontSize: '2em',
+                      marginLeft: 'auto',
+                      marginRight: 'auto',
+                  }
+                : undefined,
         [short]
     );
 
@@ -75,7 +79,11 @@ function AlertBox({ short, severity, hideIcon, title, children }: Props) {
                 success: <TaskAltOutlinedIcon sx={iconComponentStyling} />,
             }}
             sx={{
+                'backgroundColor': (theme) =>
+                    alertBackground[theme.palette.mode],
                 'color': (theme) => alertTextPrimary[theme.palette.mode],
+                'borderColor': (theme) =>
+                    theme.palette[severity][theme.palette.mode],
                 'padding': 0,
                 '& > .MuiAlert-message': {
                     p: 1,

--- a/src/components/shared/AlertBox.tsx
+++ b/src/components/shared/AlertBox.tsx
@@ -1,0 +1,111 @@
+import DangerousOutlinedIcon from '@mui/icons-material/DangerousOutlined';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
+import TaskAltOutlinedIcon from '@mui/icons-material/TaskAltOutlined';
+import { Alert, AlertColor, AlertTitle, Typography } from '@mui/material';
+import { alertTextPrimary } from 'context/Theme';
+import { ReactNode, useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { BaseComponentProps } from 'types';
+
+interface Props extends BaseComponentProps {
+    severity: AlertColor;
+    short?: boolean;
+    hideIcon?: boolean;
+    title?: string | ReactNode;
+}
+
+const SHORT_ICON_STYLING = {
+    color: 'white',
+};
+
+const ICON_STYLING = {
+    ...SHORT_ICON_STYLING,
+    fontSize: '2.5em',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+};
+
+const SHARED_STYLING = {
+    borderRadius: 4,
+    borderTopRightRadius: 0,
+    borderBottomRightRadius: 0,
+};
+
+const HEADER_MESSAGE = {
+    warning: 'alert.warning',
+    success: 'alert.success',
+    info: 'alert.info',
+    error: 'alert.error',
+};
+
+function AlertBox({ short, severity, hideIcon, title, children }: Props) {
+    const iconComponentStyling = useMemo(
+        () => (!short ? ICON_STYLING : undefined),
+        [short]
+    );
+
+    const header = useMemo(
+        () =>
+            !short && HEADER_MESSAGE[severity] ? (
+                <Typography
+                    variant="h4"
+                    component="div"
+                    sx={{
+                        pb: 1,
+                    }}
+                >
+                    <FormattedMessage id={HEADER_MESSAGE[severity]} />
+                </Typography>
+            ) : null,
+        [severity, short]
+    );
+
+    return (
+        <Alert
+            severity={severity}
+            variant="outlined"
+            icon={hideIcon ?? undefined}
+            iconMapping={{
+                error: <DangerousOutlinedIcon sx={iconComponentStyling} />,
+                warning: (
+                    <ReportProblemOutlinedIcon sx={iconComponentStyling} />
+                ),
+                info: <InfoOutlinedIcon sx={iconComponentStyling} />,
+                success: <TaskAltOutlinedIcon sx={iconComponentStyling} />,
+            }}
+            sx={{
+                'color': (theme) => alertTextPrimary[theme.palette.mode],
+                'padding': 0,
+                '& > .MuiAlert-message': {
+                    p: 1,
+                },
+                '& > .MuiAlert-icon': short
+                    ? {
+                          ...SHARED_STYLING,
+                          borderLeftColor: (theme) =>
+                              theme.palette[severity][theme.palette.mode],
+                          color: (theme) =>
+                              theme.palette[severity][theme.palette.mode],
+                          mr: 0,
+                          px: 1,
+                          borderLeftStyle: 'solid',
+                          borderLeftWidth: 15,
+                      }
+                    : {
+                          ...SHARED_STYLING,
+                          background: (theme) =>
+                              theme.palette[severity][theme.palette.mode],
+                          px: 3,
+                          pt: 2,
+                      },
+            }}
+        >
+            {header}
+            {title ? <AlertTitle>{title}</AlertTitle> : null}
+            {children}
+        </Alert>
+    );
+}
+
+export default AlertBox;

--- a/src/components/shared/Entity/Create.tsx
+++ b/src/components/shared/Entity/Create.tsx
@@ -1,4 +1,4 @@
-import { Alert, Collapse, Typography } from '@mui/material';
+import { Box, Collapse, Typography } from '@mui/material';
 import CollectionConfig from 'components/collection/Config';
 import ConnectorTiles from 'components/ConnectorTiles';
 import {
@@ -19,7 +19,7 @@ import useBrowserTitle from 'hooks/useBrowserTitle';
 import useCombinedGrantsExt from 'hooks/useCombinedGrantsExt';
 import useConnectorTag from 'hooks/useConnectorTag';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useDetailsForm_connectorImage } from 'stores/DetailsForm';
 import { useEndpointConfigStore_setEndpointSchema } from 'stores/EndpointConfig';
@@ -31,23 +31,26 @@ import {
 } from 'stores/FormState';
 import { EntityWithCreateWorkflow, Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
+import AlertBox from '../AlertBox';
 
 interface Props {
     title: string;
     connectorType: EntityWithCreateWorkflow;
-    Header: any;
+    toolbar: ReactNode;
     showCollections?: boolean;
     promptDataLoss: any;
+    errorSummary: ReactNode;
     resetState: () => void;
 }
 
 function EntityCreate({
     title,
     connectorType,
-    Header,
+    toolbar,
     showCollections,
     promptDataLoss,
     resetState,
+    errorSummary,
 }: Props) {
     useBrowserTitle(title);
 
@@ -118,7 +121,11 @@ function EntityCreate({
     if (showConnectorTiles === null) return null;
     return (
         <>
-            {Header}
+            {toolbar}
+
+            <Box sx={{ maxHeight: 200, overflowY: 'auto', mb: 2 }}>
+                {errorSummary}
+            </Box>
 
             <Collapse in={showConnectorTiles} unmountOnExit>
                 <Typography sx={{ mb: 2 }}>
@@ -136,7 +143,7 @@ function EntityCreate({
                     <Error error={connectorTagsError} />
                 ) : (
                     <>
-                        <Collapse in={formSubmitError !== null}>
+                        <Collapse in={formSubmitError !== null} unmountOnExit>
                             {formSubmitError ? (
                                 <EntityError
                                     title={formSubmitError.title}
@@ -148,11 +155,11 @@ function EntityCreate({
                         </Collapse>
 
                         {!isValidating && connectorTags.length === 0 ? (
-                            <Alert severity="warning">
+                            <AlertBox severity="warning">
                                 <FormattedMessage
                                     id={`${messagePrefix}.missingConnectors`}
                                 />
-                            </Alert>
+                            </AlertBox>
                         ) : connectorTags.length > 0 ? (
                             <ErrorBoundryWrapper>
                                 <DetailsForm

--- a/src/components/shared/Entity/DetailsForm/Form.tsx
+++ b/src/components/shared/Entity/DetailsForm/Form.tsx
@@ -1,7 +1,8 @@
 import { materialCells } from '@jsonforms/material-renderers';
 import { JsonForms } from '@jsonforms/react';
-import { Alert, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import { useEditorStore_isSaving } from 'components/editor/Store';
+import AlertBox from 'components/shared/AlertBox';
 import { Props } from 'components/shared/Entity/DetailsForm/types';
 import useEntityCreateNavigate from 'components/shared/Entity/hooks/useEntityCreateNavigate';
 import { CATALOG_NAME_SCOPE } from 'forms/renderers/CatalogName';
@@ -207,11 +208,13 @@ function DetailsFormForm({
             </Typography>
 
             {readOnly ? (
-                <Alert color="info" style={{ marginBottom: 8 }}>
-                    {intl.formatMessage({
-                        id: 'entityEdit.alert.detailsFormDisabled',
-                    })}
-                </Alert>
+                <Box sx={{ mb: 2 }}>
+                    <AlertBox short severity="info">
+                        {intl.formatMessage({
+                            id: 'entityEdit.alert.detailsFormDisabled',
+                        })}
+                    </AlertBox>
+                </Box>
             ) : null}
 
             <Stack direction="row" spacing={2}>
@@ -230,18 +233,18 @@ function DetailsFormForm({
                             onChange={updateDetails}
                         />
                     ) : (
-                        <Alert severity="warning">
+                        <AlertBox severity="warning" short>
                             <FormattedMessage
                                 id={`${messagePrefix}.noAccessGrants`}
                             />
-                        </Alert>
+                        </AlertBox>
                     )
                 ) : (
-                    <Alert severity="warning">
+                    <AlertBox severity="warning" short>
                         <FormattedMessage
                             id={`${messagePrefix}.missingConnectors`}
                         />
-                    </Alert>
+                    </AlertBox>
                 )}
             </Stack>
         </>

--- a/src/components/shared/Entity/Edit.tsx
+++ b/src/components/shared/Entity/Edit.tsx
@@ -1,4 +1,4 @@
-import { Alert, Collapse } from '@mui/material';
+import { Collapse } from '@mui/material';
 import { RealtimeSubscription } from '@supabase/supabase-js';
 import { createEntityDraft } from 'api/drafts';
 import { createDraftSpec, updateDraftSpec } from 'api/draftSpecs';
@@ -52,6 +52,7 @@ import {
 } from 'stores/FormState';
 import { ENTITY, JsonFormsData, Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
+import AlertBox from '../AlertBox';
 
 interface Props {
     title: string;
@@ -346,11 +347,11 @@ function EntityEdit({
                     </Collapse>
 
                     {!isValidating && connectorTags.length === 0 ? (
-                        <Alert severity="warning">
+                        <AlertBox severity="warning" short>
                             <FormattedMessage
                                 id={`${messagePrefix}.missingConnectors`}
                             />
-                        </Alert>
+                        </AlertBox>
                     ) : connectorTags.length > 0 ? (
                         <ErrorBoundryWrapper>
                             <DetailsForm

--- a/src/components/shared/Entity/Edit.tsx
+++ b/src/components/shared/Entity/Edit.tsx
@@ -32,7 +32,7 @@ import {
     useLiveSpecsExtWithSpec,
 } from 'hooks/useLiveSpecsExt';
 import { isEmpty } from 'lodash';
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
     Details,
@@ -64,8 +64,9 @@ interface Props {
     };
     callFailed: (formState: any, subscription?: RealtimeSubscription) => void;
     resetState: () => void;
-    Header: any;
+    toolbar: ReactNode;
     showCollections?: boolean;
+    errorSummary: ReactNode;
 }
 
 interface InitializationHelpers {
@@ -164,12 +165,13 @@ const initDraftToEdit = async (
 function EntityEdit({
     title,
     entityType,
-    Header,
+    toolbar,
     callFailed,
     showCollections,
     readOnly,
     promptDataLoss,
     resetState,
+    errorSummary,
 }: Props) {
     useBrowserTitle(title);
 
@@ -326,7 +328,7 @@ function EntityEdit({
 
     return (
         <>
-            {Header}
+            {errorSummary}
 
             {connectorTagsError ? (
                 <Error error={connectorTagsError} />
@@ -385,6 +387,8 @@ function EntityEdit({
                     </ErrorBoundryWrapper>
                 </>
             )}
+
+            {toolbar}
         </>
     );
 }

--- a/src/components/shared/Entity/Edit.tsx
+++ b/src/components/shared/Entity/Edit.tsx
@@ -329,6 +329,8 @@ function EntityEdit({
 
     return (
         <>
+            {toolbar}
+
             {errorSummary}
 
             {connectorTagsError ? (
@@ -388,8 +390,6 @@ function EntityEdit({
                     </ErrorBoundryWrapper>
                 </>
             )}
-
-            {toolbar}
         </>
     );
 }

--- a/src/components/shared/Entity/EndpointConfig/Form.tsx
+++ b/src/components/shared/Entity/EndpointConfig/Form.tsx
@@ -9,7 +9,6 @@ import {
     custom_generateDefaultUISchema,
     defaultOptions,
     defaultRenderers,
-    generateCategoryUiSchema,
     showValidation,
 } from 'services/jsonforms';
 import {
@@ -51,13 +50,7 @@ function EndpointConfigForm({ readOnly, initialEndpointConfig }: Props) {
 
     const categoryLikeSchema = useMemo(() => {
         if (!isEmpty(endpointSchema)) {
-            const generatedSchema = generateCategoryUiSchema(
-                custom_generateDefaultUISchema(endpointSchema)
-            );
-
-            console.log('generatedSchema', generatedSchema);
-
-            return generatedSchema;
+            return custom_generateDefaultUISchema(endpointSchema);
         } else {
             return null;
         }
@@ -75,6 +68,7 @@ function EndpointConfigForm({ readOnly, initialEndpointConfig }: Props) {
                 id={CONFIG_EDITOR_ID}
                 sx={{
                     ...jsonFormsPadding,
+                    // TODO (horizontal forms) : potential styling for making form horizontal
                     // '& .MuiAccordionDetails-root .MuiGrid-root.MuiGrid-item > .MuiFormControl-root':
                     //     {
                     //         background: 'red',

--- a/src/components/shared/Entity/EndpointConfig/Form.tsx
+++ b/src/components/shared/Entity/EndpointConfig/Form.tsx
@@ -55,6 +55,8 @@ function EndpointConfigForm({ readOnly, initialEndpointConfig }: Props) {
                 custom_generateDefaultUISchema(endpointSchema)
             );
 
+            console.log('generatedSchema', generatedSchema);
+
             return generatedSchema;
         } else {
             return null;
@@ -73,6 +75,11 @@ function EndpointConfigForm({ readOnly, initialEndpointConfig }: Props) {
                 id={CONFIG_EDITOR_ID}
                 sx={{
                     ...jsonFormsPadding,
+                    // '& .MuiAccordionDetails-root .MuiGrid-root.MuiGrid-item > .MuiFormControl-root':
+                    //     {
+                    //         background: 'red',
+                    //         minWidth: 300,
+                    //     },
                 }}
             >
                 <JsonForms

--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -1,5 +1,6 @@
-import { Alert } from '@mui/material';
+import { Box } from '@mui/material';
 import { useEditorStore_id } from 'components/editor/Store';
+import AlertBox from 'components/shared/AlertBox';
 import EndpointConfigForm from 'components/shared/Entity/EndpointConfig/Form';
 import EndpointConfigHeader from 'components/shared/Entity/EndpointConfig/Header';
 import WrapperWithHeader from 'components/shared/Entity/WrapperWithHeader';
@@ -39,11 +40,13 @@ function EndpointConfig({
                 }
             >
                 {readOnly ? (
-                    <Alert color="info" style={{ marginBottom: 8 }}>
-                        {intl.formatMessage({
-                            id: 'entityEdit.alert.endpointConfigDisabled',
-                        })}
-                    </Alert>
+                    <Box sx={{ mb: 3 }}>
+                        <AlertBox severity="info" short>
+                            {intl.formatMessage({
+                                id: 'entityEdit.alert.endpointConfigDisabled',
+                            })}
+                        </AlertBox>
+                    </Box>
                 ) : null}
 
                 <EndpointConfigForm

--- a/src/components/shared/Entity/Error/DraftErrors.tsx
+++ b/src/components/shared/Entity/Error/DraftErrors.tsx
@@ -11,8 +11,8 @@ function DraftErrors({ draftId, enablePolling }: DraftErrorProps) {
 
     if (draftSpecErrors.length > 0) {
         const errors: KeyValue[] = draftSpecErrors.map((draftError) => ({
-            title: draftError.scope,
-            val: draftError.detail,
+            title: draftError.detail,
+            val: draftError.scope,
         }));
         return <KeyValueList data={errors} />;
     } else {

--- a/src/components/shared/Entity/Error/Logs.tsx
+++ b/src/components/shared/Entity/Error/Logs.tsx
@@ -1,13 +1,9 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
-    Box,
-    Typography,
-} from '@mui/material';
+import { Button, Collapse, Stack } from '@mui/material';
 import Logs, { type LogProps } from 'components/logs';
 import ErrorBoundryWrapper from 'components/shared/ErrorBoundryWrapper';
+import { LINK_BUTTON_STYLING } from 'context/Theme';
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 export interface ErrorLogsProps {
@@ -24,35 +20,49 @@ function ErrorLogs({
     logProps,
 }: ErrorLogsProps) {
     const heightVal = height ?? 250;
+    const [showLogs, setShowLogs] = useState(defaultOpen ?? false);
+
+    const toggleLogs = () => {
+        setShowLogs(!showLogs);
+    };
 
     if (logToken) {
         return (
-            <Accordion
-                defaultExpanded={defaultOpen ?? false}
-                TransitionProps={{ unmountOnExit: true }}
-            >
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <Typography>
-                        <FormattedMessage id="entityCreate.errors.collapseTitle" />
-                    </Typography>
-                </AccordionSummary>
-
-                <AccordionDetails>
-                    <Box
-                        sx={{
-                            width: '100%',
-                        }}
-                    >
-                        <ErrorBoundryWrapper>
-                            <Logs
-                                {...logProps}
-                                token={logToken}
-                                height={heightVal}
-                            />
-                        </ErrorBoundryWrapper>
-                    </Box>
-                </AccordionDetails>
-            </Accordion>
+            <Stack>
+                <Button
+                    variant="text"
+                    sx={{ ...LINK_BUTTON_STYLING, width: 'max-content' }}
+                    onClick={toggleLogs}
+                    endIcon={
+                        <ExpandMoreIcon
+                            sx={{
+                                transform: `rotate(${
+                                    showLogs ? '180' : '0'
+                                }deg)`,
+                                transition: (theme) =>
+                                    `${theme.transitions.duration.shortest}ms`,
+                            }}
+                        />
+                    }
+                >
+                    <FormattedMessage
+                        id={
+                            showLogs
+                                ? 'entityCreate.errors.collapseTitleOpen'
+                                : 'entityCreate.errors.collapseTitle'
+                        }
+                    />
+                </Button>
+                <Collapse in={showLogs} unmountOnExit>
+                    <ErrorBoundryWrapper>
+                        <Logs
+                            {...logProps}
+                            token={logToken}
+                            height={heightVal}
+                        />
+                    </ErrorBoundryWrapper>
+                </Collapse>
+            </Stack>
         );
     } else {
         return null;

--- a/src/components/shared/Entity/Error/index.tsx
+++ b/src/components/shared/Entity/Error/index.tsx
@@ -27,7 +27,12 @@ function EntityError({ logToken, error, title, draftId }: Props) {
                     {draftId ? <DraftErrors draftId={draftId} /> : null}
                 </Box>
 
-                <ErrorLogs logToken={logToken} />
+                <ErrorLogs
+                    logToken={logToken}
+                    logProps={{
+                        fetchAll: true,
+                    }}
+                />
             </Stack>
         </HeaderSummary>
     );

--- a/src/components/shared/Entity/Header.tsx
+++ b/src/components/shared/Entity/Header.tsx
@@ -1,12 +1,10 @@
 import {
-    Box,
     Collapse,
     LinearProgress,
     Stack,
     SxProps,
     Theme,
     Toolbar,
-    Typography,
 } from '@mui/material';
 import { ReactNode } from 'react';
 import { useFormStateStore_isActive } from 'stores/FormState';
@@ -16,28 +14,16 @@ interface Props {
     GenerateButton?: ReactNode;
     TestButton: ReactNode;
     SaveButton: ReactNode;
-    heading: ReactNode;
-    ErrorSummary: ReactNode;
 }
 
 export const buttonSx: SxProps<Theme> = { ml: 1 };
 
-function FooHeader({
-    GenerateButton,
-    TestButton,
-    SaveButton,
-    heading,
-    ErrorSummary,
-}: Props) {
+function EntityToolbar({ GenerateButton, TestButton, SaveButton }: Props) {
     const formActive = useFormStateStore_isActive();
 
     return (
         <Stack spacing={2} sx={{ mb: 1 }}>
             <Toolbar disableGutters>
-                <Typography variant="h6" noWrap>
-                    {heading}
-                </Typography>
-
                 <Stack
                     direction="row"
                     alignItems="center"
@@ -61,10 +47,8 @@ function FooHeader({
             <Collapse in={formActive} unmountOnExit>
                 <LinearProgress />
             </Collapse>
-
-            <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>{ErrorSummary}</Box>
         </Stack>
     );
 }
 
-export default FooHeader;
+export default EntityToolbar;

--- a/src/components/shared/Entity/HeaderSummary.tsx
+++ b/src/components/shared/Entity/HeaderSummary.tsx
@@ -1,29 +1,22 @@
-import { Alert, AlertProps, AlertTitle, Box } from '@mui/material';
+import { AlertColor, Box } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import { BaseComponentProps } from 'types';
+import AlertBox from '../AlertBox';
 
 interface Props extends BaseComponentProps {
-    severity: AlertProps['severity'];
+    severity: AlertColor;
     title: string;
 }
 
 function HeaderSummary({ severity, title, children }: Props) {
     return (
         <Box sx={{ width: '100%', mb: 2 }}>
-            <Alert
-                icon={false}
-                sx={{
-                    'width': '100%',
-                    '& .MuiAlert-message': { width: '100%' },
-                }}
+            <AlertBox
                 severity={severity}
-                variant="standard"
+                title={<FormattedMessage id={title} />}
             >
-                <AlertTitle>
-                    <FormattedMessage id={title} />
-                </AlertTitle>
                 {children}
-            </Alert>
+            </AlertBox>
         </Box>
     );
 }

--- a/src/components/shared/Entity/HeaderSummary.tsx
+++ b/src/components/shared/Entity/HeaderSummary.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertProps, AlertTitle, Box, useTheme } from '@mui/material';
+import { Alert, AlertProps, AlertTitle, Box } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import { BaseComponentProps } from 'types';
 
@@ -8,8 +8,6 @@ interface Props extends BaseComponentProps {
 }
 
 function HeaderSummary({ severity, title, children }: Props) {
-    const theme = useTheme();
-
     return (
         <Box sx={{ width: '100%', mb: 2 }}>
             <Alert
@@ -19,7 +17,7 @@ function HeaderSummary({ severity, title, children }: Props) {
                     '& .MuiAlert-message': { width: '100%' },
                 }}
                 severity={severity}
-                variant={theme.palette.mode === 'dark' ? 'standard' : 'filled'}
+                variant="standard"
             >
                 <AlertTitle>
                     <FormattedMessage id={title} />

--- a/src/components/shared/Entity/LogDialog.tsx
+++ b/src/components/shared/Entity/LogDialog.tsx
@@ -34,10 +34,6 @@ function LogDialog({ open, token, actionComponent, title }: Props) {
                     backgroundColor:
                         theme.palette.mode === 'dark' ? slate[800] : slate[25],
                     borderRadius: 5,
-                    backgroundImage:
-                        theme.palette.mode === 'dark'
-                            ? 'linear-gradient(160deg, rgba(99, 138, 169, 0.24) 0%, rgba(13, 43, 67, 0.22) 75%, rgba(13, 43, 67, 0.18) 100%)'
-                            : 'linear-gradient(160deg, rgba(246, 250, 255, 0.4) 0%, rgba(216, 233, 245, 0.4) 75%, rgba(172, 199, 220, 0.4) 100%)',
                 },
                 '& .MuiAccordionSummary-root': {
                     backgroundColor:

--- a/src/components/shared/Entity/Status.tsx
+++ b/src/components/shared/Entity/Status.tsx
@@ -1,10 +1,11 @@
-import { Alert, AlertColor, Typography } from '@mui/material';
+import { AlertColor, Typography } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import {
     FormStatus,
     useFormStateStore_isActive,
     useFormStateStore_status,
 } from 'stores/FormState';
+import AlertBox from '../AlertBox';
 
 function Status() {
     const formStatus = useFormStateStore_status();
@@ -24,15 +25,11 @@ function Status() {
     if (messageKey) {
         if (severity) {
             return (
-                <Alert
-                    severity={severity}
-                    variant="outlined"
-                    sx={{ border: 0 }}
-                >
+                <AlertBox severity={severity}>
                     <Typography sx={{ mr: 1 }}>
                         <FormattedMessage id={messageKey} />
                     </Typography>
-                </Alert>
+                </AlertBox>
             );
         } else {
             return (

--- a/src/components/shared/Entity/ValidationErrorSummary/capture/index.tsx
+++ b/src/components/shared/Entity/ValidationErrorSummary/capture/index.tsx
@@ -1,4 +1,5 @@
-import { Alert, AlertTitle, Collapse } from '@mui/material';
+import { Collapse } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import DetailsErrors from 'components/shared/Entity/ValidationErrorSummary/DetailsErrors';
 import EndpointConfigErrors from 'components/shared/Entity/ValidationErrorSummary/EndpointConfigErrors';
 import NoConnectorError from 'components/shared/Entity/ValidationErrorSummary/NoConnectorError';
@@ -28,16 +29,18 @@ function ValidationErrorSummary({
 
     return displayValidation ? (
         <Collapse in={errorsExist} timeout="auto" unmountOnExit>
-            <Alert severity="error" icon={hideIcon ?? undefined}>
-                <AlertTitle>
+            <AlertBox
+                hideIcon={hideIcon}
+                severity="error"
+                title={
                     <FormattedMessage
                         id={
                             headerMessageId ??
                             'entityCreate.endpointConfig.errorSummary'
                         }
                     />
-                </AlertTitle>
-
+                }
+            >
                 {ErrorComponent === false ? null : ErrorComponent ? (
                     <ErrorComponent />
                 ) : hasLength(connectorID) ? (
@@ -49,7 +52,7 @@ function ValidationErrorSummary({
                 ) : (
                     <NoConnectorError />
                 )}
-            </Alert>
+            </AlertBox>
         </Collapse>
     ) : null;
 }

--- a/src/components/shared/Entity/ValidationErrorSummary/materialization/index.tsx
+++ b/src/components/shared/Entity/ValidationErrorSummary/materialization/index.tsx
@@ -1,5 +1,6 @@
-import { Alert, AlertTitle, Collapse } from '@mui/material';
+import { AlertTitle, Collapse } from '@mui/material';
 import MessageWithLink from 'components/content/MessageWithLink';
+import AlertBox from 'components/shared/AlertBox';
 import DetailsErrors from 'components/shared/Entity/ValidationErrorSummary/DetailsErrors';
 import EndpointConfigErrors from 'components/shared/Entity/ValidationErrorSummary/EndpointConfigErrors';
 import NoConnectorError from 'components/shared/Entity/ValidationErrorSummary/NoConnectorError';
@@ -53,11 +54,12 @@ function ValidationErrorSummary({
             timeout="auto"
             unmountOnExit
         >
-            <Alert severity="error" icon={hideIcon ?? undefined}>
+            <AlertBox severity="error" hideIcon={hideIcon}>
                 <AlertTitle>
                     <FormattedMessage
                         id={headerMessageId ?? defaultHeaderMessageId}
                     />
+                    s
                 </AlertTitle>
 
                 {resourceConfigHydrationErrorsExist ? (
@@ -77,7 +79,7 @@ function ValidationErrorSummary({
                 ) : (
                     <NoConnectorError />
                 )}
-            </Alert>
+            </AlertBox>
         </Collapse>
     ) : null;
 }

--- a/src/components/shared/Error.tsx
+++ b/src/components/shared/Error.tsx
@@ -1,6 +1,5 @@
 import { ExpandMore } from '@mui/icons-material';
 import {
-    Alert,
     AlertTitle,
     Box,
     Collapse,
@@ -16,6 +15,7 @@ import KeyValueList, { KeyValue } from 'components/shared/KeyValueList';
 import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { hasLength } from 'utils/misc-utils';
+import AlertBox from './AlertBox';
 
 export interface ErrorProps {
     error?: PostgrestError | any | null;
@@ -64,13 +64,16 @@ function Error({ error, hideTitle }: ErrorProps) {
 
         return (
             <Box sx={{ width: '100%' }}>
-                <Alert severity="error" icon={!hideTitle}>
-                    {!hideTitle ? (
-                        <AlertTitle>
-                            <FormattedMessage id="error.title" />
-                        </AlertTitle>
-                    ) : null}
-
+                <AlertBox
+                    severity="error"
+                    title={
+                        !hideTitle ? (
+                            <AlertTitle>
+                                <FormattedMessage id="error.title" />
+                            </AlertTitle>
+                        ) : null
+                    }
+                >
                     <Box>
                         <MessageWithLink messageID="error.message" />
                     </Box>
@@ -114,7 +117,7 @@ function Error({ error, hideTitle }: ErrorProps) {
                             </Collapse>
                         </>
                     ) : null}
-                </Alert>
+                </AlertBox>
             </Box>
         );
     } else {

--- a/src/components/shared/ErrorBoundryWrapper.tsx
+++ b/src/components/shared/ErrorBoundryWrapper.tsx
@@ -1,15 +1,9 @@
 import { ExpandMore } from '@mui/icons-material';
-import {
-    Alert,
-    AlertTitle,
-    Collapse,
-    Divider,
-    IconButton,
-    Paper,
-} from '@mui/material';
+import { Collapse, Divider, IconButton, Paper } from '@mui/material';
 import React, { ReactNode } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { FormattedMessage, useIntl } from 'react-intl';
+import AlertBox from './AlertBox';
 
 interface Props {
     children: ReactNode;
@@ -25,10 +19,10 @@ function ErrorFallback({ error }: { error: Error }): JSX.Element {
     };
 
     return (
-        <Alert severity="error">
-            <AlertTitle>
-                <FormattedMessage id="errorBoundry.title" />
-            </AlertTitle>
+        <AlertBox
+            severity="error"
+            title={<FormattedMessage id="errorBoundry.title" />}
+        >
             <FormattedMessage id="errorBoundry.message1" />
             <FormattedMessage id="errorBoundry.message2" />
 
@@ -54,7 +48,7 @@ function ErrorFallback({ error }: { error: Error }): JSX.Element {
                     {error.stack}
                 </Paper>
             </Collapse>
-        </Alert>
+        </AlertBox>
     );
 }
 

--- a/src/components/shared/PageContainer.tsx
+++ b/src/components/shared/PageContainer.tsx
@@ -1,18 +1,12 @@
-import {
-    Alert,
-    Container,
-    Paper,
-    Snackbar,
-    Toolbar,
-    useTheme,
-} from '@mui/material';
+import { Box, Container, Snackbar, Toolbar, useTheme } from '@mui/material';
 import { PageTitleProps } from 'components/navigation/PageTitle';
 import Topbar from 'components/navigation/TopBar';
-import { darkGlassBkgWithBlur, lightGlassBkgWithBlur } from 'context/Theme';
+import { glassBkgWithBlur } from 'context/Theme';
 import { ReactNode, useEffect, useState } from 'react';
 import useNotificationStore, {
     NotificationState,
 } from 'stores/NotificationStore';
+import AlertBox from './AlertBox';
 
 interface Props {
     children: ReactNode | ReactNode[];
@@ -28,10 +22,7 @@ const selectors = {
 
 function PageContainer({ children, pageTitleProps }: Props) {
     const theme = useTheme();
-    const backgroundSx =
-        theme.palette.mode === 'dark'
-            ? darkGlassBkgWithBlur
-            : lightGlassBkgWithBlur;
+    const backgroundSx = glassBkgWithBlur[theme.palette.mode];
 
     const notification = useNotificationStore(selectors.notification);
 
@@ -57,7 +48,7 @@ function PageContainer({ children, pageTitleProps }: Props) {
         <Container
             maxWidth={false}
             sx={{
-                paddingTop: 2,
+                paddingTop: 3,
             }}
         >
             {notification ? (
@@ -66,26 +57,24 @@ function PageContainer({ children, pageTitleProps }: Props) {
                     autoHideDuration={5000}
                     onClose={handlers.notificationClose}
                 >
-                    <Alert severity={notification.severity} variant="filled">
+                    <AlertBox severity={notification.severity}>
                         {`${notification.title}. ${notification.description}`}
-                    </Alert>
+                    </AlertBox>
                 </Snackbar>
             ) : null}
 
             <Topbar pageTitleProps={pageTitleProps} />
             <Toolbar />
 
-            <Paper
+            <Box
                 sx={{
-                    padding: 2,
+                    p: 2,
                     width: '100%',
-                    borderRadius: 5,
                     ...backgroundSx,
                 }}
-                variant="outlined"
             >
                 {children}
-            </Paper>
+            </Box>
         </Container>
     );
 }

--- a/src/components/tables/Details/DetailsPanel.tsx
+++ b/src/components/tables/Details/DetailsPanel.tsx
@@ -12,7 +12,10 @@ import { createEditorStore } from 'components/editor/Store';
 import EditorAndLogs from 'components/tables/Details/EditorAndLogs';
 import ShardInformation from 'components/tables/Details/ShardInformation';
 import { LocalZustandProvider } from 'context/LocalZustand';
-import { darkGlassBkgColorIntensified, tableBorderSx } from 'context/Theme';
+import {
+    semiTransparentBackgroundIntensified,
+    tableBorderSx,
+} from 'context/Theme';
 import { EditorStoreNames } from 'context/Zustand';
 import { concat } from 'lodash';
 import { useMemo } from 'react';
@@ -61,9 +64,9 @@ function DetailsPanel({
                         mb: 2,
                         mt: 0,
                         bgcolor: (theme) =>
-                            theme.palette.mode === 'dark'
-                                ? darkGlassBkgColorIntensified
-                                : 'rgba(172, 199, 220, 0.45)',
+                            semiTransparentBackgroundIntensified[
+                                theme.palette.mode
+                            ],
                     }}
                     unmountOnExit
                 >

--- a/src/components/tables/Details/EditorAndLogs.tsx
+++ b/src/components/tables/Details/EditorAndLogs.tsx
@@ -1,4 +1,4 @@
-import { Alert, Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 import LiveSpecEditor from 'components/editor/LiveSpec';
 import { DEFAULT_TOTAL_HEIGHT } from 'components/editor/MonacoEditor';
 import {
@@ -6,6 +6,7 @@ import {
     useEditorStore_setSpecs,
 } from 'components/editor/Store';
 import Logs from 'components/logs';
+import AlertBox from 'components/shared/AlertBox';
 import Error from 'components/shared/Error';
 import { useLiveSpecs_spec } from 'hooks/useLiveSpecs';
 import usePublications from 'hooks/usePublications';
@@ -60,9 +61,9 @@ function EditorAndLogs({
 
                 <Grid item xs={6}>
                     {pubsError && !disableLogs ? (
-                        <Alert variant="filled" severity="warning">
+                        <AlertBox severity="warning" short>
                             <FormattedMessage id="detailsPanel.logs.notFound" />
-                        </Alert>
+                        </AlertBox>
                     ) : !disableLogs && publications !== null ? (
                         <Logs
                             token={publications.logs_token}

--- a/src/components/tables/RowActions/Delete/Confirmation.tsx
+++ b/src/components/tables/RowActions/Delete/Confirmation.tsx
@@ -1,18 +1,21 @@
-import { Alert, AlertTitle, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import { FormattedMessage } from 'react-intl';
 
 function DeleteConfirmation() {
     return (
-        <Alert variant="filled" severity="warning">
-            <AlertTitle>
+        <AlertBox
+            severity="warning"
+            title={
                 <Typography component="div">
                     <FormattedMessage id="common.noUnDo" />
                 </Typography>
-            </AlertTitle>
+            }
+        >
             <Typography component="div">
                 <FormattedMessage id="capturesTable.delete.confirm" />
             </Typography>
-        </Alert>
+        </AlertBox>
     );
 }
 

--- a/src/components/tables/RowActions/DisableEnable/Confirmation.tsx
+++ b/src/components/tables/RowActions/DisableEnable/Confirmation.tsx
@@ -1,10 +1,11 @@
-import { Alert, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import { DisableEnableButtonProps } from 'components/tables/RowActions/DisableEnable/Button';
 import { FormattedMessage } from 'react-intl';
 
 function DisableEnableConfirmation({ enabling }: DisableEnableButtonProps) {
     return (
-        <Alert variant="filled" severity="info">
+        <AlertBox severity="info" short>
             <Typography component="div">
                 <FormattedMessage
                     id="capturesTable.disableEnable.confirm"
@@ -21,7 +22,7 @@ function DisableEnableConfirmation({ enabling }: DisableEnableButtonProps) {
                     }}
                 />
             </Typography>
-        </Alert>
+        </AlertBox>
     );
 }
 

--- a/src/components/tables/RowActions/Shared/Button.tsx
+++ b/src/components/tables/RowActions/Shared/Button.tsx
@@ -6,7 +6,7 @@ import {
     selectableTableStoreSelectors,
 } from 'components/tables/Store';
 import { useConfirmationModalContext } from 'context/Confirmation';
-import { slate } from 'context/Theme';
+import { glassBkgWithoutBlur } from 'context/Theme';
 import { SelectTableStoreNames, useZustandStore } from 'context/Zustand';
 import { ReactNode, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -100,14 +100,8 @@ function RowActionButton({
                 sx={{
                     '& .MuiPaper-root.MuiDialog-paper': {
                         backgroundColor: (themes) =>
-                            themes.palette.mode === 'dark'
-                                ? slate[800]
-                                : slate[25],
+                            glassBkgWithoutBlur[themes.palette.mode],
                         borderRadius: 5,
-                        backgroundImage: (themes) =>
-                            themes.palette.mode === 'dark'
-                                ? 'linear-gradient(160deg, rgba(99, 138, 169, 0.24) 0%, rgba(13, 43, 67, 0.22) 75%, rgba(13, 43, 67, 0.18) 100%)'
-                                : 'linear-gradient(160deg, rgba(246, 250, 255, 0.4) 0%, rgba(216, 233, 245, 0.4) 75%, rgba(172, 199, 220, 0.4) 100%)',
                     },
                 }}
             >

--- a/src/context/Confirmation.tsx
+++ b/src/context/Confirmation.tsx
@@ -6,7 +6,7 @@ import {
     DialogContent,
     DialogTitle,
 } from '@mui/material';
-import { slate } from 'context/Theme';
+import { glassBkgWithoutBlur, slate } from 'context/Theme';
 import { createContext, ReactNode, useContext, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { BaseComponentProps } from 'types';
@@ -84,15 +84,9 @@ const ConfirmationModalContextProvider = ({ children }: BaseComponentProps) => {
                 aria-describedby={DESCRIPTION_ID}
                 sx={{
                     '& .MuiPaper-root.MuiDialog-paper': {
-                        backgroundColor: (themes) =>
-                            themes.palette.mode === 'dark'
-                                ? slate[800]
-                                : slate[25],
+                        backgroundColor: (theme) =>
+                            glassBkgWithoutBlur[theme.palette.mode],
                         borderRadius: 5,
-                        backgroundImage: (themes) =>
-                            themes.palette.mode === 'dark'
-                                ? 'linear-gradient(160deg, rgba(99, 138, 169, 0.24) 0%, rgba(13, 43, 67, 0.22) 75%, rgba(13, 43, 67, 0.18) 100%)'
-                                : 'linear-gradient(160deg, rgba(246, 250, 255, 0.4) 0%, rgba(216, 233, 245, 0.4) 75%, rgba(172, 199, 220, 0.4) 100%)',
                     },
                 }}
             >

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -200,6 +200,10 @@ export const alertTextPrimary = {
     light: 'rgba(0, 0, 0, 0.8)',
     dark: 'rgb(255, 255, 255)',
 };
+export const alertBackground = {
+    light: 'white',
+    dark: semiTransparentBackgroundIntensified.dark,
+};
 
 const expandedRowBgColor = {
     light: slate[50],

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -159,45 +159,64 @@ export const outlineSx: SxProps<Theme> = {
     border: `1px solid ${slate[200]}`,
 };
 
-// TODO: Either drop "color" in all variables, as the distinction is no longer required, or introduce the word
-// "color" in all variables setting the backgroundColor property.
-export const darkGlassBkgColor = 'rgba(172, 199, 220, 0.12)';
-export const darkGlassBkgColorIntensified = 'rgba(172, 199, 220, 0.18)';
-
-// TODO: Set the backgroundColor property, not the background property. The background property was previously set
-// because of the use of linear-gradient.
-export const darkGlassBkgWithBlur = {
-    background: 'rgb(13, 43, 67)',
+// TODO (Colors) need to follow a pattern where all colors are in the theme file.
+//      this is one way to handle the light/dark mode:
+export const glassBkgWithBlur = {
+    light: {
+        background: 'white',
+    },
+    dark: {
+        background: 'rgb(13, 43, 67)',
+    },
 };
 
-export const darkGlassBkgWithoutBlur = {
-    background: 'rgb(13, 43, 67)',
-    borderRadius: 5,
+export const glassBkgWithoutBlur = {
+    light: {
+        background: 'white',
+        borderRadius: 5,
+    },
+    dark: {
+        background: 'rgb(13, 43, 67)',
+        borderRadius: 5,
+    },
 };
 
-export const lightGlassBkgWithBlur = {
-    background: 'white',
+export const semiTransparentBackground = {
+    light: slate[25],
+    dark: 'rgba(172, 199, 220, 0.12)',
 };
 
-export const lightGlassBkgWithoutBlur = {
-    background: 'white',
-    borderRadius: 5,
+export const semiTransparentBackgroundIntensified = {
+    light: slate[50],
+    dark: 'rgba(172, 199, 220, 0.18)',
 };
 
+export const jsonFormsGroupHeaders = {
+    light: slate[25],
+    dark: 'transparent',
+};
+
+export const alertTextPrimary = {
+    light: 'rgba(0, 0, 0, 0.8)',
+    dark: 'rgb(255, 255, 255)',
+};
+
+const expandedRowBgColor = {
+    light: slate[50],
+    dark: slate[800],
+};
 export const getEntityTableRowSx = (
     theme: Theme,
     detailsExpanded: boolean
 ): SxProps<Theme> => {
-    const expandedRowBgColor =
-        theme.palette.mode === 'dark' ? slate[800] : slate[50];
-
     return {
-        background: detailsExpanded ? expandedRowBgColor : null,
+        background: detailsExpanded
+            ? expandedRowBgColor[theme.palette.mode]
+            : null,
         cursor: 'pointer',
     };
 };
 
-// TODO (theme) Figure out how to make these composable
 export const truncateTextSx: SxProps<Theme> = {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -218,6 +237,7 @@ export const jsonFormsPadding: SxProps<Theme> = {
     },
 };
 
+// Used to make buttons look like a normal(ish) link
 export const LINK_BUTTON_STYLING: SxProps<Theme> = {
     'px': 1,
     'py': 0,

--- a/src/forms/renderers/CollapsibleGroup.tsx
+++ b/src/forms/renderers/CollapsibleGroup.tsx
@@ -12,7 +12,7 @@ import {
     Hidden,
     Typography,
 } from '@mui/material';
-import { slate } from 'context/Theme';
+import { jsonFormsGroupHeaders } from 'context/Theme';
 
 export const CollapsibleGroupType = 'CollapsibleGroup';
 
@@ -46,18 +46,12 @@ const CollapsibleGroupRenderer = ({
 
     return (
         <Hidden xsUp={!visible}>
-            <Accordion
-                defaultExpanded={expand}
-                disableGutters
-                variant="elevation"
-            >
+            <Accordion defaultExpanded={expand}>
                 <AccordionSummary
                     expandIcon={<ExpandMoreIcon />}
                     sx={{
                         backgroundColor: (theme) =>
-                            theme.palette.mode === 'dark'
-                                ? 'transparent'
-                                : slate[50],
+                            jsonFormsGroupHeaders[theme.palette.mode],
                     }}
                 >
                     <Typography>{uischema.label}</Typography>

--- a/src/forms/renderers/CollapsibleGroup.tsx
+++ b/src/forms/renderers/CollapsibleGroup.tsx
@@ -46,7 +46,11 @@ const CollapsibleGroupRenderer = ({
 
     return (
         <Hidden xsUp={!visible}>
-            <Accordion defaultExpanded={expand}>
+            <Accordion
+                defaultExpanded={expand}
+                disableGutters
+                variant="elevation"
+            >
                 <AccordionSummary
                     expandIcon={<ExpandMoreIcon />}
                     sx={{

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -60,6 +60,12 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'connectionConfig.header': `Connection Config`,
 
     'commin.pathShort.prefix': '.../{path}',
+
+    // Alert messages
+    'alert.error': 'Error!',
+    'alert.warning': 'Warning!',
+    'alert.success': 'Success!',
+    'alert.info': 'Important!',
 };
 
 const CTAs: ResolvedIntlConfig['messages'] = {
@@ -408,7 +414,7 @@ const Collections: ResolvedIntlConfig['messages'] = {
     'collections.message2.docLink': `collections`,
     'collections.message2.docPath': `https://docs.estuary.dev/concepts/collections/`,
     'collectionsPreview.notFound.title': `Not Found`,
-    'collectionsPreview.notFound.message': `We were unable to find the journals to display the preview. This could mean the Capture has not injested data yet or is not running. Check the status on the Captures page to make sure it is running.`,
+    'collectionsPreview.notFound.message': `We were unable to find the journals to display the preview. This could mean there is no injested data yet.`,
     'collectionsPreview.tooFewDocuments.title': `Low document count`,
     'collectionsPreview.tooFewDocuments.message': `Fewer documents than desired were found. This could mean that your collection isn't seeing very much data.`,
     'collectionsPreview.tooManyBytes.title': `Large documents`,
@@ -421,7 +427,8 @@ const entityCreateHeader = `Endpoint Config`;
 const EntityCreate: ResolvedIntlConfig['messages'] = {
     'entityCreate.catalogEditor.heading': `Specification Editor`,
     'entityCreate.ctas.docs': `Connector Help`,
-    'entityCreate.errors.collapseTitle': `Expand to see logs`,
+    'entityCreate.errors.collapseTitle': `View logs`,
+    'entityCreate.errors.collapseTitleOpen': `Hide logs`,
     'entityCreate.sops.failedTitle': `Configuration Encryption Failed`,
     'entityCreate.endpointConfig.heading': `${entityCreateHeader}`,
     'entityCreate.endpointConfig.errorSummary': `There are issues with the form.`,

--- a/src/pages/dev/TestJsonForms.tsx
+++ b/src/pages/dev/TestJsonForms.tsx
@@ -3,13 +3,13 @@ import { materialCells } from '@jsonforms/material-renderers';
 import { JsonForms } from '@jsonforms/react';
 import Editor from '@monaco-editor/react';
 import {
-    Alert,
     Box,
     Button,
     Divider,
     Stack,
     StyledEngineProvider,
 } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import WrapperWithHeader from 'components/shared/Entity/WrapperWithHeader';
 import PageContainer from 'components/shared/PageContainer';
 import { jsonFormsPadding } from 'context/Theme';
@@ -71,7 +71,7 @@ const TestJsonForms = () => {
                 }}
             >
                 {error !== null ? (
-                    <Alert severity="error">{error}</Alert>
+                    <AlertBox severity="error">{error}</AlertBox>
                 ) : null}
 
                 <Editor

--- a/src/pages/dev/TestJsonForms.tsx
+++ b/src/pages/dev/TestJsonForms.tsx
@@ -19,7 +19,6 @@ import {
     custom_generateDefaultUISchema,
     defaultOptions,
     defaultRenderers,
-    generateCategoryUiSchema,
 } from 'services/jsonforms';
 
 const TITLE = 'Test JSON Forms';
@@ -48,9 +47,9 @@ const TestJsonForms = () => {
             const parsedSchema = JSON.parse(schemaInput);
             setSchema(parsedSchema);
 
-            const generatedSchema = generateCategoryUiSchema(
-                custom_generateDefaultUISchema(parsedSchema)
-            );
+            const generatedSchema =
+                custom_generateDefaultUISchema(parsedSchema);
+
             setUiSchema(generatedSchema);
 
             console.log('Generated this UI Schema:', {

--- a/src/services/ajv.ts
+++ b/src/services/ajv.ts
@@ -28,7 +28,7 @@ export const addKeywords = (ajv: any) => {
     ajv.addKeyword('secret'); // should render as a password
     ajv.addKeyword('airbyte_secret'); // should render as a password
     ajv.addKeyword('advanced'); // Should be collapsed by default
-    ajv.addKeyword('order'); // Unused at this time, but still present in airbyte schemas.
+    ajv.addKeyword('order'); // Used to order the fields in the UI
     ajv.addKeyword('x-oauth2-provider'); // Used to display OAuth
     ajv.addKeyword('discriminator'); // Used to know what field in a complex oneOf should be unique (ex: parser)
     return ajv;

--- a/src/services/jsonforms.ts
+++ b/src/services/jsonforms.ts
@@ -167,35 +167,54 @@ const copyAdvancedOption = (elem: Layout, schema: JsonSchema) => {
     }
 };
 
+// const generateHorizontalLayout = (elements: any[]) => {
+//     return arrayToMatrix(elements, 2).map((controls: any) => ({
+//         type: 'HorizontalLayout',
+//         elements: controls,
+//     }));
+// };
+
+interface CategoryUiSchema {
+    type: string;
+    elements: [
+        {
+            type: string;
+            label: string;
+            options?: any;
+            elements: any[];
+        }
+    ];
+}
 export const generateCategoryUiSchema = (uiSchema: any) => {
     const basicElements: any[] = [];
-    const categoryUiSchema = {
-        type: 'Categorization',
+    const categoryUiSchema: CategoryUiSchema = {
+        type: 'VerticalLayout',
         elements: [
             {
-                type: 'Category',
+                type: 'Group',
                 label: 'Basic Config',
-                elements: [
-                    {
-                        type: 'VerticalLayout',
-                        elements: [],
-                    } as { type: string; elements: any[] },
-                ],
+                elements: [],
             },
         ],
     };
 
     uiSchema.elements.forEach((element: any) => {
         if (element.label) {
+            const groupElements = element.elements
+                ? element.elements
+                : [element];
+
             categoryUiSchema.elements.push({
-                type: 'Category',
+                type: 'Group',
                 label: element.label,
+                options: {
+                    ...(element.options ?? {}),
+                    advanced: true,
+                },
                 elements: [
                     {
                         type: 'VerticalLayout',
-                        elements: element.elements
-                            ? element.elements
-                            : [element],
+                        elements: groupElements,
                     },
                 ],
             });

--- a/src/services/jsonforms.ts
+++ b/src/services/jsonforms.ts
@@ -57,6 +57,7 @@ import { oAuthProviderTester, OAuthType } from 'forms/renderers/OAuth';
 import MaterialOneOfRenderer_Discriminator, {
     materialOneOfControlTester_Discriminator,
 } from 'forms/renderers/Overrides/material/complex/MaterialOneOfRenderer_Discriminator';
+import { orderBy } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import keys from 'lodash/keys';
 import startCase from 'lodash/startCase';
@@ -168,7 +169,7 @@ const copyAdvancedOption = (elem: Layout, schema: JsonSchema) => {
 };
 
 // const generateHorizontalLayout = (elements: any[]) => {
-//     return arrayToMatrix(elements, 2).map((controls: any) => ({
+//     return arrayToMatrix(elements, 4).map((controls: any) => ({
 //         type: 'HorizontalLayout',
 //         elements: controls,
 //     }));
@@ -318,6 +319,7 @@ const generateUISchema = (
     currentRef: string,
     schemaName: string,
     layoutType: string,
+    rootGenerating: boolean,
     rootSchema?: JsonSchema
 ): UISchemaElement => {
     if (!isEmpty(jsonSchema) && jsonSchema.$ref !== undefined) {
@@ -331,6 +333,7 @@ const generateUISchema = (
             currentRef,
             schemaName,
             layoutType,
+            rootGenerating,
             rootSchema
         );
     }
@@ -403,10 +406,14 @@ const generateUISchema = (
     ) {
         let layout: Layout | GroupLayout;
 
-        if (currentRef === '#') {
-            layout = createLayout(layoutType);
+        if (rootGenerating) {
+            if (currentRef === '#') {
+                layout = createLayout(layoutType);
+            } else {
+                layout = createLayout('Group');
+            }
         } else {
-            layout = createLayout('Group');
+            layout = createLayout(layoutType);
         }
 
         // Add the advanced option to the layout, if required
@@ -428,29 +435,41 @@ const generateUISchema = (
             // traverse properties
             const nextRef: string = `${currentRef}/properties`;
 
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            layout.elements = Object.keys(jsonSchema.properties).map(
-                (propName) => {
+            // Order the properties based on the schema
+            const orderedProps = orderBy(
+                Object.keys(jsonSchema.properties),
+                (propName: string) => {
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    let value: JsonSchema = jsonSchema.properties![propName];
-                    const ref = `${nextRef}/${encode(propName)}`;
-                    if (value.$ref !== undefined) {
-                        value = resolveSchema(
-                            rootSchema as JsonSchema,
-                            value.$ref,
-                            rootSchema as JsonSchema
-                        );
-                    }
-                    return generateUISchema(
-                        value,
-                        layout.elements,
-                        ref,
-                        propName,
-                        layoutType,
-                        rootSchema
+                    const prop = jsonSchema.properties![propName] as any;
+
+                    return prop.order;
+                },
+                ['asc']
+            );
+
+            // Step through the ordered properties
+            layout.elements = orderedProps.map((propName) => {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                let value: JsonSchema = jsonSchema.properties![propName];
+                const ref = `${nextRef}/${encode(propName)}`;
+                if (value.$ref !== undefined) {
+                    value = resolveSchema(
+                        rootSchema as JsonSchema,
+                        value.$ref,
+                        rootSchema as JsonSchema
                     );
                 }
-            );
+
+                return generateUISchema(
+                    value,
+                    layout.elements,
+                    ref,
+                    propName,
+                    layoutType,
+                    rootGenerating,
+                    rootSchema
+                );
+            });
         }
 
         return layout;
@@ -509,13 +528,32 @@ const generateUISchema = (
  */
 export const custom_generateDefaultUISchema = (
     jsonSchema: JsonSchema,
-    layoutType = 'VerticalLayout',
-    prefix = '#',
-    rootSchema = jsonSchema
-): UISchemaElement =>
-    wrapInLayoutIfNecessary(
-        generateUISchema(jsonSchema, [], prefix, '', layoutType, rootSchema),
-        layoutType
+    layoutType?: string,
+    prefix?: string,
+    rootSchema?: JsonSchema
+): UISchemaElement => {
+    const rootGenerating = !layoutType && !prefix && !rootSchema;
+    const defaultLayout = layoutType ?? 'VerticalLayout';
+
+    let response;
+    response = wrapInLayoutIfNecessary(
+        generateUISchema(
+            jsonSchema,
+            [],
+            prefix ?? '#',
+            '',
+            defaultLayout,
+            rootGenerating,
+            rootSchema ?? jsonSchema
+        ),
+        defaultLayout
     );
+
+    if (rootGenerating) {
+        response = generateCategoryUiSchema(response);
+    }
+
+    return response;
+};
 
 Generate.uiSchema = custom_generateDefaultUISchema;

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -45,3 +45,12 @@ export const incrementInterval = (
     interval: number,
     max: number | undefined = INTERVAL_MAX
 ) => (interval < max ? interval + INTERVAL_INCREMENT : max);
+
+export const arrayToMatrix = (arr: any[], width: number) =>
+    arr.reduce(
+        (rows, key, index) =>
+            (index % width == 0
+                ? rows.push([key])
+                : rows[rows.length - 1].push(key)) && rows,
+        []
+    );


### PR DESCRIPTION
## Changes

New alert message
Removed duplicate header to prepare for moving buttons to bottom of form
Forms no longer display as tabs but show vertically
Make page spacing equal on all sides
Follow the order (somewhat) in the Schema

## Tests

Manual

## Issues

N/A

## Content

Some tweaks to messaging to make more open ended until we get some new features in.

## Screenshots

New alert tall version
![image](https://user-images.githubusercontent.com/270078/192602421-c89ae77d-603a-456e-84ea-408d195dd3e9.png)
![image](https://user-images.githubusercontent.com/270078/192602447-a8fe5f33-bc5a-4b61-a556-c97e6c4a85d2.png)

New Alert tall details list
![image](https://user-images.githubusercontent.com/270078/192602622-7b4a33c0-3938-4b4c-ab49-df21f1403915.png)
![image](https://user-images.githubusercontent.com/270078/192602664-5c1d344a-7c68-463d-a7aa-5e244c581c63.png)


New alert short version
![image](https://user-images.githubusercontent.com/270078/192602352-3ff784a8-bcfb-4fbe-b1b9-4d0b68a358c5.png)
![image](https://user-images.githubusercontent.com/270078/192602385-ebf6c924-0c90-4203-b1c0-ddc26e145bd2.png)


Header only contains buttons
![image](https://user-images.githubusercontent.com/270078/192594314-aee2f7a1-8789-4d59-9a42-d15bc2ee1903.png)

Form displays sections vertically
![image](https://user-images.githubusercontent.com/270078/192594368-79d48844-0f7a-4bae-a15c-9b8cb9b19195.png)


Page container equal on top and sides now
![image](https://user-images.githubusercontent.com/270078/192605479-5d08209e-13c8-40a7-8a65-a16dd91f27a9.png)


Order is being followed (ignore red styling):
![image](https://user-images.githubusercontent.com/270078/192846198-457f4c69-1196-4ae1-8d96-298622b1a065.png)
![image](https://user-images.githubusercontent.com/270078/192846231-c70e2cd1-e2e3-4919-94fe-72c784a1e253.png)
