### PR TITLE
prod: Prevent duplication in the available collections list

### DIFF
--- a/src/components/collection/Picker.tsx
+++ b/src/components/collection/Picker.tsx
@@ -97,7 +97,7 @@ function CollectionPicker({ readOnly = false }: Props) {
 
     useEffect(() => {
         if (populateCollectionData) {
-            let collectionsOnServer: CollectionData[] =
+            const liveSpecCollectionData: CollectionData[] =
                 workflow === 'capture_create'
                     ? []
                     : liveSpecs.map(({ catalog_name }) => ({
@@ -105,25 +105,33 @@ function CollectionPicker({ readOnly = false }: Props) {
                           classification: existingCollectionsLabel,
                       }));
 
-            if (entityType === ENTITY.CAPTURE) {
-                collectionsOnServer = [
-                    ...draftSpecs
-                        .filter(
-                            ({ spec_type }) => spec_type === ENTITY.COLLECTION
-                        )
-                        .map(({ catalog_name }) => ({
-                            name: catalog_name,
-                            classification: discoveredCollectionsLabel,
-                        })),
-                    ...collectionsOnServer,
-                ];
-            }
+            const draftSpecCollectionData: CollectionData[] =
+                entityType === ENTITY.CAPTURE
+                    ? draftSpecs
+                          .filter(
+                              ({ spec_type }) => spec_type === ENTITY.COLLECTION
+                          )
+                          .map(({ catalog_name }) => ({
+                              name: catalog_name,
+                              classification: discoveredCollectionsLabel,
+                          }))
+                    : [];
+
+            const draftSpecCollections: string[] = draftSpecCollectionData.map(
+                (collection) => collection.name
+            );
+
+            const collectionsOnServer: CollectionData[] = [
+                ...draftSpecCollectionData,
+                ...liveSpecCollectionData.filter(
+                    ({ name }) => !draftSpecCollections.includes(name)
+                ),
+            ];
 
             setCollectionData(collectionsOnServer);
         }
     }, [
         setCollectionData,
-        collections,
         discoveredCollectionsLabel,
         draftSpecs,
         entityType,


### PR DESCRIPTION
## Changes

Updated the logic which calculates the options for the list of available collections so that the array of existing collections is explicitly pruned, removing any existing collection that has a discovered counterpart.

## Tests

Only manual testing was performed. I ran through all of the capture and materialization workflows, evaluating the list of available collections after taking actions on the form. For captures, taking special note to monitor the list of available collections after subsequent discoveries.