### PR TITLE
Update user-facing status message for enabled yet inactive shards

### DIFF
--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -621,9 +621,9 @@ const Workflows: ResolvedIntlConfig['messages'] = {
 const ShardStatus: ResolvedIntlConfig['messages'] = {
     'shardStatus.primary': `PRIMARY`,
     'shardStatus.failed': `FAILED`,
-    'shardStatus.idle': `IDLE`,
-    'shardStatus.standby': `STANDBY`,
-    'shardStatus.backfill': `BACKFILL`,
+    'shardStatus.idle': `PENDING`,
+    'shardStatus.standby': `PENDING`,
+    'shardStatus.backfill': `PENDING`,
     'shardStatus.disabled': `DISABLED`,
     'shardStatus.none': `No shard status found.`,
 };


### PR DESCRIPTION
## Changes

Update the message displayed to the user for shards of the following status: `IDLE`, `BACKFILL`, and `STANDBY`. The status message in the UI will be `PENDING`.

## Tests

Untested. This was a simple content change.

## Issues

The issues directly below are completely resolved by this PR:
#351 

## Content

The message IDs of updated content are as follows: `'shardStatus.idle'`, `'shardStatus.backfill'`, and `'shardStatus.standby'`.
