### PR TITLE
Make registration apparent on login page

### DIFF
--- a/src/app/Unauthenticated.tsx
+++ b/src/app/Unauthenticated.tsx
@@ -11,6 +11,10 @@ const Unauthenticated = () => {
                 path={unauthenticatedRoutes.magicLink.path}
                 element={<Auth />}
             />
+            <Route
+                path={unauthenticatedRoutes.register.path}
+                element={<Login showRegister={true} />}
+            />
             <Route path="*" element={<Login />} />
         </Routes>
     );

--- a/src/app/Unauthenticated.tsx
+++ b/src/app/Unauthenticated.tsx
@@ -13,7 +13,7 @@ const Unauthenticated = () => {
             />
             <Route
                 path={unauthenticatedRoutes.register.path}
-                element={<Login showRegister={true} />}
+                element={<Login showRegistration={true} />}
             />
             <Route path="*" element={<Login />} />
         </Routes>

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -3,6 +3,9 @@ export const unauthenticatedRoutes = {
     auth: {
         path: '/auth',
     },
+    register: {
+        path: '/register',
+    },
     magicLink: {
         path: '/magicLink',
     },

--- a/src/components/login/GithubButton.tsx
+++ b/src/components/login/GithubButton.tsx
@@ -3,14 +3,17 @@ import { GithubLoginButton } from 'react-social-login-buttons';
 
 interface Props {
     login: () => void;
+    isRegister?: boolean;
 }
 
-const GithubButton = ({ login }: Props) => {
+const GithubButton = ({ login, isRegister }: Props) => {
     const intl = useIntl();
     return (
         <GithubLoginButton
             onClick={login}
-            text={intl.formatMessage({ id: 'cta.login.github' })}
+            text={intl.formatMessage({
+                id: isRegister ? 'cta.register.github' : 'cta.login.github',
+            })}
         />
     );
 };

--- a/src/components/login/OIDCs.tsx
+++ b/src/components/login/OIDCs.tsx
@@ -9,7 +9,11 @@ import GithubButton from './GithubButton';
 // TODO (routes) This is hardcoded because unauthenticated routes... (same as MagicLink)
 const redirectTo = `${window.location.origin}/auth`;
 
-function OIDCs() {
+interface Props {
+    isRegister?: boolean;
+}
+
+function OIDCs({ isRegister }: Props) {
     const supabaseClient = useClient();
     const intl = useIntl();
 
@@ -18,7 +22,9 @@ function OIDCs() {
     const loginFailed = (key: Provider) => {
         enqueueSnackbar(
             intl.formatMessage({
-                id: `login.loginFailed.${key}`,
+                id: `login.${
+                    isRegister ? 'registerFailed' : 'loginFailed'
+                }.${key}`,
             }),
             {
                 anchorOrigin: {
@@ -55,10 +61,20 @@ function OIDCs() {
             }}
         >
             <Box>
-                <GithubButton login={() => login('github')} />
+                <GithubButton
+                    isRegister={isRegister}
+                    login={() => login('github')}
+                />
             </Box>
             <Box>
-                <GoogleButton onClick={() => login('google')} />
+                <GoogleButton
+                    label={intl.formatMessage({
+                        id: isRegister
+                            ? 'cta.register.google'
+                            : 'cta.login.google',
+                    })}
+                    onClick={() => login('google')}
+                />
             </Box>
         </Stack>
     );

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -102,7 +102,10 @@ const CTAs: ResolvedIntlConfig['messages'] = {
     'cta.table': `Table`,
     'cta.list': `List`,
     'cta.expandToView': `Expand to view`,
+    'cta.login.google': `Sign in with Google`,
+    'cta.register.google': `Register with Google`,
     'cta.login.github': `Sign in with GitHub`,
+    'cta.register.github': `Register with GitHub`,
 };
 
 const Data: ResolvedIntlConfig['messages'] = {
@@ -264,9 +267,13 @@ const Registration: ResolvedIntlConfig['messages'] = {
 };
 
 const LoginPage: ResolvedIntlConfig['messages'] = {
-    'login.oidc.message': `Sign in to continue to ${CommonMessages.productName}.`,
     'login.documentAcknowledgement': `By accessing ${CommonMessages.productName} you agree to our {terms} and {privacy}.`,
     'login.jwtExpired': 'Your authorization has expired. Please sign in again.',
+
+    'login.tabs.login': `Sign In`,
+    'login.tabs.register': `Register`,
+    'login.login.message': `Sign in to continue to ${CommonMessages.productName}.`,
+    'login.register.message': `Please use a provider below to regisiter for a free trial of ${CommonMessages.productName}.`,
 
     'login.passwordReset': 'You should not need to reset your password.',
 
@@ -285,6 +292,9 @@ const LoginPage: ResolvedIntlConfig['messages'] = {
     'login.loginFailed': 'Failed to sign in',
     'login.loginFailed.google': 'Failed to sign in with Google',
     'login.loginFailed.github': 'Failed to sign in with GitHub',
+    'login.registerFailed': 'Failed to register',
+    'login.registerFailed.google': 'Failed to register with Google',
+    'login.registerFailed.github': 'Failed to register with GitHub',
     'login.userNotFound': 'User not found. Please sign up below.',
 };
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,31 +1,69 @@
-import { Box, Divider, Stack, Typography } from '@mui/material';
+import { Box, Divider, Stack, Tab, Tabs, Typography } from '@mui/material';
 import FullPageDialog from 'components/fullPage/Dialog';
 import MagicLink from 'components/login/MagicLink';
 import OIDCs from 'components/login/OIDCs';
 import useBrowserTitle from 'hooks/useBrowserTitle';
-import { FormattedMessage } from 'react-intl';
+import { useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useEffectOnce, useLocalStorage } from 'react-use';
 import { getLoginSettings } from 'utils/env-utils';
 import { LocalStorageKeys } from 'utils/localStorage-utils';
 
 const loginSettings = getLoginSettings();
 
-const Login = () => {
+interface Props {
+    showRegister?: boolean;
+}
+
+const Login = ({ showRegister }: Props) => {
     useBrowserTitle('browserTitle.login');
 
     const { 2: clearGatewayConfig } = useLocalStorage(LocalStorageKeys.GATEWAY);
     useEffectOnce(() => clearGatewayConfig());
 
+    const intl = useIntl();
+    const [tabIndex, setTabIndex] = useState(showRegister ? 1 : 0);
+    const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+        setTabIndex(newValue);
+    };
+
+    const isRegister = tabIndex === 1;
+
     return (
         <FullPageDialog>
-            <Box sx={{ mt: 2 }}>
-                <Typography align="center" sx={{ mb: 4 }}>
-                    <FormattedMessage id="login.oidc.message" />
+            <Box sx={{ mt: 2, minWidth: 300, maxWidth: 300 }}>
+                <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                    <Tabs
+                        value={tabIndex}
+                        onChange={handleChange}
+                        variant="fullWidth"
+                    >
+                        <Tab
+                            label={intl.formatMessage({
+                                id: 'login.tabs.login',
+                            })}
+                        />
+                        <Tab
+                            label={intl.formatMessage({
+                                id: 'login.tabs.register',
+                            })}
+                        />
+                    </Tabs>
+                </Box>
+
+                <Typography align="center" sx={{ my: 4 }}>
+                    <FormattedMessage
+                        id={
+                            isRegister
+                                ? 'login.register.message'
+                                : 'login.login.message'
+                        }
+                    />
                 </Typography>
 
                 <Stack direction="column" spacing={2}>
                     <Box>
-                        <OIDCs />
+                        <OIDCs isRegister={isRegister} />
                     </Box>
 
                     {loginSettings.showEmail ? (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -12,17 +12,17 @@ import { LocalStorageKeys } from 'utils/localStorage-utils';
 const loginSettings = getLoginSettings();
 
 interface Props {
-    showRegister?: boolean;
+    showRegistration?: boolean;
 }
 
-const Login = ({ showRegister }: Props) => {
+const Login = ({ showRegistration }: Props) => {
     useBrowserTitle('browserTitle.login');
 
     const { 2: clearGatewayConfig } = useLocalStorage(LocalStorageKeys.GATEWAY);
     useEffectOnce(() => clearGatewayConfig());
 
     const intl = useIntl();
-    const [tabIndex, setTabIndex] = useState(showRegister ? 1 : 0);
+    const [tabIndex, setTabIndex] = useState(showRegistration ? 1 : 0);
     const handleChange = (event: React.SyntheticEvent, newValue: number) => {
         setTabIndex(newValue);
     };
@@ -66,7 +66,7 @@ const Login = ({ showRegister }: Props) => {
                         <OIDCs isRegister={isRegister} />
                     </Box>
 
-                    {loginSettings.showEmail ? (
+                    {!isRegister && loginSettings.showEmail ? (
                         <>
                             <Divider flexItem>
                                 <FormattedMessage id="login.separator" />


### PR DESCRIPTION
## Changes

1. Add new path that shows registration first
2. Show login/registration tabs
3. Change language for registration

## Tests

Manual

## Issues

https://github.com/estuary/ui/issues/382

## Content

Some minor message changes for stuff where `login` becomes `registration`

## Screenshots
![image](https://user-images.githubusercontent.com/270078/202334971-72e6452f-cdbd-4547-9d71-076eef745267.png)

Magic link is only used to login on locals
![image](https://user-images.githubusercontent.com/270078/202335099-37fdc76f-4063-4a77-88aa-fd3f42ea87a9.png)


