### PR TITLE
jsonforms: keep Z pattern in forms

### DIFF
--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -38,7 +38,7 @@ import {
     toDataPath,
     UISchemaElement,
 } from '@jsonforms/core';
-import { concat, forEach, includes, orderBy } from 'lodash';
+import { concat, includes, orderBy } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import keys from 'lodash/keys';
 import startCase from 'lodash/startCase';
@@ -48,19 +48,6 @@ import { ADVANCED, CONTAINS_REQUIRED_FIELDS } from './shared';
 /////////////////////////////////////////////////////////
 //  CUSTOM FUNCTIONS AND SETTINGS
 /////////////////////////////////////////////////////////
-
-// This is where we do all the "pre processing" that the UI requires
-//  1. Replace timezone string so validation works
-export const processSchemaForRendering = (endpointSchema: JsonSchema) => {
-    forEach(endpointSchema.properties, (value) => {
-        if (value.properties) {
-            processSchemaForRendering(value.properties);
-        }
-    });
-
-    return endpointSchema;
-};
-
 const addOption = (elem: ControlElement | Layout, key: string, value: any) => {
     if (!elem.options) {
         elem.options = {};

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -55,11 +55,6 @@ export const processSchemaForRendering = (endpointSchema: JsonSchema) => {
     forEach(endpointSchema.properties, (value) => {
         if (value.properties) {
             processSchemaForRendering(value.properties);
-        } else if (value.pattern?.endsWith('Z$')) {
-            value.pattern = value.pattern.replace(
-                'Z$',
-                `[-+]{1}[0-9]{2}:[0-9]{2}$`
-            );
         }
     });
 

--- a/src/stores/EndpointConfig.tsx
+++ b/src/stores/EndpointConfig.tsx
@@ -10,7 +10,6 @@ import {
     useContext,
 } from 'react';
 import { createJSONFormDefaults } from 'services/ajv';
-import { processSchemaForRendering } from 'services/jsonforms';
 import {
     Entity,
     EntityWithCreateWorkflow,
@@ -207,7 +206,7 @@ const getInitialState = (
     setEndpointSchema: (val) => {
         set(
             produce((state) => {
-                state.endpointSchema = processSchemaForRendering(val);
+                state.endpointSchema = val;
             }),
             false,
             'Endpoint Schema Set'

--- a/src/types/jsonforms.ts
+++ b/src/types/jsonforms.ts
@@ -23,8 +23,8 @@ export enum Formats {
 // https://day.js.org/docs/en/display/format
 export enum Patterns {
     date = 'YYYY-MM-DD',
-    dateTime = 'YYYY-MM-DDTHH:mm:ssZ',
-    time = 'HH:mm:ss',
+    dateTime = 'YYYY-MM-DDTHH:mm:ss[Z]',
+    time = 'HH:mm:ss[Z]',
 }
 
 export enum Annotations {


### PR DESCRIPTION
## Changes

- Keep the Z pattern in forms as the literal `Z` stands for UTC and that's what connectors expect

## Tests

Tested locally

## Issues

_Please list out any related issues (Here so issue is not auto closed by PR)_

## Content

_Were there any changes to [content](https://github.com/estuary/ui/tree/main/src/lang) that you need to get reviewed?_

## Screenshots

Local test:
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/2807772/205054876-74d25df6-1b84-4ecb-8626-4b895dd9fda7.png">

