### PR TITLE
Chunk DELETE requests, and add `Add All`/`Remove All` buttons for collection selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "madge": "^5.0.1",
                 "monaco-editor": "^0.33.0",
                 "notistack": "^2.0.5",
+                "p-limit": "^4.0.0",
                 "path-list-to-tree": "^1.1.1",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
@@ -13286,6 +13287,35 @@
                 "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
             }
         },
+        "node_modules/jest-changed-files/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-changed-files/node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/jest-circus": {
             "version": "28.1.3",
             "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
@@ -13471,6 +13501,22 @@
                 "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
             }
         },
+        "node_modules/jest-circus/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/jest-circus/node_modules/pretty-format": {
             "version": "28.1.3",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
@@ -13511,6 +13557,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/jest-circus/node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/jest-cli": {
@@ -15806,6 +15865,22 @@
                 "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
             }
         },
+        "node_modules/jest-runner/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/jest-runner/node_modules/pretty-format": {
             "version": "28.1.3",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
@@ -15846,6 +15921,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/jest-runner/node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/jest-runtime": {
@@ -18827,6 +18915,35 @@
             }
         },
         "node_modules/p-limit": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+            "dependencies": {
+                "yocto-queue": "^1.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate/node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -18841,14 +18958,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+        "node_modules/p-locate/node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
-            "dependencies": {
-                "p-limit": "^3.0.2"
-            },
             "engines": {
                 "node": ">=10"
             },
@@ -26580,12 +26694,11 @@
             }
         },
         "node_modules/yocto-queue": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "dev": true,
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
             "engines": {
-                "node": ">=10"
+                "node": ">=12.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -36266,6 +36379,25 @@
             "requires": {
                 "execa": "^5.0.0",
                 "p-limit": "^3.1.0"
+            },
+            "dependencies": {
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
+                "yocto-queue": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+                    "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+                    "dev": true,
+                    "peer": true
+                }
             }
         },
         "jest-circus": {
@@ -36414,6 +36546,16 @@
                         "picomatch": "^2.2.3"
                     }
                 },
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
                 "pretty-format": {
                     "version": "28.1.3",
                     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
@@ -36445,6 +36587,13 @@
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
+                },
+                "yocto-queue": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+                    "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -38217,6 +38366,16 @@
                         "picomatch": "^2.2.3"
                     }
                 },
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
                 "pretty-format": {
                     "version": "28.1.3",
                     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
@@ -38248,6 +38407,13 @@
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
+                },
+                "yocto-queue": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+                    "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -40483,12 +40649,11 @@
             "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
         },
         "p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
             "requires": {
-                "yocto-queue": "^0.1.0"
+                "yocto-queue": "^1.0.0"
             }
         },
         "p-locate": {
@@ -40498,6 +40663,23 @@
             "dev": true,
             "requires": {
                 "p-limit": "^3.0.2"
+            },
+            "dependencies": {
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
+                "yocto-queue": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+                    "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+                    "dev": true
+                }
             }
         },
         "p-map": {
@@ -46242,10 +46424,9 @@
             "peer": true
         },
         "yocto-queue": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "dev": true
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
         },
         "zustand": {
             "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "madge": "^5.0.1",
         "monaco-editor": "^0.33.0",
         "notistack": "^2.0.5",
+        "p-limit": "^4.0.0",
         "path-list-to-tree": "^1.1.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -22,6 +22,7 @@ import {
     typographyTruncation,
 } from 'context/Theme';
 import { useEntityWorkflow } from 'context/Workflow';
+import useLiveSpecs from 'hooks/useLiveSpecs';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useUnmount } from 'react-use';
@@ -57,6 +58,7 @@ function Row({ collection, task, disabled }: RowProps) {
 
     const discoveredCollections = useResourceConfig_discoveredCollections();
     const removeCollection = useResourceConfig_removeCollection();
+    const updateSelection = useResourceConfig_setCurrentCollection();
 
     const setRestrictedDiscoveredCollections =
         useResourceConfig_setRestrictedDiscoveredCollections();
@@ -66,6 +68,7 @@ function Row({ collection, task, disabled }: RowProps) {
             event.preventDefault();
 
             removeCollection(collection);
+            updateSelection(null);
 
             if (
                 workflow === 'capture_edit' &&
@@ -133,6 +136,8 @@ function BindingSelector({
             id: 'workflows.collectionSelector.label.listHeader',
         })
     );
+
+    const { liveSpecs } = useLiveSpecs('collection');
 
     // Details Form Store
     const task = useDetailsForm_details_entityName();
@@ -219,7 +224,17 @@ function BindingSelector({
                 <Button
                     sx={{ flex: 1, borderRadius: 0 }}
                     onClick={() => {
-                        setResourceConfig(discoveredCollections ?? []);
+                        const collections =
+                            discoveredCollections ??
+                            liveSpecs
+                                .filter(
+                                    ({ spec_type }) =>
+                                        spec_type === 'collection'
+                                )
+                                .flatMap((spec) => spec.catalog_name);
+                        console.log('Adding collections: ', collections);
+
+                        setResourceConfig(collections);
                     }}
                 >
                     Add All

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -222,6 +222,7 @@ function BindingSelector({
                     Remove All
                 </Button>
                 <Button
+                    disabled
                     sx={{ flex: 1, borderRadius: 0 }}
                     onClick={() => {
                         const collections =

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -1,6 +1,12 @@
 import { Clear } from '@mui/icons-material';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import { Box, IconButton, ListItemText } from '@mui/material';
+import {
+    Box,
+    Button,
+    ButtonGroup,
+    IconButton,
+    ListItemText,
+} from '@mui/material';
 import {
     DataGrid,
     GridColDef,
@@ -24,9 +30,11 @@ import { useFormStateStore_isActive } from 'stores/FormState/hooks';
 import {
     useResourceConfig_currentCollection,
     useResourceConfig_discoveredCollections,
+    useResourceConfig_removeAllCollections,
     useResourceConfig_removeCollection,
     useResourceConfig_resourceConfig,
     useResourceConfig_setCurrentCollection,
+    useResourceConfig_setResourceConfig,
     useResourceConfig_setRestrictedDiscoveredCollections,
 } from 'stores/ResourceConfig/hooks';
 import useConstant from 'use-constant';
@@ -137,6 +145,10 @@ function BindingSelector({
     const setCurrentCollection = useResourceConfig_setCurrentCollection();
 
     const resourceConfig = useResourceConfig_resourceConfig();
+    const discoveredCollections = useResourceConfig_discoveredCollections();
+
+    const setResourceConfig = useResourceConfig_setResourceConfig();
+    const removeAllCollection = useResourceConfig_removeAllCollections();
 
     const resourceConfigKeys = Object.keys(resourceConfig);
 
@@ -190,6 +202,29 @@ function BindingSelector({
     ) : (
         <>
             <CollectionPicker readOnly={readOnly} />
+            <ButtonGroup
+                sx={{
+                    flex: 1,
+                    display: 'flex',
+                }}
+                variant="text"
+                aria-label="outlined button group"
+            >
+                <Button
+                    sx={{ flex: 1, borderRadius: 0 }}
+                    onClick={removeAllCollection}
+                >
+                    Remove All
+                </Button>
+                <Button
+                    sx={{ flex: 1, borderRadius: 0 }}
+                    onClick={() => {
+                        setResourceConfig(discoveredCollections ?? []);
+                    }}
+                >
+                    Add All
+                </Button>
+            </ButtonGroup>
 
             <Box sx={{ height: 280 }}>
                 <DataGrid

--- a/src/components/editor/ListAndDetails.tsx
+++ b/src/components/editor/ListAndDetails.tsx
@@ -49,7 +49,10 @@ function ListAndDetails({
                     <div
                         className="pane-content"
                         style={{
-                            height: heightVal,
+                            // height: heightVal,
+                            height: '100%',
+                            display: 'flex',
+                            flexDirection: 'column',
                             border: displayBorder ? slateOutline : undefined,
                         }}
                     >

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -225,35 +225,6 @@ const getInitialState = (
         );
     },
 
-    addAllCollections: () => {
-        set(
-            produce((_state: ResourceConfigState) => {
-                const {
-                    discoveredCollections,
-                    setResourceConfig,
-                    setRestrictedDiscoveredCollections,
-                } = get();
-
-                const collections = discoveredCollections ?? [];
-
-                setResourceConfig(collections);
-
-                collections.forEach((collection) =>
-                    setRestrictedDiscoveredCollections(collection)
-                );
-
-                const all = get();
-                console.log(all);
-
-                // if (collections.length > 0) {
-                //     state.currentCollection = collections[0];
-                // }
-            }),
-            false,
-            'All Collections Added'
-        );
-    },
-
     setCurrentCollection: (value) => {
         set(
             produce((state: ResourceConfigState) => {

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -206,6 +206,54 @@ const getInitialState = (
         );
     },
 
+    removeAllCollections: () => {
+        set(
+            produce((state: ResourceConfigState) => {
+                state.currentCollection = null;
+                const { resourceConfig } = get();
+                state.collections = [];
+
+                const updatedResourceConfig = pick(
+                    resourceConfig,
+                    state.collections
+                ) as ResourceConfigDictionary;
+
+                state.resourceConfig = updatedResourceConfig;
+            }),
+            false,
+            'Removed All Selected Collections'
+        );
+    },
+
+    addAllCollections: () => {
+        set(
+            produce((_state: ResourceConfigState) => {
+                const {
+                    discoveredCollections,
+                    setResourceConfig,
+                    setRestrictedDiscoveredCollections,
+                } = get();
+
+                const collections = discoveredCollections ?? [];
+
+                setResourceConfig(collections);
+
+                collections.forEach((collection) =>
+                    setRestrictedDiscoveredCollections(collection)
+                );
+
+                const all = get();
+                console.log(all);
+
+                // if (collections.length > 0) {
+                //     state.currentCollection = collections[0];
+                // }
+            }),
+            false,
+            'All Collections Added'
+        );
+    },
+
     setCurrentCollection: (value) => {
         set(
             produce((state: ResourceConfigState) => {

--- a/src/stores/ResourceConfig/hooks.ts
+++ b/src/stores/ResourceConfig/hooks.ts
@@ -59,6 +59,24 @@ export const useResourceConfig_removeCollection = () => {
     >(getStoreName(entityType), (state) => state.removeCollection);
 };
 
+export const useResourceConfig_removeAllCollections = () => {
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        ResourceConfigState,
+        ResourceConfigState['removeAllCollections']
+    >(getStoreName(entityType), (state) => state.removeAllCollections);
+};
+
+export const useResourceConfig_addAllCollections = () => {
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        ResourceConfigState,
+        ResourceConfigState['addAllCollections']
+    >(getStoreName(entityType), (state) => state.addAllCollections);
+};
+
 export const useResourceConfig_collectionErrorsExist = () => {
     const entityType = useEntityType();
 

--- a/src/stores/ResourceConfig/hooks.ts
+++ b/src/stores/ResourceConfig/hooks.ts
@@ -68,15 +68,6 @@ export const useResourceConfig_removeAllCollections = () => {
     >(getStoreName(entityType), (state) => state.removeAllCollections);
 };
 
-export const useResourceConfig_addAllCollections = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        ResourceConfigState,
-        ResourceConfigState['addAllCollections']
-    >(getStoreName(entityType), (state) => state.addAllCollections);
-};
-
 export const useResourceConfig_collectionErrorsExist = () => {
     const entityType = useEntityType();
 

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -23,6 +23,8 @@ export interface ResourceConfigState {
     ) => void;
     addCollection: (value: string) => void;
     removeCollection: (value: string) => void;
+    addAllCollections: () => void;
+    removeAllCollections: () => void;
 
     collectionRemovalMetadata: {
         selectedCollection: string | null;

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -23,7 +23,6 @@ export interface ResourceConfigState {
     ) => void;
     addCollection: (value: string) => void;
     removeCollection: (value: string) => void;
-    addAllCollections: () => void;
     removeAllCollections: () => void;
 
     collectionRemovalMetadata: {


### PR DESCRIPTION
## Changes
Per our convo earlier today, this adds delete chunking, currently set to a chunk size of 10 and concurrency limit of 3 to avoid overloading supabase or running afowl of ratelimits.

It also adds `Add All`/`Delete All` buttons. @travjenkins or @kiahna-tucker, these took me a bunch of fiddling to get right, and I'm not entirely sure I did. They appear to work, but I might have missed some edge cases?

## Screenshots

See `DELETE` chunking:
<img width="1308" alt="Screen Shot 2022-11-08 at 21 00 03" src="https://user-images.githubusercontent.com/4368270/200732076-efa56e0d-1126-4851-baf4-1e63dec70b37.png">

`Add All`/`Remove All` buttons:
<img width="456" alt="Screen Shot 2022-11-08 at 21 01 11" src="https://user-images.githubusercontent.com/4368270/200732116-cb0ff1ca-a784-42f7-b1f8-889afc72700c.png">

**Note** that `Add All` adds collections without their fields being autofilled. This is less than optimal, but is the same behavior that we have today when adding a collection from the dropdown, so I figured it was good enough for this PR.

Fixes https://github.com/estuary/ui/issues/372


