### PR TITLE
Adding config to oauth calls

### DIFF
--- a/src/api/oauth.ts
+++ b/src/api/oauth.ts
@@ -15,27 +15,28 @@ export interface AuthURLResponse {
     state: string;
 }
 
-export const authURL = (connectorId: string) => {
+export const authURL = (connectorId: string, config: any) => {
     return invokeSupabase<AuthURLResponse>(FUNCTIONS.OAUTH, {
         operation: OPERATIONS.AUTH_URL,
         connector_id: connectorId,
         redirect_uri: `${window.location.origin}/oauth`,
+        config,
     });
 };
 
-export const accessToken = (state: string, code: string) => {
+export const accessToken = (state: string, code: string, config: any) => {
     return invokeSupabase<AccessTokenResponse>(FUNCTIONS.OAUTH, {
         operation: OPERATIONS.ACCESS_TOKEN,
         redirect_uri: `${window.location.origin}/oauth`,
         state,
         code,
+        config,
     });
 };
 
 export const encryptConfig = (
     connectorId: string,
     connectorTagId: string,
-
     config: any
 ) => {
     return invokeSupabase<any>(FUNCTIONS.OAUTH, {

--- a/src/forms/renderers/OAuth.tsx
+++ b/src/forms/renderers/OAuth.tsx
@@ -10,6 +10,7 @@ import { useMemo, useState } from 'react';
 import GoogleButton from 'react-google-button';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDetailsForm_connectorImage_connectorId } from 'stores/DetailsForm';
+import { useEndpointConfigStore_endpointConfig_data } from 'stores/EndpointConfig';
 import { Options } from 'types/jsonforms';
 import { hasLength } from 'utils/misc-utils';
 import { getDiscriminator } from './Overrides/material/complex/MaterialOneOfRenderer_Discriminator';
@@ -36,8 +37,8 @@ const OAuthproviderRenderer = ({
     const { options } = uischema;
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-    // Feels jank - but may it is fine. Feels weird to have a JSONForms
-    //      renderer dependent on a Zustand store
+    // Fetch what we need from stores
+    const endpointConfigData = useEndpointConfigStore_endpointConfig_data();
     const imageTag = useDetailsForm_connectorImage_connectorId();
 
     // This usually means the control is nested inside a tab
@@ -124,7 +125,11 @@ const OAuthproviderRenderer = ({
 
     // handler for the useOauth stuff
     const onSuccess = async (payload: any) => {
-        const tokenResponse = await accessToken(payload.state, payload.code);
+        const tokenResponse = await accessToken(
+            payload.state,
+            payload.code,
+            endpointConfigData
+        );
 
         if (tokenResponse.error) {
             setErrorMessage(
@@ -161,7 +166,7 @@ const OAuthproviderRenderer = ({
         setErrorMessage(null);
 
         // Make the call to know what pop url to open
-        const fetchAuthURL = await authURL(imageTag);
+        const fetchAuthURL = await authURL(imageTag, endpointConfigData);
 
         if (fetchAuthURL.error) {
             setErrorMessage(


### PR DESCRIPTION
## Changes

1. add endpoint config to oauth related calls so that connectors that need user provided details can use it

## Tests

manual

## Issues

fixes: https://github.com/estuary/ui/issues/294

## Content

none

## Screenshots

none
