### PR TITLE
Handle empty Oauth response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8871,7 +8871,7 @@
         "node_modules/data-plane-gateway": {
             "version": "0.0.0",
             "resolved": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-zMH07PDX2ko2W/iWFFsNbQ6mSw/1qDXK36uNfC96cK38FgV7ePKmgcouRX99gOFCcdp4OYqTZ/UQdU4E1414dA==",
+            "integrity": "sha512-gZiskCQ8F3eEjtZq7EI8+niycHhcl3vs79FJY9UvTnAQo4/i+OlYF8ABs9L4jzxQywvLLKXe0m3RewtOTEHi8w==",
             "license": "MIT"
         },
         "node_modules/data-urls": {
@@ -32072,7 +32072,7 @@
         },
         "data-plane-gateway": {
             "version": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-zMH07PDX2ko2W/iWFFsNbQ6mSw/1qDXK36uNfC96cK38FgV7ePKmgcouRX99gOFCcdp4OYqTZ/UQdU4E1414dA=="
+            "integrity": "sha512-gZiskCQ8F3eEjtZq7EI8+niycHhcl3vs79FJY9UvTnAQo4/i+OlYF8ABs9L4jzxQywvLLKXe0m3RewtOTEHi8w=="
         },
         "data-urls": {
             "version": "2.0.0",

--- a/src/forms/renderers/OAuth.tsx
+++ b/src/forms/renderers/OAuth.tsx
@@ -138,7 +138,14 @@ const OAuthproviderRenderer = ({
                     { provider }
                 )
             );
-        } else if (!isEmpty(tokenResponse.data)) {
+        } else if (isEmpty(tokenResponse.data)) {
+            setErrorMessage(
+                intl.formatMessage(
+                    { id: 'oauth.emptyData.error' },
+                    { provider }
+                )
+            );
+        } else {
             // These are injected by the server/encryption call so just setting
             //      some value here to pass the validation
             const fakeDefaults = {

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -635,9 +635,10 @@ const ShardStatus: ResolvedIntlConfig['messages'] = {
 
 const OAuth: ResolvedIntlConfig['messages'] = {
     'oauth.instructions': `Authenticate your {provider} account by clicking below. A pop up will open where you can authorize access. No data will be accessed during authorization.`,
-    'oauth.fetchAuthURL.error': `We were unable to fetch the proper URL to start OAuth. ${Error['error.tryAgain']}`,
+    'oauth.fetchAuthURL.error': `We failed to fetch the proper URL to start OAuth. ${Error['error.tryAgain']}`,
     'oauth.authentication.denied': `To use OAuth as your authentication you must allow our app access to your {provider} account.`,
     'oauth.accessToken.error': `There was an issue attempting to get the access token from {provider}. ${Error['error.tryAgain']}`,
+    'oauth.emptyData.error': `We failed to get the data we need to populate the {provider} OAuth configuration. ${Error['error.tryAgain']}`,
     'oauth.authenticated': `Authenticated`,
     'oauth.unauthenticated': `Not Authenticated`,
     'oauth.authenticate': `Authenticate your {provider} account`,


### PR DESCRIPTION
## Changes

If we got an empty response from Oauth we just failed silently. We not catch that and display an error.

## Tests

Manual

## Issues

N/A

## Content

Tweaked messages to take up less space.
New message that just follows the current pattern of error messages.

## Screenshots

N/A