### PR TITLE
Phil/flowctl auth 2

### DIFF
--- a/src/app/Unauthenticated.tsx
+++ b/src/app/Unauthenticated.tsx
@@ -13,9 +13,19 @@ const Unauthenticated = () => {
             />
             <Route
                 path={unauthenticatedRoutes.register.path}
-                element={<Login showRegistration={true} />}
+                element={
+                    <Login
+                        showRegistration={true}
+                        redirectTo={`${window.location.origin}/auth`}
+                    />
+                }
             />
-            <Route path="*" element={<Login />} />
+            <Route
+                path="*"
+                element={
+                    <Login redirectTo={`${window.location.origin}/auth`} />
+                }
+            />
         </Routes>
     );
 };

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -2,7 +2,13 @@ import FullPageSpinner from 'components/fullPage/Spinner';
 import useBrowserTitle from 'hooks/useBrowserTitle';
 import * as React from 'react';
 import 'react-reflex/styles.css';
+
+import CliAuthContextLayout from 'components/cli/CliAuthContextLayout';
+import { CliAuthSuccess } from 'components/cli/CliAuthSuccess';
+import { CliLogin } from 'components/cli/CliLogin';
+import { Route, Routes } from 'react-router';
 import AppGuards from './guards';
+import { unauthenticatedRoutes } from './routes';
 
 const AuthenticatedApp = React.lazy(
     () => import(/* webpackPrefetch: true */ './Authenticated')
@@ -12,11 +18,31 @@ function App() {
     useBrowserTitle('browserTitle.loginLoading');
 
     return (
-        <AppGuards>
-            <React.Suspense fallback={<FullPageSpinner />}>
-                <AuthenticatedApp />
-            </React.Suspense>
-        </AppGuards>
+        <Routes>
+            <Route
+                path={unauthenticatedRoutes.cliAuth.path}
+                element={<CliAuthContextLayout />}
+            >
+                <Route
+                    path={unauthenticatedRoutes.cliAuth.login.path}
+                    element={<CliLogin />}
+                />
+                <Route
+                    path={unauthenticatedRoutes.cliAuth.success.path}
+                    element={<CliAuthSuccess />}
+                />
+            </Route>
+            <Route
+                path="*"
+                element={
+                    <AppGuards>
+                        <React.Suspense fallback={<FullPageSpinner />}>
+                            <AuthenticatedApp />
+                        </React.Suspense>
+                    </AppGuards>
+                }
+            />
+        </Routes>
     );
 }
 

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -9,6 +9,20 @@ export const unauthenticatedRoutes = {
     magicLink: {
         path: '/magicLink',
     },
+    cliAuth: {
+        title: 'routeTitle.cliAuth',
+        path: '/cli-auth',
+        login: {
+            title: 'routeTitle.cliAuth.login',
+            path: 'login',
+            fullPath: '/cli-auth/login',
+        },
+        success: {
+            title: 'routeTitle.cliAuth.success',
+            path: 'success',
+            fullPath: '/cli-auth/success',
+        },
+    },
 };
 
 export const authenticatedRoutes = {

--- a/src/components/cli/CliAuthContextLayout.tsx
+++ b/src/components/cli/CliAuthContextLayout.tsx
@@ -1,0 +1,18 @@
+import { Auth } from '@supabase/ui';
+import { SwrSupabaseContext } from 'hooks/supabase-swr';
+import { Outlet } from 'react-router-dom';
+import { cliAuthClient } from 'services/supabase';
+
+// Wraps routes related to CLI (flowctl) authentication and sets up context providers
+// that are needed in order to power the authentication flow.
+const CliAuthContextLayout = () => {
+    return (
+        <SwrSupabaseContext.Provider value={cliAuthClient}>
+            <Auth.UserContextProvider supabaseClient={cliAuthClient}>
+                <Outlet />
+            </Auth.UserContextProvider>
+        </SwrSupabaseContext.Provider>
+    );
+};
+
+export default CliAuthContextLayout;

--- a/src/components/cli/CliAuthSuccess.tsx
+++ b/src/components/cli/CliAuthSuccess.tsx
@@ -13,6 +13,7 @@ import useBrowserTitle from 'hooks/useBrowserTitle';
 import LogRocket from 'logrocket';
 import { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { useNavigate } from 'react-router';
 import { CustomEvents } from 'services/logrocket';
 
 const boxStyling: SxProps<Theme> = {
@@ -21,6 +22,7 @@ const boxStyling: SxProps<Theme> = {
 };
 
 export function CliAuthSuccess() {
+    const navigate = useNavigate();
     const user = Auth.useUser();
     const session = user.session;
     const tokenValue = btoa(
@@ -33,13 +35,19 @@ export function CliAuthSuccess() {
     useBrowserTitle('browserTitle.cliAuth.success');
 
     useEffect(() => {
-        LogRocket.track(CustomEvents.FLOWCTL_LOGIN, {
-            user_id: session?.user?.id,
-        });
-    }, [tokenValue, session?.user?.id]);
+        if (!session) {
+            return navigate(unauthenticatedRoutes.cliAuth.login.fullPath, {
+                replace: true,
+            });
+        } else {
+            LogRocket.track(CustomEvents.FLOWCTL_LOGIN, {
+                user_id: session.user?.id,
+            });
+        }
+    }, [tokenValue, session, navigate]);
 
     const copyToken = () => {
-        navigator.clipboard.writeText(tokenValue);
+        void navigator.clipboard.writeText(tokenValue);
     };
 
     return (

--- a/src/components/cli/CliAuthSuccess.tsx
+++ b/src/components/cli/CliAuthSuccess.tsx
@@ -11,7 +11,7 @@ import { unauthenticatedRoutes } from 'app/routes';
 import PageContainer from 'components/shared/PageContainer';
 import useBrowserTitle from 'hooks/useBrowserTitle';
 import LogRocket from 'logrocket';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router';
 import { CustomEvents } from 'services/logrocket';
@@ -22,17 +22,27 @@ const boxStyling: SxProps<Theme> = {
 };
 
 export function CliAuthSuccess() {
+    useBrowserTitle('browserTitle.cliAuth.success');
+
     const navigate = useNavigate();
     const user = Auth.useUser();
     const session = user.session;
-    const tokenValue = btoa(
-        JSON.stringify({
-            access_token: session?.access_token,
-            refresh_token: session?.refresh_token,
-            expires_at: (session?.expires_at ?? 0) + (session?.expires_in ?? 0),
-        })
+
+    const tokenValue = useMemo(
+        () =>
+            session
+                ? btoa(
+                      JSON.stringify({
+                          access_token: session.access_token,
+                          refresh_token: session.refresh_token,
+                          expires_at:
+                              (session.expires_at ?? 0) +
+                              (session.expires_in ?? 0),
+                      })
+                  )
+                : null,
+        [session]
     );
-    useBrowserTitle('browserTitle.cliAuth.success');
 
     useEffect(() => {
         if (!session) {
@@ -47,7 +57,7 @@ export function CliAuthSuccess() {
     }, [tokenValue, session, navigate]);
 
     const copyToken = () => {
-        void navigator.clipboard.writeText(tokenValue);
+        void navigator.clipboard.writeText(tokenValue ?? '');
     };
 
     return (
@@ -70,7 +80,7 @@ export function CliAuthSuccess() {
                 <TextareaAutosize
                     minRows={4}
                     cols={50}
-                    value={tokenValue}
+                    value={tokenValue ?? ''}
                     id="accessTokenValue"
                 />
             </Box>

--- a/src/components/cli/CliAuthSuccess.tsx
+++ b/src/components/cli/CliAuthSuccess.tsx
@@ -1,0 +1,76 @@
+import {
+    Box,
+    Button,
+    SxProps,
+    TextareaAutosize,
+    Theme,
+    Typography,
+} from '@mui/material';
+import { Auth } from '@supabase/ui';
+import { unauthenticatedRoutes } from 'app/routes';
+import PageContainer from 'components/shared/PageContainer';
+import useBrowserTitle from 'hooks/useBrowserTitle';
+import LogRocket from 'logrocket';
+import { useEffect } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { CustomEvents } from 'services/logrocket';
+
+const boxStyling: SxProps<Theme> = {
+    marginBottom: 2,
+    padding: 2,
+};
+
+export function CliAuthSuccess() {
+    const user = Auth.useUser();
+    const session = user.session;
+    const tokenValue = btoa(
+        JSON.stringify({
+            access_token: session?.access_token,
+            refresh_token: session?.refresh_token,
+            expires_at: (session?.expires_at ?? 0) + (session?.expires_in ?? 0),
+        })
+    );
+    useBrowserTitle('browserTitle.cliAuth.success');
+
+    useEffect(() => {
+        LogRocket.track(CustomEvents.FLOWCTL_LOGIN, {
+            user_id: session?.user?.id,
+        });
+    }, [tokenValue, session?.user?.id]);
+
+    const copyToken = () => {
+        navigator.clipboard.writeText(tokenValue);
+    };
+
+    return (
+        <PageContainer
+            pageTitleProps={{
+                header: unauthenticatedRoutes.cliAuth.success.title,
+                headerLink:
+                    'https://docs.estuary.dev/reference/authentication/#authenticating-flow-using-the-cli',
+            }}
+        >
+            <Box sx={boxStyling}>
+                <Typography variant="h6" sx={{ mb: 0.5 }}>
+                    <FormattedMessage id="cliAuth.accessToken" />
+                </Typography>
+
+                <Typography sx={{ mb: 2 }}>
+                    <FormattedMessage id="cliAuth.accessToken.message" />
+                </Typography>
+
+                <TextareaAutosize
+                    minRows={4}
+                    cols={50}
+                    value={tokenValue}
+                    id="accessTokenValue"
+                />
+            </Box>
+            <Button onClick={copyToken} sx={{ mb: 1.0 }}>
+                <FormattedMessage id="cliAuth.accessToken.copyButton" />
+            </Button>
+        </PageContainer>
+    );
+}
+
+export default CliAuthSuccess;

--- a/src/components/cli/CliLogin.tsx
+++ b/src/components/cli/CliLogin.tsx
@@ -1,7 +1,4 @@
 import { Login } from 'pages/Login';
-
-import FullPageSpinner from 'components/fullPage/Spinner';
-import * as React from 'react';
 import { unauthenticatedRoutes } from '../../app/routes';
 
 export const CliLogin = () => {
@@ -19,9 +16,5 @@ export const CliLogin = () => {
             redirectTo + unauthenticatedRoutes.cliAuth.success.fullPath;
     }
 
-    return (
-        <React.Suspense fallback={<FullPageSpinner />}>
-            <Login redirectTo={redirectTo} />
-        </React.Suspense>
-    );
+    return <Login redirectTo={redirectTo} />;
 };

--- a/src/components/cli/CliLogin.tsx
+++ b/src/components/cli/CliLogin.tsx
@@ -1,0 +1,27 @@
+import { Login } from 'pages/Login';
+
+import FullPageSpinner from 'components/fullPage/Spinner';
+import * as React from 'react';
+import { unauthenticatedRoutes } from '../../app/routes';
+
+export const CliLogin = () => {
+    // The origin will likely end with a '/', which can result in doubled '/'
+    // characters, which doesn't work with magicLink redirects. So this ensures
+    // that `redirectTo` is always a well-formed absolute URL.
+    let redirectTo = window.location.origin;
+    if (redirectTo.substr(-1) === '/') {
+        // fullPath always starts with a '/'
+        redirectTo =
+            redirectTo +
+            unauthenticatedRoutes.cliAuth.success.fullPath.substr(1);
+    } else {
+        redirectTo =
+            redirectTo + unauthenticatedRoutes.cliAuth.success.fullPath;
+    }
+
+    return (
+        <React.Suspense fallback={<FullPageSpinner />}>
+            <Login redirectTo={redirectTo} />
+        </React.Suspense>
+    );
+};

--- a/src/components/login/MagicLink.tsx
+++ b/src/components/login/MagicLink.tsx
@@ -6,12 +6,11 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { custom_generateDefaultUISchema } from 'services/jsonforms';
 import useConstant from 'use-constant';
 
-// TODO (routes) This is hardcoded because unauthenticated routes is not yet invoked
-//   need to move the routes to a single location. Also... just need to make the route
-//   settings in all JSON probably.
-const redirectTo = `${window.location.origin}/auth`;
+interface Props {
+    redirectTo: string;
+}
 
-const MagicLink = () => {
+const MagicLink = ({ redirectTo }: Props) => {
     const [showTokenValidation, setShowTokenValidation] = useState(false);
 
     const supabaseClient = useClient();
@@ -68,6 +67,10 @@ const MagicLink = () => {
 
     custom_generateDefaultUISchema;
 
+    // Redirects need to be handled manually using the react router api, which
+    // only deals with paths, not full urls.
+    const redirectUrl = new URL(redirectTo);
+
     return (
         <Stack direction="column" spacing={1}>
             {showTokenValidation ? (
@@ -79,13 +82,12 @@ const MagicLink = () => {
                                 token: formData.token,
                                 type: 'magiclink',
                             },
-                            {
-                                redirectTo,
-                            }
+                            {}
                         );
                     }}
                     schema={verifySchema}
                     uiSchema={verifyUiSchema}
+                    navigateOnSuccess={`${redirectUrl.pathname}${redirectUrl.search}`}
                 />
             ) : (
                 <MagicLinkInputs

--- a/src/components/login/MagicLinkInputs.tsx
+++ b/src/components/login/MagicLinkInputs.tsx
@@ -8,6 +8,7 @@ import { isEmpty } from 'lodash';
 import { useSnackbar, VariantType } from 'notistack';
 import React, { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useNavigate } from 'react-router-dom';
 import defaultRenderers from 'services/jsonforms/defaultRenderers';
 import {
     defaultOptions,
@@ -19,11 +20,19 @@ interface Props {
     onSubmit: Function;
     schema: JsonSchema;
     uiSchema: any; //UISchemaElement
+    // If provided, then the form will navigate to this location once `onSubmit` is successful.
+    navigateOnSuccess?: string;
 }
 
-const MagicLinkInputs = ({ onSubmit, schema, uiSchema }: Props) => {
+const MagicLinkInputs = ({
+    onSubmit,
+    schema,
+    uiSchema,
+    navigateOnSuccess,
+}: Props) => {
     const hasToken = schema.properties?.token;
 
+    const navigate = useNavigate();
     const { enqueueSnackbar } = useSnackbar();
     const intl = useIntl();
 
@@ -88,6 +97,9 @@ const MagicLinkInputs = ({ onSubmit, schema, uiSchema }: Props) => {
 
             if (!hasToken) {
                 displayNotification('login.magicLink', 'success');
+            }
+            if (navigateOnSuccess) {
+                navigate(navigateOnSuccess);
             }
         },
     };

--- a/src/components/login/MagicLinkInputs.tsx
+++ b/src/components/login/MagicLinkInputs.tsx
@@ -86,17 +86,17 @@ const MagicLinkInputs = ({
             setShowErrors(false);
             setLoading(true);
 
-            const { error } = await onSubmit(formData).finally(() => {
-                setLoading(false);
-            });
+            const { error } = await onSubmit(formData);
 
             if (error) {
                 setSubmitError(error);
+                setLoading(false);
                 return;
             }
 
             if (!hasToken) {
                 displayNotification('login.magicLink', 'success');
+                setLoading(false);
             }
             if (navigateOnSuccess) {
                 navigate(navigateOnSuccess);

--- a/src/components/login/OIDCs.tsx
+++ b/src/components/login/OIDCs.tsx
@@ -6,14 +6,12 @@ import GoogleButton from 'react-google-button';
 import { useIntl } from 'react-intl';
 import GithubButton from './GithubButton';
 
-// TODO (routes) This is hardcoded because unauthenticated routes... (same as MagicLink)
-const redirectTo = `${window.location.origin}/auth`;
-
 interface Props {
     isRegister?: boolean;
+    redirectTo: string;
 }
 
-function OIDCs({ isRegister }: Props) {
+function OIDCs({ isRegister, redirectTo }: Props) {
     const supabaseClient = useClient();
     const intl = useIntl();
 

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -173,6 +173,9 @@ const RouteTitles: ResolvedIntlConfig['messages'] = {
     'routeTitle.captureEdit': `Edit Capture`,
     'routeTitle.captures': `Captures`,
     'routeTitle.collections': `Collections`,
+    'routeTitle.cliAuth': `Flowctl Login`,
+    'routeTitle.cliAuth.login': `Flowctl Login`,
+    'routeTitle.cliAuth.success': `Flowctl Login Successful`,
     'routeTitle.directives': `Directives`,
     'routeTitle.error.pageNotFound': `Page Not Found`,
     'routeTitle.login': `Login`,
@@ -192,6 +195,8 @@ const BrowserTitles: ResolvedIntlConfig['messages'] = {
     'browserTitle.admin': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.admin']}`,
     'browserTitle.admin.accessGrants': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.admin.accessGrants']}`,
     'browserTitle.admin.api': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.admin.api']}`,
+
+    'browserTitle.cliAuth.success': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.cliAuth.success']}`,
     'browserTitle.admin.connectors': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.admin.connectors']}`,
     'browserTitle.captureCreate': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.captureCreate']}`,
     'browserTitle.captureEdit': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.captureEdit']}`,
@@ -304,6 +309,12 @@ const LoginPage: ResolvedIntlConfig['messages'] = {
     'login.registerFailed.google': 'Failed to register with Google',
     'login.registerFailed.github': 'Failed to register with GitHub',
     'login.userNotFound': 'User not found. Please sign up below.',
+};
+
+const CliAuth: ResolvedIntlConfig['messages'] = {
+    'cliAuth.accessToken': 'Access Token',
+    'cliAuth.accessToken.message': `Copy the access token below and paste it into your terminal.`,
+    'cliAuth.accessToken.copyButton': 'Copy Token',
 };
 
 const EntityStatus: ResolvedIntlConfig['messages'] = {
@@ -755,6 +766,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...Error,
     ...NoGrants,
     ...LoginPage,
+    ...CliAuth,
     ...AccessGrants,
     ...Collections,
     ...Materializations,

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -13,9 +13,10 @@ const loginSettings = getLoginSettings();
 
 interface Props {
     showRegistration?: boolean;
+    redirectTo: string;
 }
 
-const Login = ({ showRegistration }: Props) => {
+export const Login = ({ showRegistration, redirectTo }: Props) => {
     useBrowserTitle('browserTitle.login');
 
     const { 2: clearGatewayConfig } = useLocalStorage(LocalStorageKeys.GATEWAY);
@@ -63,7 +64,10 @@ const Login = ({ showRegistration }: Props) => {
 
                 <Stack direction="column" spacing={2}>
                     <Box>
-                        <OIDCs isRegister={isRegister} />
+                        <OIDCs
+                            isRegister={isRegister}
+                            redirectTo={redirectTo}
+                        />
                     </Box>
 
                     {!isRegister && loginSettings.showEmail ? (
@@ -73,7 +77,7 @@ const Login = ({ showRegistration }: Props) => {
                             </Divider>
 
                             <Box>
-                                <MagicLink />
+                                <MagicLink redirectTo={redirectTo} />
                             </Box>
                         </>
                     ) : null}

--- a/src/services/logrocket.ts
+++ b/src/services/logrocket.ts
@@ -33,6 +33,7 @@ export enum CustomEvents {
     MATERIALIZATION_TEST = 'Materialization_Test',
     MATERIALIZATION_EDIT = 'Materialization_Edit',
     DIRECTIVE = 'Directive',
+    FLOWCTL_LOGIN = 'Flowctl_Login',
 }
 
 const logRocketSettings = getLogRocketSettings();

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -118,7 +118,6 @@ export const cliScopedLocalStorage = {
             }
         }
 
-        console.log('clear', toRemove);
         toRemove.forEach((k: string) => {
             localStorage.removeItem(k);
         });


### PR DESCRIPTION
## Changes

Adds support for a new way for `flowctl` to authenticate.  First, the `/cli-auth/login` page was added. Once a user logs in there, they are redirected to `/cli-auth/success`. Both of those pages use separate Context providers so that they will use an entirely separate go-true session and local storage entry than the rest of the web app. Effectively, `flowctl` has its own separate session, and only it will attempt to refresh the credentials for it.

As part of this, I had to do a bit of refactoring to allow re-using our existing `Login` component with different redirect urls. I also fixed an issue where redirects weren't working if the user manually entered the OTP rather than clicking the link from the email. In that case, we need to handle the redirect ourselves, since the `/auth/v1/validateToken` endpoint will not respond with redirects.

There's definitely still a bunch of room for improvement here. Some things that I'd like to eventually see:

- The login page for the CLI being differentiated from the general login page
- Better handling for if a user ends up on `/cli-auth/success` without there being a session in localStorage. Currently, we just generate a bogus token value, which is pretty rough.
- Passing the credential to the CLI via an XHR request.
- Some sort of UX around logging out and invalidating the CLI session / refresh token

Note that this leaves the existing Admin - API tab untouched for the time being, so that current CLI users are not impacted. Once the new `flowctl` is released, we can remove that tab or replace it with a note about using `flowctl auth login` instead.

## Tests

I've tested this manually by navigating to the `/cli-auth/login` url and going through the flow end to end with `flowctl`.

## Content

There's a little bit of copy that was added.

## Screenshots

After a successful login:

![image](https://user-images.githubusercontent.com/4495829/204666675-f4d620cb-7698-45b8-8093-728559376eb7.png)

