### PR TITLE
Ordering connector cards and adding label

### DIFF
--- a/src/components/ConnectorTiles.tsx
+++ b/src/components/ConnectorTiles.tsx
@@ -24,7 +24,12 @@ import {
 } from 'hooks/useConnectorWithTagDetail';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { CONNECTOR_NAME, defaultTableFilter, TABLES } from 'services/supabase';
+import {
+    CONNECTOR_NAME,
+    CONNECTOR_RECOMMENDED,
+    defaultTableFilter,
+    TABLES,
+} from 'services/supabase';
 import {
     BaseComponentProps,
     EntityWithCreateWorkflow,
@@ -43,6 +48,7 @@ import ConnectorCardTitle from './connectors/card/Title';
 interface ConnectorTilesProps {
     protocolPreset?: EntityWithCreateWorkflow;
     replaceOnNavigate?: boolean;
+    hideSort?: boolean;
 }
 
 type TileProps = BaseComponentProps;
@@ -85,6 +91,7 @@ function Tile({ children }: TileProps) {
 function ConnectorTiles({
     protocolPreset,
     replaceOnNavigate,
+    hideSort,
 }: ConnectorTilesProps) {
     const navigateToCreate = useEntityCreateNavigate();
     const isFiltering = useRef(false);
@@ -114,8 +121,16 @@ function ConnectorTiles({
                     query,
                     [columnToSort],
                     searchQuery,
-                    columnToSort,
-                    sortDirection,
+                    [
+                        {
+                            col: CONNECTOR_RECOMMENDED,
+                            direction: 'desc',
+                        },
+                        {
+                            col: columnToSort,
+                            direction: sortDirection,
+                        },
+                    ],
                     undefined,
                     { column: 'connector_tags.protocol', value: protocol }
                 );
@@ -165,6 +180,7 @@ function ConnectorTiles({
                     setProtocol={setProtocol}
                     setSortDirection={setSortDirection}
                     setSearchQuery={setSearchQuery}
+                    hideSort={hideSort}
                 />
             </Grid>
 
@@ -188,6 +204,7 @@ function ConnectorTiles({
                                     entity={row.connector_tags[0].protocol}
                                 />
                             }
+                            recommended={row.recommended}
                         />
                     ))
                     .concat(

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -33,6 +33,7 @@ interface Props {
         SetStateAction<keyof ConnectorWithTagDetailQuery>
     >;
     hideProtocol?: boolean;
+    hideSort?: boolean;
     setProtocol: Dispatch<SetStateAction<string | null>>;
     setSortDirection: Dispatch<SetStateAction<SortDirection>>;
     setSearchQuery: Dispatch<SetStateAction<string | null>>;
@@ -70,6 +71,7 @@ function ConnectorToolbar({
     gridSpacing,
     setColumnToSort,
     hideProtocol,
+    hideSort,
     setProtocol,
     setSortDirection,
     setSearchQuery,
@@ -202,63 +204,69 @@ function ConnectorToolbar({
                     />
                 </Grid>
 
-                <Grid item xs={hideProtocol ? 6 : 4} md={2}>
-                    <Autocomplete
-                        options={sortByOptions.map(({ message }) => message)}
-                        renderInput={({
-                            InputProps,
-                            ...params
-                        }: AutocompleteRenderInputParams) => (
-                            <TextField
-                                {...params}
-                                InputProps={{
-                                    ...InputProps,
-                                    ...inputProps,
-                                }}
-                                label={intl.formatMessage({
-                                    id: 'connectorTable.label.sortBy',
+                {!hideSort ? (
+                    <>
+                        <Grid item xs={hideProtocol ? 6 : 4} md={2}>
+                            <Autocomplete
+                                options={sortByOptions.map(
+                                    ({ message }) => message
+                                )}
+                                renderInput={({
+                                    InputProps,
+                                    ...params
+                                }: AutocompleteRenderInputParams) => (
+                                    <TextField
+                                        {...params}
+                                        InputProps={{
+                                            ...InputProps,
+                                            ...inputProps,
+                                        }}
+                                        label={intl.formatMessage({
+                                            id: 'connectorTable.label.sortBy',
+                                        })}
+                                        variant="filled"
+                                    />
+                                )}
+                                defaultValue={intl.formatMessage({
+                                    id: 'connectorTable.data.title',
                                 })}
-                                variant="filled"
+                                disableClearable
+                                onChange={handlers.setSortBy}
+                                sx={toolbarSectionSx}
                             />
-                        )}
-                        defaultValue={intl.formatMessage({
-                            id: 'connectorTable.data.title',
-                        })}
-                        disableClearable
-                        onChange={handlers.setSortBy}
-                        sx={toolbarSectionSx}
-                    />
-                </Grid>
+                        </Grid>
 
-                <Grid item xs={hideProtocol ? 6 : 4} md={2}>
-                    <Autocomplete
-                        options={sortDirectionOptions.map(
-                            ({ message }) => message
-                        )}
-                        renderInput={({
-                            InputProps,
-                            ...params
-                        }: AutocompleteRenderInputParams) => (
-                            <TextField
-                                {...params}
-                                InputProps={{
-                                    ...InputProps,
-                                    ...inputProps,
-                                }}
-                                label={intl.formatMessage({
-                                    id: 'connectorTable.label.sortDirection',
+                        <Grid item xs={hideProtocol ? 6 : 4} md={2}>
+                            <Autocomplete
+                                options={sortDirectionOptions.map(
+                                    ({ message }) => message
+                                )}
+                                renderInput={({
+                                    InputProps,
+                                    ...params
+                                }: AutocompleteRenderInputParams) => (
+                                    <TextField
+                                        {...params}
+                                        InputProps={{
+                                            ...InputProps,
+                                            ...inputProps,
+                                        }}
+                                        label={intl.formatMessage({
+                                            id: 'connectorTable.label.sortDirection',
+                                        })}
+                                        variant="filled"
+                                    />
+                                )}
+                                defaultValue={intl.formatMessage({
+                                    id: 'sortDirection.ascending',
                                 })}
-                                variant="filled"
+                                disableClearable
+                                onChange={handlers.switchSortDirection}
+                                sx={toolbarSectionSx}
                             />
-                        )}
-                        defaultValue={intl.formatMessage({
-                            id: 'sortDirection.ascending',
-                        })}
-                        disableClearable
-                        onChange={handlers.switchSortDirection}
-                        sx={toolbarSectionSx}
-                    />
-                </Grid>
+                        </Grid>
+                    </>
+                ) : null}
 
                 {hideProtocol ? null : (
                     <Grid item xs={4} md={2}>

--- a/src/components/connectors/card/index.tsx
+++ b/src/components/connectors/card/index.tsx
@@ -1,9 +1,11 @@
 import { Box, Grid, Paper, Stack } from '@mui/material';
 import ExternalLink from 'components/shared/ExternalLink';
 import {
+    connectorImageBackgroundRadius,
     connectorImageBackgroundSx,
     semiTransparentBackground,
     semiTransparentBackgroundIntensified,
+    teal,
 } from 'context/Theme';
 import { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -40,8 +42,16 @@ interface Props {
     title: ReactNode;
 
     docsUrl?: string;
+    recommended?: boolean;
 }
-function ConnectorCard({ cta, docsUrl, logo, title, details }: Props) {
+function ConnectorCard({
+    cta,
+    docsUrl,
+    logo,
+    title,
+    details,
+    recommended,
+}: Props) {
     return (
         <Grid item xs={2} md={4} lg={3} xl={2} sx={{ maxWidth: 275 }}>
             <Tile>
@@ -53,22 +63,56 @@ function ConnectorCard({ cta, docsUrl, logo, title, details }: Props) {
                     }}
                 >
                     <Box>
-                        <Box sx={connectorImageBackgroundSx}>
-                            <Stack
-                                sx={{
-                                    justifyContent: 'center',
-                                    alignItems: 'center',
-                                }}
+                        <Stack
+                            sx={{
+                                marginBottom: recommended ? 1 : 2,
+                            }}
+                        >
+                            <Box
+                                sx={
+                                    recommended
+                                        ? {
+                                              ...connectorImageBackgroundSx,
+                                              mb: 0,
+                                              borderBottomLeftRadius: 0,
+                                              borderBottomRightRadius: 0,
+                                          }
+                                        : connectorImageBackgroundSx
+                                }
                             >
-                                <Box>{logo}</Box>
+                                <Stack
+                                    sx={{
+                                        justifyContent: 'center',
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    <Box>{logo}</Box>
 
-                                {docsUrl ? (
-                                    <ExternalLink link={docsUrl}>
-                                        <FormattedMessage id="terms.documentation" />
-                                    </ExternalLink>
-                                ) : null}
-                            </Stack>
-                        </Box>
+                                    {docsUrl ? (
+                                        <ExternalLink link={docsUrl}>
+                                            <FormattedMessage id="terms.documentation" />
+                                        </ExternalLink>
+                                    ) : null}
+                                </Stack>
+                            </Box>
+
+                            {recommended ? (
+                                <Box
+                                    sx={{
+                                        bgcolor: teal[500],
+                                        color: 'white',
+                                        borderBottomLeftRadius:
+                                            connectorImageBackgroundRadius,
+                                        borderBottomRightRadius:
+                                            connectorImageBackgroundRadius,
+                                        opacity: 0.75,
+                                        textAlign: 'center',
+                                    }}
+                                >
+                                    <FormattedMessage id="common.recommended" />
+                                </Box>
+                            ) : null}
+                        </Stack>
 
                         {title}
 

--- a/src/components/shared/Entity/Create.tsx
+++ b/src/components/shared/Entity/Create.tsx
@@ -153,7 +153,11 @@ function EntityCreate({
                     <FormattedMessage id="entityCreate.instructions" />
                 </Typography>
 
-                <ConnectorTiles protocolPreset={entityType} replaceOnNavigate />
+                <ConnectorTiles
+                    protocolPreset={entityType}
+                    replaceOnNavigate
+                    hideSort
+                />
             </Collapse>
 
             <Collapse in={!showConnectorTiles} unmountOnExit>

--- a/src/components/tables/AccessGrants/index.tsx
+++ b/src/components/tables/AccessGrants/index.tsx
@@ -28,8 +28,12 @@ function AccessGrantsTable() {
                     query,
                     ['user_full_name', 'subject_role', 'object_role'],
                     searchQuery,
-                    columnToSort,
-                    sortDirection,
+                    [
+                        {
+                            col: columnToSort,
+                            direction: sortDirection,
+                        },
+                    ],
                     pagination
                 );
             },

--- a/src/components/tables/Captures/index.tsx
+++ b/src/components/tables/Captures/index.tsx
@@ -47,8 +47,12 @@ function CapturesTable() {
                     query,
                     ['catalog_name', QUERY_PARAM_CONNECTOR_TITLE],
                     searchQuery,
-                    columnToSort,
-                    sortDirection,
+                    [
+                        {
+                            col: columnToSort,
+                            direction: sortDirection,
+                        },
+                    ],
                     pagination
                 ).eq('spec_type', 'capture');
             },

--- a/src/components/tables/Collections/index.tsx
+++ b/src/components/tables/Collections/index.tsx
@@ -41,8 +41,12 @@ function CollectionsTable() {
                     query,
                     ['catalog_name'],
                     searchQuery,
-                    columnToSort,
-                    sortDirection,
+                    [
+                        {
+                            col: columnToSort,
+                            direction: sortDirection,
+                        },
+                    ],
                     pagination
                 ).eq('spec_type', 'collection');
             },

--- a/src/components/tables/Connectors/index.tsx
+++ b/src/components/tables/Connectors/index.tsx
@@ -30,8 +30,12 @@ function ConnectorsTable() {
                     query,
                     [CONNECTOR_NAME],
                     searchQuery,
-                    columnToSort,
-                    sortDirection,
+                    [
+                        {
+                            col: columnToSort,
+                            direction: sortDirection,
+                        },
+                    ],
                     pagination
                 );
             },

--- a/src/components/tables/Materializations/index.tsx
+++ b/src/components/tables/Materializations/index.tsx
@@ -46,8 +46,12 @@ function MaterializationsTable() {
                     query,
                     ['catalog_name', QUERY_PARAM_CONNECTOR_TITLE],
                     searchQuery,
-                    columnToSort,
-                    sortDirection,
+                    [
+                        {
+                            col: columnToSort,
+                            direction: sortDirection,
+                        },
+                    ],
                     pagination
                 ).eq('spec_type', 'materialization');
             },

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -297,6 +297,7 @@ export const LINK_BUTTON_STYLING: SxProps<Theme> = {
     },
 };
 
+export const connectorImageBackgroundRadius = 5;
 export const connectorImageBackgroundSx: SxProps<Theme> = {
     width: '100%',
     height: 125,
@@ -304,7 +305,7 @@ export const connectorImageBackgroundSx: SxProps<Theme> = {
     justifyContent: 'center',
     alignItems: 'center',
     marginBottom: 2,
-    borderRadius: 5,
+    borderRadius: connectorImageBackgroundRadius,
     background: connectorCardLogoBackground,
 };
 

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -30,6 +30,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'common.noUnDo': `This action cannot be undone.`,
     'common.version': `version`,
     'common.tenant': `Prefix`,
+    'common.recommended': `Recommended`,
 
     // Aria
     'aria.openExpand': `show more`,

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1,8 +1,8 @@
 import { PostgrestError, PostgrestFilterBuilder } from '@supabase/postgrest-js';
 import { createClient, User } from '@supabase/supabase-js';
-import { isEmpty } from 'lodash';
+import { forEach, isEmpty } from 'lodash';
 import LogRocket from 'logrocket';
-import { JobStatus } from 'types';
+import { JobStatus, SortDirection } from 'types';
 import { hasLength, incrementInterval, timeoutCleanUp } from 'utils/misc-utils';
 
 if (
@@ -81,13 +81,16 @@ export const supabaseClient = createClient(
     }
 );
 
+interface SortingProps<Data> {
+    col: keyof Data;
+    direction: SortDirection;
+}
 export const DEFAULT_POLLING_INTERVAL = 750;
 export const defaultTableFilter = <Data>(
     query: PostgrestFilterBuilder<Data>,
     searchParam: Array<keyof Data | any>, // TODO (typing) added any because of how Supabase handles keys. Hoping Supabase 2.0 fixes https://github.com/supabase/supabase-js/issues/170
     searchQuery: string | null,
-    columnToSort: keyof Data,
-    sortDirection: string,
+    sorting: SortingProps<Data>[],
     pagination?: { from: number; to: number },
     protocol?: { column: keyof Data; value: string | null }
 ) => {
@@ -103,8 +106,10 @@ export const defaultTableFilter = <Data>(
         );
     }
 
-    queryBuilder = queryBuilder.order(columnToSort, {
-        ascending: sortDirection === 'asc',
+    forEach(sorting, (sort) => {
+        queryBuilder = queryBuilder.order(sort.col, {
+            ascending: sort.direction === 'asc',
+        });
     });
 
     if (pagination) {


### PR DESCRIPTION
## Changes

1. Have connector tiles order with recommended first
2. Add the "recommended" label to cards based on the one on estuary.dev
3. Refactor default table filter to support multiple filters

## Tests

Manually tested

## Issues

Fixes: https://github.com/estuary/ui/issues/326

## Content

Added the common word "recommended" taken from estuary.dev

## Screenshots

![image](https://user-images.githubusercontent.com/270078/201770059-2406726a-5580-4567-b26b-b2c5c9247df8.png)

