### PR TITLE
Prefill empty collections when materialize table CTA clicked

### DIFF
--- a/src/api/hydration.ts
+++ b/src/api/hydration.ts
@@ -43,7 +43,7 @@ export const getSchema_Resource = async (connectorId: string | null) => {
 const liveSpecColumns = `id,spec_type,spec,writes_to,reads_from,last_pub_id`;
 
 export const getLiveSpecsByLiveSpecId = async (
-    liveSpecId: string,
+    liveSpecId: string | string[],
     specType: Entity
 ) => {
     const draftArray: string[] =
@@ -60,7 +60,7 @@ export const getLiveSpecsByLiveSpecId = async (
 };
 
 export const getLiveSpecsByLastPubId = async (
-    lastPubId: string,
+    lastPubId: string | string[],
     specType: Entity
 ) => {
     const draftArray: string[] =

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -480,8 +480,10 @@ const getInitialState = (
     hydrateState: async (editWorkflow, entityType) => {
         const searchParams = new URLSearchParams(window.location.search);
         const connectorId = searchParams.get(GlobalSearchParams.CONNECTOR_ID);
-        const liveSpecId = searchParams.get(GlobalSearchParams.LIVE_SPEC_ID);
         const lastPubId = searchParams.get(GlobalSearchParams.LAST_PUB_ID);
+        const liveSpecIds = searchParams.getAll(
+            GlobalSearchParams.LIVE_SPEC_ID
+        );
 
         const { setHydrationErrorsExist } = get();
 
@@ -503,6 +505,10 @@ const getInitialState = (
 
         if (!editWorkflow) {
             if (lastPubId) {
+                // Prefills collections in the materialization create workflow when the Materialize CTA
+                // on the Captures page is clicked.
+                console.log('A');
+
                 const { data, error } = await getLiveSpecsByLastPubId(
                     lastPubId,
                     'capture'
@@ -517,10 +523,12 @@ const getInitialState = (
 
                     preFillEmptyCollections(data);
                 }
-            } else if (liveSpecId) {
+            } else if (liveSpecIds.length > 0) {
+                // Prefills collections in the materialization create workflow when the Materialize CTA
+                // on the capture pubilication log dialog is clicked.
                 const { data, error } = await getLiveSpecsByLiveSpecId(
-                    liveSpecId,
-                    entityType
+                    liveSpecIds,
+                    'capture'
                 );
 
                 if (error) {
@@ -533,9 +541,9 @@ const getInitialState = (
                     preFillEmptyCollections(data);
                 }
             }
-        } else if (liveSpecId) {
+        } else if (liveSpecIds.length > 0) {
             const { data, error } = await getLiveSpecsByLiveSpecId(
-                liveSpecId,
+                liveSpecIds[0],
                 entityType
             );
 

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -507,8 +507,6 @@ const getInitialState = (
             if (lastPubId) {
                 // Prefills collections in the materialization create workflow when the Materialize CTA
                 // on the Captures page is clicked.
-                console.log('A');
-
                 const { data, error } = await getLiveSpecsByLastPubId(
                     lastPubId,
                     'capture'

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -22,7 +22,6 @@ export const hasLength = (val: string | any[] | null | undefined): boolean => {
     return Boolean(val && val.length > 0);
 };
 
-// TODO: Replace instances of getPathWithParam with the expanded utility function below.
 export const getPathWithParams = (
     baseURL: string,
     params: { [key: string]: string | string[] } | URLSearchParams


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Prefill the _Output Collections_ section of the materialization create form with the collections associated with the captures selected on the _Captures_ table when the _Materialize_ CTA was clicked.

1. Update the resource config store hydration logic for the materialization create workflow. The live spec hydration queries performed here should only apply to captures and it is possible for a series of live spec IDs to be passed as query parameters.

1. Expand the type annotation for the id-related parameter of the live specs hydration APIs (i.e., _src/api/hydration.ts_) to included a string array.

## Tests

Only manual testing was performed.

## Issues

The issues directly below are completely resolved by this PR:
#385

## Screenshots

**Captures Selected**

<img width="990" alt="pr_screenshot-403-materialization_table_cta-selected_captures" src="https://user-images.githubusercontent.com/77648584/206024099-9f69388e-1357-4b28-975b-0c7161530372.PNG">

<br />

**Prefilled Materialization Create Form**

<img width="990" alt="pr_screenshot-403-materialization_table_cta-form_prefilled" src="https://user-images.githubusercontent.com/77648584/206024320-e9809899-a50b-4b2c-9b25-ec7cf47a0b79.PNG">