### PR TITLE
Add rediscover CTA to capture workflows

### DIFF
--- a/src/api/draftSpecs.ts
+++ b/src/api/draftSpecs.ts
@@ -140,26 +140,28 @@ export const generateDraftSpec = (
 };
 
 export const generateCaptureDraftSpec = (
-    resourceConfig: ResourceConfigDictionary,
-    endpoint: CaptureEndpoint
+    endpoint: CaptureEndpoint,
+    resourceConfig: ResourceConfigDictionary | null
 ): CaptureDef => {
     const draftSpec: CaptureDef = {
         bindings: [],
         endpoint,
     };
 
-    Object.keys(resourceConfig).forEach((collectionName) => {
-        const resources = resourceConfig[collectionName].data;
+    if (resourceConfig) {
+        Object.keys(resourceConfig).forEach((collectionName) => {
+            const resources = resourceConfig[collectionName].data;
 
-        if (Object.keys(resources).length > 0) {
-            draftSpec.bindings.push({
-                target: collectionName,
-                resource: {
-                    ...resources,
-                },
-            });
-        }
-    });
+            if (Object.keys(resources).length > 0) {
+                draftSpec.bindings.push({
+                    target: collectionName,
+                    resource: {
+                        ...resources,
+                    },
+                });
+            }
+        });
+    }
 
     return draftSpec;
 };

--- a/src/components/capture/Create.tsx
+++ b/src/components/capture/Create.tsx
@@ -1,6 +1,7 @@
 import { getDraftSpecsBySpecType } from 'api/draftSpecs';
 import { authenticatedRoutes } from 'app/routes';
 import CaptureGenerateButton from 'components/capture/GenerateButton';
+import RediscoverButton from 'components/capture/RediscoverButton';
 import {
     useEditorStore_id,
     useEditorStore_persistedDraftId,
@@ -340,6 +341,13 @@ function CaptureCreate() {
                                     logEvent={CustomEvents.CAPTURE_CREATE}
                                 />
                             }
+                        />
+                    }
+                    RediscoverButton={
+                        <RediscoverButton
+                            disabled={!hasConnectors}
+                            callFailed={helpers.callFailed}
+                            subscription={discoversSubscription}
                         />
                     }
                 />

--- a/src/components/capture/Create.tsx
+++ b/src/components/capture/Create.tsx
@@ -1,4 +1,3 @@
-import { getDraftSpecsBySpecType } from 'api/draftSpecs';
 import { authenticatedRoutes } from 'app/routes';
 import CaptureGenerateButton from 'components/capture/GenerateButton';
 import RediscoverButton from 'components/capture/RediscoverButton';
@@ -8,7 +7,6 @@ import {
     useEditorStore_pubId,
     useEditorStore_resetState,
     useEditorStore_setId,
-    useEditorStore_setPersistedDraftId,
 } from 'components/editor/Store/hooks';
 import EntitySaveButton from 'components/shared/Entity/Actions/SaveButton';
 import EntityTestButton from 'components/shared/Entity/Actions/TestButton';
@@ -17,66 +15,31 @@ import EntityToolbar from 'components/shared/Entity/Header';
 import ValidationErrorSummary from 'components/shared/Entity/ValidationErrorSummary';
 import PageContainer from 'components/shared/PageContainer';
 import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
-import { useClient } from 'hooks/supabase-swr';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import useDraftSpecs from 'hooks/useDraftSpecs';
-import LogRocket from 'logrocket';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 import {
-    DEFAULT_FILTER,
-    jobStatusPoller,
-    JOB_STATUS_POLLER_ERROR,
-    TABLES,
-} from 'services/supabase';
-import {
     useDetailsForm_connectorImage,
     useDetailsForm_errorsExist,
     useDetailsForm_resetState,
-    useDetailsForm_setDraftedEntityName,
 } from 'stores/DetailsForm';
-import {
-    useEndpointConfigStore_reset,
-    useEndpointConfigStore_setEncryptedEndpointConfig,
-    useEndpointConfigStore_setPreviousEndpointConfig,
-} from 'stores/EndpointConfig';
+import { useEndpointConfigStore_reset } from 'stores/EndpointConfig';
 import {
     useFormStateStore_exitWhenLogsClose,
-    useFormStateStore_messagePrefix,
     useFormStateStore_resetState,
     useFormStateStore_setFormState,
 } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
-import {
-    useResourceConfig_evaluateDiscoveredCollections,
-    useResourceConfig_resetState,
-    useResourceConfig_restrictedDiscoveredCollections,
-    useResourceConfig_setDiscoveredCollections,
-} from 'stores/ResourceConfig/hooks';
+import { useResourceConfig_resetState } from 'stores/ResourceConfig/hooks';
 import ResourceConfigHydrator from 'stores/ResourceConfig/Hydrator';
-import { ResourceConfigDictionary } from 'stores/ResourceConfig/types';
-import { JsonFormsData } from 'types';
 import { getPathWithParams } from 'utils/misc-utils';
-import { modifyDiscoveredDraftSpec } from 'utils/workflow-utils';
-
-const trackEvent = (payload: any) => {
-    LogRocket.track(CustomEvents.CAPTURE_DISCOVER, {
-        name: payload.capture_name ?? DEFAULT_FILTER,
-        id: payload.id ?? DEFAULT_FILTER,
-        draft_id: payload.draft_id ?? DEFAULT_FILTER,
-        logs_token: payload.logs_token ?? DEFAULT_FILTER,
-        status: payload.job_status?.type ?? DEFAULT_FILTER,
-    });
-};
 
 function CaptureCreate() {
     const navigate = useNavigate();
 
     const entityType = 'capture';
-
-    // Supabase stuff
-    const supabaseClient = useClient();
 
     const { connectorTags } = useConnectorWithTagDetail(entityType);
     const hasConnectors = connectorTags.length > 0;
@@ -86,44 +49,22 @@ function CaptureCreate() {
     const detailsFormErrorsExist = useDetailsForm_errorsExist();
     const resetDetailsForm = useDetailsForm_resetState();
 
-    const setDraftedEntityName = useDetailsForm_setDraftedEntityName();
-
     // Draft Editor Store
     const draftId = useEditorStore_id();
     const setDraftId = useEditorStore_setId();
-
     const persistedDraftId = useEditorStore_persistedDraftId();
-    const setPersistedDraftId = useEditorStore_setPersistedDraftId();
-
     const pubId = useEditorStore_pubId();
-
     const resetEditorStore = useEditorStore_resetState();
 
     // Endpoint Config Store
-    const setEncryptedEndpointConfig =
-        useEndpointConfigStore_setEncryptedEndpointConfig();
-
-    const setPreviousEndpointConfig =
-        useEndpointConfigStore_setPreviousEndpointConfig();
-
     const resetEndpointConfigState = useEndpointConfigStore_reset();
 
     // Form State Store
-    const messagePrefix = useFormStateStore_messagePrefix();
     const setFormState = useFormStateStore_setFormState();
     const resetFormState = useFormStateStore_resetState();
     const exitWhenLogsClose = useFormStateStore_exitWhenLogsClose();
 
     // Resource Config Store
-    const restrictedDiscoveredCollections =
-        useResourceConfig_restrictedDiscoveredCollections();
-
-    const setDiscoveredCollections =
-        useResourceConfig_setDiscoveredCollections();
-
-    const evaluateDiscoveredCollections =
-        useResourceConfig_evaluateDiscoveredCollections();
-
     const resetResourceConfigState = useResourceConfig_resetState();
 
     const { mutate: mutateDraftSpecs, ...draftSpecsMetadata } =
@@ -191,109 +132,6 @@ function CaptureCreate() {
         },
     };
 
-    const storeDiscoveredCollections = async (
-        newDraftId: string,
-        resourceConfig: ResourceConfigDictionary
-    ) => {
-        // TODO (optimization | typing): Narrow the columns selected from the draft_specs_ext table.
-        //   More columns are selected than required to appease the typing of the editor store.
-        const draftSpecsResponse = await getDraftSpecsBySpecType(
-            newDraftId,
-            entityType
-        );
-
-        if (draftSpecsResponse.error) {
-            return helpers.callFailed({
-                error: {
-                    title: 'captureCreate.generate.failedErrorTitle',
-                    error: draftSpecsResponse.error,
-                },
-            });
-        }
-
-        if (draftSpecsResponse.data && draftSpecsResponse.data.length > 0) {
-            setDiscoveredCollections(draftSpecsResponse.data[0]);
-
-            const updatedDraftSpecsResponse = await modifyDiscoveredDraftSpec(
-                draftSpecsResponse,
-                resourceConfig,
-                restrictedDiscoveredCollections
-            );
-            if (updatedDraftSpecsResponse.error) {
-                return helpers.callFailed({
-                    error: {
-                        title: 'captureCreate.generate.failedErrorTitle',
-                        error: updatedDraftSpecsResponse.error,
-                    },
-                });
-            }
-
-            if (
-                updatedDraftSpecsResponse.data &&
-                updatedDraftSpecsResponse.data.length > 0
-            ) {
-                evaluateDiscoveredCollections(updatedDraftSpecsResponse);
-
-                setEncryptedEndpointConfig({
-                    data: updatedDraftSpecsResponse.data[0].spec.endpoint
-                        .connector.config,
-                });
-            }
-        }
-
-        setDraftId(newDraftId);
-        setPersistedDraftId(newDraftId);
-    };
-
-    // TODO (optimization): Create a shared discovers table subscription.
-    const discoversSubscription = (
-        discoverDraftId: string,
-        existingEndpointConfig: JsonFormsData,
-        resourceConfig: ResourceConfigDictionary
-    ) => {
-        setDraftId(null);
-
-        jobStatusPoller(
-            supabaseClient
-                .from(TABLES.DISCOVERS)
-                .select(
-                    `
-                    capture_name,
-                    draft_id,
-                    job_status
-                `
-                )
-                .match({
-                    draft_id: discoverDraftId,
-                }),
-            async (payload: any) => {
-                await storeDiscoveredCollections(
-                    payload.draft_id,
-                    resourceConfig
-                );
-
-                void mutateDraftSpecs();
-
-                setDraftedEntityName(payload.capture_name);
-
-                setPreviousEndpointConfig({ data: existingEndpointConfig });
-
-                setFormState({
-                    status: FormStatus.GENERATED,
-                });
-
-                trackEvent(payload);
-            },
-            (payload: any) => {
-                if (payload.error === JOB_STATUS_POLLER_ERROR) {
-                    helpers.jobFailed(payload.error);
-                } else {
-                    helpers.jobFailed(`${messagePrefix}.test.failedErrorTitle`);
-                }
-            }
-        );
-    };
-
     return (
         <PageContainer
             pageTitleProps={{
@@ -317,9 +155,10 @@ function CaptureCreate() {
                         <EntityToolbar
                             GenerateButton={
                                 <CaptureGenerateButton
+                                    entityType={entityType}
                                     disabled={!hasConnectors}
                                     callFailed={helpers.callFailed}
-                                    subscription={discoversSubscription}
+                                    postGenerateMutate={mutateDraftSpecs}
                                 />
                             }
                             TestButton={
@@ -345,9 +184,10 @@ function CaptureCreate() {
                     }
                     RediscoverButton={
                         <RediscoverButton
+                            entityType={entityType}
                             disabled={!hasConnectors}
                             callFailed={helpers.callFailed}
-                            subscription={discoversSubscription}
+                            postGenerateMutate={mutateDraftSpecs}
                         />
                     }
                 />

--- a/src/components/capture/GenerateButton.tsx
+++ b/src/components/capture/GenerateButton.tsx
@@ -1,166 +1,27 @@
 import { Button } from '@mui/material';
-import { discover } from 'api/discovers';
-import { createEntityDraft } from 'api/drafts';
-import {
-    useEditorStore_isSaving,
-    useEditorStore_resetState,
-} from 'components/editor/Store/hooks';
 import { buttonSx } from 'components/shared/Entity/Header';
-import { useEntityWorkflow } from 'context/Workflow';
-import useGlobalSearchParams, {
-    GlobalSearchParams,
-} from 'hooks/searchParams/useGlobalSearchParams';
-import { isEmpty } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import {
-    useDetailsForm_connectorImage_connectorId,
-    useDetailsForm_connectorImage_id,
-    useDetailsForm_details_entityName,
-    useDetailsForm_errorsExist,
-} from 'stores/DetailsForm';
-import {
-    useEndpointConfigStore_changed,
-    useEndpointConfigStore_encryptedEndpointConfig_data,
-    useEndpointConfigStore_endpointConfig_data,
-    useEndpointConfigStore_endpointSchema,
-    useEndpointConfigStore_errorsExist,
-    useEndpointConfig_serverUpdateRequired,
-} from 'stores/EndpointConfig';
-import {
-    useFormStateStore_isActive,
-    useFormStateStore_setFormState,
-    useFormStateStore_updateStatus,
-} from 'stores/FormState/hooks';
-import { FormStatus } from 'stores/FormState/types';
-import { useResourceConfig_resourceConfig } from 'stores/ResourceConfig/hooks';
-import { encryptEndpointConfig } from 'utils/sops-utils';
+import { Entity } from 'types';
+import useDiscoverCapture from './useDiscoverCapture';
 
-// TODO (typing): Narrow the type annotation attributed to the subscription property.
 interface Props {
+    entityType: Entity;
     disabled: boolean;
     callFailed: Function;
-    subscription: Function;
+    postGenerateMutate: Function;
 }
 
-function CaptureGenerateButton({ disabled, callFailed, subscription }: Props) {
-    const initialConnectorId = useGlobalSearchParams(
-        GlobalSearchParams.CONNECTOR_ID
+function CaptureGenerateButton({
+    entityType,
+    disabled,
+    callFailed,
+    postGenerateMutate,
+}: Props) {
+    const { generateCatalog, isSaving, formActive } = useDiscoverCapture(
+        entityType,
+        callFailed,
+        postGenerateMutate
     );
-
-    const workflow = useEntityWorkflow();
-    const editWorkflow = workflow === 'capture_edit';
-
-    // Editor Store
-    const isSaving = useEditorStore_isSaving();
-
-    const resetEditorState = useEditorStore_resetState();
-
-    // Form State Store
-    const formActive = useFormStateStore_isActive();
-
-    const setFormState = useFormStateStore_setFormState();
-
-    const updateFormStatus = useFormStateStore_updateStatus();
-
-    // Details Form Store
-    const entityName = useDetailsForm_details_entityName();
-    const detailsFormsHasErrors = useDetailsForm_errorsExist();
-
-    const imageConnectorId = useDetailsForm_connectorImage_connectorId();
-    const imageConnectorTagId = useDetailsForm_connectorImage_id();
-
-    // Endpoint Config Store
-    const endpointSchema = useEndpointConfigStore_endpointSchema();
-
-    const endpointConfigData = useEndpointConfigStore_endpointConfig_data();
-
-    const serverEndpointConfigData =
-        useEndpointConfigStore_encryptedEndpointConfig_data();
-    const endpointConfigErrorsExist = useEndpointConfigStore_errorsExist();
-
-    const endpointConfigChanged = useEndpointConfigStore_changed();
-    const serverUpdateRequired = useEndpointConfig_serverUpdateRequired();
-
-    // Resource Config Store
-    const resourceConfig = useResourceConfig_resourceConfig();
-
-    const endpointConfigErrorFlag = editWorkflow
-        ? endpointConfigChanged() && endpointConfigErrorsExist
-        : endpointConfigErrorsExist || isEmpty(endpointConfigData);
-
-    const generateCatalog = async (event: React.MouseEvent<HTMLElement>) => {
-        event.preventDefault();
-        updateFormStatus(FormStatus.GENERATING);
-
-        if (detailsFormsHasErrors || endpointConfigErrorFlag) {
-            return setFormState({
-                status: FormStatus.FAILED,
-                displayValidation: true,
-            });
-        } else {
-            resetEditorState(true);
-
-            const draftsResponse = await createEntityDraft(entityName);
-            if (draftsResponse.error) {
-                return callFailed({
-                    error: {
-                        title: 'captureCreate.generate.failedErrorTitle',
-                        error: draftsResponse.error,
-                    },
-                });
-            }
-
-            const draftId = draftsResponse.data[0].id;
-
-            const selectedEndpointConfig = serverUpdateRequired
-                ? endpointConfigData
-                : serverEndpointConfigData;
-
-            const encryptedEndpointConfig = await encryptEndpointConfig(
-                selectedEndpointConfig,
-                endpointSchema,
-                serverUpdateRequired,
-                imageConnectorId,
-                imageConnectorTagId,
-                callFailed,
-                { overrideJsonFormDefaults: true }
-            );
-
-            let catalogName = entityName;
-
-            if (editWorkflow && imageConnectorId === initialConnectorId) {
-                // The discovery RPC will insert a row into the draft spec-related tables for the given task with verbiage
-                // identifying the external source appended to the task name (e.g., '/source-postgres'). To limit duplication
-                // of draft spec-related data, the aforementioned external source identifier is removed from the task name
-                // prior to executing the discovery RPC.
-                const lastSlashIndex = entityName.lastIndexOf('/');
-
-                if (lastSlashIndex !== -1) {
-                    catalogName = entityName.slice(0, lastSlashIndex);
-                }
-            }
-
-            const discoverResponse = await discover(
-                catalogName,
-                encryptedEndpointConfig.data,
-                imageConnectorTagId,
-                draftId
-            );
-            if (discoverResponse.error) {
-                return callFailed({
-                    error: {
-                        title: 'captureCreate.generate.failedErrorTitle',
-                        error: discoverResponse.error,
-                    },
-                });
-            }
-            subscription(draftId, endpointConfigData, resourceConfig);
-
-            setFormState({
-                logToken: discoverResponse.data[0].logs_token,
-            });
-        }
-    };
 
     return (
         <Button

--- a/src/components/capture/RediscoverButton.tsx
+++ b/src/components/capture/RediscoverButton.tsx
@@ -1,5 +1,18 @@
-import { Button } from '@mui/material';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Typography,
+} from '@mui/material';
 import useDiscoverCapture from 'components/capture/useDiscoverCapture';
+import {
+    glassBkgWithoutBlur,
+    secondaryButtonBackground,
+    secondaryButtonHoverBackground,
+} from 'context/Theme';
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Entity } from 'types';
 
@@ -10,12 +23,16 @@ interface Props {
     postGenerateMutate: Function;
 }
 
+const TITLE_ID = 'rediscovery-confirmation-dialog-title';
+
 function RediscoverButton({
     entityType,
     disabled,
     callFailed,
     postGenerateMutate,
 }: Props) {
+    const [open, setOpen] = useState<boolean>(false);
+
     const { generateCatalog, isSaving, formActive } = useDiscoverCapture(
         entityType,
         callFailed,
@@ -23,15 +40,85 @@ function RediscoverButton({
         { initiateRediscovery: true }
     );
 
+    const handlers = {
+        openConfirmationDialog: (event: React.MouseEvent<HTMLElement>) => {
+            event.preventDefault();
+
+            setOpen(true);
+        },
+        closeConfirmationDialog: (event: React.MouseEvent<HTMLElement>) => {
+            event.preventDefault();
+
+            setOpen(false);
+        },
+    };
+
     return (
-        <Button
-            variant="text"
-            disabled={disabled || isSaving || formActive}
-            onClick={generateCatalog}
-            sx={{ borderRadius: 0 }}
-        >
-            <FormattedMessage id="workflows.collectionSelector.cta.rediscover" />
-        </Button>
+        <>
+            <Dialog
+                open={open}
+                maxWidth="md"
+                aria-labelledby={TITLE_ID}
+                sx={{
+                    '& .MuiPaper-root.MuiDialog-paper': {
+                        backgroundColor: (theme) =>
+                            glassBkgWithoutBlur[theme.palette.mode],
+                        borderRadius: 5,
+                    },
+                }}
+            >
+                <DialogTitle id={TITLE_ID}>
+                    <FormattedMessage id="workflows.collectionSelector.rediscoverDialog.title" />
+                </DialogTitle>
+
+                <DialogContent>
+                    <Typography sx={{ mb: 2 }}>
+                        <FormattedMessage id="workflows.collectionSelector.rediscoverDialog.message1" />
+                    </Typography>
+
+                    <Typography>
+                        <FormattedMessage id="workflows.collectionSelector.rediscoverDialog.message2" />
+                    </Typography>
+                </DialogContent>
+
+                <DialogActions
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'flex-end',
+                    }}
+                >
+                    <Button
+                        onClick={handlers.closeConfirmationDialog}
+                        sx={{
+                            'backgroundColor': (theme) =>
+                                secondaryButtonBackground[theme.palette.mode],
+                            '&:hover': {
+                                backgroundColor: (theme) =>
+                                    secondaryButtonHoverBackground[
+                                        theme.palette.mode
+                                    ],
+                            },
+                        }}
+                    >
+                        <FormattedMessage id="cta.cancel" />
+                    </Button>
+
+                    <Button onClick={generateCatalog}>
+                        <FormattedMessage id="cta.continue" />
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <Button
+                variant="text"
+                disabled={disabled || isSaving || formActive}
+                onClick={handlers.openConfirmationDialog}
+                sx={{ borderRadius: 0 }}
+            >
+                <FormattedMessage id="workflows.collectionSelector.cta.rediscover" />
+            </Button>
+        </>
     );
 }
 

--- a/src/components/capture/RediscoverButton.tsx
+++ b/src/components/capture/RediscoverButton.tsx
@@ -51,6 +51,11 @@ function RediscoverButton({
 
             setOpen(false);
         },
+        rediscoveryRequested: (event: React.MouseEvent<HTMLElement>) => {
+            setOpen(false);
+
+            generateCatalog(event);
+        },
     };
 
     return (
@@ -104,7 +109,7 @@ function RediscoverButton({
                         <FormattedMessage id="cta.cancel" />
                     </Button>
 
-                    <Button onClick={generateCatalog}>
+                    <Button onClick={handlers.rediscoveryRequested}>
                         <FormattedMessage id="cta.continue" />
                     </Button>
                 </DialogActions>

--- a/src/components/capture/RediscoverButton.tsx
+++ b/src/components/capture/RediscoverButton.tsx
@@ -1,0 +1,174 @@
+import { Button } from '@mui/material';
+import { discover } from 'api/discovers';
+import { createEntityDraft } from 'api/drafts';
+import {
+    useEditorStore_isSaving,
+    useEditorStore_resetState,
+} from 'components/editor/Store/hooks';
+import { buttonSx } from 'components/shared/Entity/Header';
+import { useEntityWorkflow } from 'context/Workflow';
+import useGlobalSearchParams, {
+    GlobalSearchParams,
+} from 'hooks/searchParams/useGlobalSearchParams';
+import { isEmpty } from 'lodash';
+import { FormattedMessage } from 'react-intl';
+import {
+    useDetailsForm_connectorImage_connectorId,
+    useDetailsForm_connectorImage_id,
+    useDetailsForm_details_entityName,
+    useDetailsForm_errorsExist,
+} from 'stores/DetailsForm';
+import {
+    useEndpointConfigStore_encryptedEndpointConfig_data,
+    useEndpointConfigStore_endpointConfig_data,
+    useEndpointConfigStore_endpointSchema,
+    useEndpointConfigStore_errorsExist,
+    useEndpointConfig_serverUpdateRequired,
+} from 'stores/EndpointConfig';
+import {
+    useFormStateStore_isActive,
+    useFormStateStore_setFormState,
+    useFormStateStore_updateStatus,
+} from 'stores/FormState/hooks';
+import { FormStatus } from 'stores/FormState/types';
+import { useResourceConfig_resourceConfig } from 'stores/ResourceConfig/hooks';
+import { encryptEndpointConfig } from 'utils/sops-utils';
+
+// TODO (typing): Narrow the type annotation attributed to the subscription property.
+interface Props {
+    disabled: boolean;
+    callFailed: Function;
+    subscription: Function;
+}
+
+function RediscoverButton({ disabled, callFailed, subscription }: Props) {
+    const initialConnectorId = useGlobalSearchParams(
+        GlobalSearchParams.CONNECTOR_ID
+    );
+
+    const workflow = useEntityWorkflow();
+    const editWorkflow = workflow === 'capture_edit';
+
+    // Editor Store
+    const isSaving = useEditorStore_isSaving();
+
+    const resetEditorState = useEditorStore_resetState();
+
+    // Form State Store
+    const formActive = useFormStateStore_isActive();
+
+    const setFormState = useFormStateStore_setFormState();
+
+    const updateFormStatus = useFormStateStore_updateStatus();
+
+    // Details Form Store
+    const entityName = useDetailsForm_details_entityName();
+    const detailsFormsHasErrors = useDetailsForm_errorsExist();
+
+    const imageConnectorId = useDetailsForm_connectorImage_connectorId();
+    const imageConnectorTagId = useDetailsForm_connectorImage_id();
+
+    // Endpoint Config Store
+    const endpointSchema = useEndpointConfigStore_endpointSchema();
+
+    const endpointConfigData = useEndpointConfigStore_endpointConfig_data();
+
+    const serverEndpointConfigData =
+        useEndpointConfigStore_encryptedEndpointConfig_data();
+    const endpointConfigErrorsExist = useEndpointConfigStore_errorsExist();
+
+    const serverUpdateRequired = useEndpointConfig_serverUpdateRequired();
+
+    // Resource Config Store
+    const resourceConfig = useResourceConfig_resourceConfig();
+
+    const endpointConfigErrorFlag = editWorkflow
+        ? endpointConfigErrorsExist
+        : endpointConfigErrorsExist || isEmpty(endpointConfigData);
+
+    const generateCatalog = async (event: React.MouseEvent<HTMLElement>) => {
+        event.preventDefault();
+        updateFormStatus(FormStatus.GENERATING);
+
+        if (detailsFormsHasErrors || endpointConfigErrorFlag) {
+            return setFormState({
+                status: FormStatus.FAILED,
+                displayValidation: true,
+            });
+        } else {
+            resetEditorState(true);
+
+            const draftsResponse = await createEntityDraft(entityName);
+            if (draftsResponse.error) {
+                return callFailed({
+                    error: {
+                        title: 'captureCreate.generate.failedErrorTitle',
+                        error: draftsResponse.error,
+                    },
+                });
+            }
+
+            const draftId = draftsResponse.data[0].id;
+
+            const selectedEndpointConfig = serverUpdateRequired
+                ? endpointConfigData
+                : serverEndpointConfigData;
+
+            const encryptedEndpointConfig = await encryptEndpointConfig(
+                selectedEndpointConfig,
+                endpointSchema,
+                serverUpdateRequired,
+                imageConnectorId,
+                imageConnectorTagId,
+                callFailed,
+                { overrideJsonFormDefaults: true }
+            );
+
+            let catalogName = entityName;
+
+            if (editWorkflow && imageConnectorId === initialConnectorId) {
+                // The discovery RPC will insert a row into the draft spec-related tables for the given task with verbiage
+                // identifying the external source appended to the task name (e.g., '/source-postgres'). To limit duplication
+                // of draft spec-related data, the aforementioned external source identifier is removed from the task name
+                // prior to executing the discovery RPC.
+                const lastSlashIndex = entityName.lastIndexOf('/');
+
+                if (lastSlashIndex !== -1) {
+                    catalogName = entityName.slice(0, lastSlashIndex);
+                }
+            }
+
+            const discoverResponse = await discover(
+                catalogName,
+                encryptedEndpointConfig.data,
+                imageConnectorTagId,
+                draftId
+            );
+            if (discoverResponse.error) {
+                return callFailed({
+                    error: {
+                        title: 'captureCreate.generate.failedErrorTitle',
+                        error: discoverResponse.error,
+                    },
+                });
+            }
+            subscription(draftId, endpointConfigData, resourceConfig);
+
+            setFormState({
+                logToken: discoverResponse.data[0].logs_token,
+            });
+        }
+    };
+
+    return (
+        <Button
+            onClick={generateCatalog}
+            disabled={disabled || isSaving || formActive}
+            sx={buttonSx}
+        >
+            <FormattedMessage id="cta.rediscoverCatalog.capture" />
+        </Button>
+    );
+}
+
+export default RediscoverButton;

--- a/src/components/capture/RediscoverButton.tsx
+++ b/src/components/capture/RediscoverButton.tsx
@@ -19,7 +19,8 @@ function RediscoverButton({
     const { generateCatalog, isSaving, formActive } = useDiscoverCapture(
         entityType,
         callFailed,
-        postGenerateMutate
+        postGenerateMutate,
+        { initiateRediscovery: true }
     );
 
     return (

--- a/src/components/capture/RediscoverButton.tsx
+++ b/src/components/capture/RediscoverButton.tsx
@@ -1,172 +1,35 @@
 import { Button } from '@mui/material';
-import { discover } from 'api/discovers';
-import { createEntityDraft } from 'api/drafts';
-import {
-    useEditorStore_isSaving,
-    useEditorStore_resetState,
-} from 'components/editor/Store/hooks';
-import { buttonSx } from 'components/shared/Entity/Header';
-import { useEntityWorkflow } from 'context/Workflow';
-import useGlobalSearchParams, {
-    GlobalSearchParams,
-} from 'hooks/searchParams/useGlobalSearchParams';
-import { isEmpty } from 'lodash';
+import useDiscoverCapture from 'components/capture/useDiscoverCapture';
 import { FormattedMessage } from 'react-intl';
-import {
-    useDetailsForm_connectorImage_connectorId,
-    useDetailsForm_connectorImage_id,
-    useDetailsForm_details_entityName,
-    useDetailsForm_errorsExist,
-} from 'stores/DetailsForm';
-import {
-    useEndpointConfigStore_encryptedEndpointConfig_data,
-    useEndpointConfigStore_endpointConfig_data,
-    useEndpointConfigStore_endpointSchema,
-    useEndpointConfigStore_errorsExist,
-    useEndpointConfig_serverUpdateRequired,
-} from 'stores/EndpointConfig';
-import {
-    useFormStateStore_isActive,
-    useFormStateStore_setFormState,
-    useFormStateStore_updateStatus,
-} from 'stores/FormState/hooks';
-import { FormStatus } from 'stores/FormState/types';
-import { useResourceConfig_resourceConfig } from 'stores/ResourceConfig/hooks';
-import { encryptEndpointConfig } from 'utils/sops-utils';
+import { Entity } from 'types';
 
-// TODO (typing): Narrow the type annotation attributed to the subscription property.
 interface Props {
+    entityType: Entity;
     disabled: boolean;
     callFailed: Function;
-    subscription: Function;
+    postGenerateMutate: Function;
 }
 
-function RediscoverButton({ disabled, callFailed, subscription }: Props) {
-    const initialConnectorId = useGlobalSearchParams(
-        GlobalSearchParams.CONNECTOR_ID
+function RediscoverButton({
+    entityType,
+    disabled,
+    callFailed,
+    postGenerateMutate,
+}: Props) {
+    const { generateCatalog, isSaving, formActive } = useDiscoverCapture(
+        entityType,
+        callFailed,
+        postGenerateMutate
     );
-
-    const workflow = useEntityWorkflow();
-    const editWorkflow = workflow === 'capture_edit';
-
-    // Editor Store
-    const isSaving = useEditorStore_isSaving();
-
-    const resetEditorState = useEditorStore_resetState();
-
-    // Form State Store
-    const formActive = useFormStateStore_isActive();
-
-    const setFormState = useFormStateStore_setFormState();
-
-    const updateFormStatus = useFormStateStore_updateStatus();
-
-    // Details Form Store
-    const entityName = useDetailsForm_details_entityName();
-    const detailsFormsHasErrors = useDetailsForm_errorsExist();
-
-    const imageConnectorId = useDetailsForm_connectorImage_connectorId();
-    const imageConnectorTagId = useDetailsForm_connectorImage_id();
-
-    // Endpoint Config Store
-    const endpointSchema = useEndpointConfigStore_endpointSchema();
-
-    const endpointConfigData = useEndpointConfigStore_endpointConfig_data();
-
-    const serverEndpointConfigData =
-        useEndpointConfigStore_encryptedEndpointConfig_data();
-    const endpointConfigErrorsExist = useEndpointConfigStore_errorsExist();
-
-    const serverUpdateRequired = useEndpointConfig_serverUpdateRequired();
-
-    // Resource Config Store
-    const resourceConfig = useResourceConfig_resourceConfig();
-
-    const endpointConfigErrorFlag = editWorkflow
-        ? endpointConfigErrorsExist
-        : endpointConfigErrorsExist || isEmpty(endpointConfigData);
-
-    const generateCatalog = async (event: React.MouseEvent<HTMLElement>) => {
-        event.preventDefault();
-        updateFormStatus(FormStatus.GENERATING);
-
-        if (detailsFormsHasErrors || endpointConfigErrorFlag) {
-            return setFormState({
-                status: FormStatus.FAILED,
-                displayValidation: true,
-            });
-        } else {
-            resetEditorState(true);
-
-            const draftsResponse = await createEntityDraft(entityName);
-            if (draftsResponse.error) {
-                return callFailed({
-                    error: {
-                        title: 'captureCreate.generate.failedErrorTitle',
-                        error: draftsResponse.error,
-                    },
-                });
-            }
-
-            const draftId = draftsResponse.data[0].id;
-
-            const selectedEndpointConfig = serverUpdateRequired
-                ? endpointConfigData
-                : serverEndpointConfigData;
-
-            const encryptedEndpointConfig = await encryptEndpointConfig(
-                selectedEndpointConfig,
-                endpointSchema,
-                serverUpdateRequired,
-                imageConnectorId,
-                imageConnectorTagId,
-                callFailed,
-                { overrideJsonFormDefaults: true }
-            );
-
-            let catalogName = entityName;
-
-            if (editWorkflow && imageConnectorId === initialConnectorId) {
-                // The discovery RPC will insert a row into the draft spec-related tables for the given task with verbiage
-                // identifying the external source appended to the task name (e.g., '/source-postgres'). To limit duplication
-                // of draft spec-related data, the aforementioned external source identifier is removed from the task name
-                // prior to executing the discovery RPC.
-                const lastSlashIndex = entityName.lastIndexOf('/');
-
-                if (lastSlashIndex !== -1) {
-                    catalogName = entityName.slice(0, lastSlashIndex);
-                }
-            }
-
-            const discoverResponse = await discover(
-                catalogName,
-                encryptedEndpointConfig.data,
-                imageConnectorTagId,
-                draftId
-            );
-            if (discoverResponse.error) {
-                return callFailed({
-                    error: {
-                        title: 'captureCreate.generate.failedErrorTitle',
-                        error: discoverResponse.error,
-                    },
-                });
-            }
-            subscription(draftId, endpointConfigData, resourceConfig);
-
-            setFormState({
-                logToken: discoverResponse.data[0].logs_token,
-            });
-        }
-    };
 
     return (
         <Button
-            onClick={generateCatalog}
+            variant="text"
             disabled={disabled || isSaving || formActive}
-            sx={buttonSx}
+            onClick={generateCatalog}
+            sx={{ borderRadius: 0 }}
         >
-            <FormattedMessage id="cta.rediscoverCatalog.capture" />
+            <FormattedMessage id="workflows.collectionSelector.cta.rediscover" />
         </Button>
     );
 }

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -47,6 +47,7 @@ import {
 import { FormStatus } from 'stores/FormState/types';
 import {
     useResourceConfig_evaluateDiscoveredCollections,
+    useResourceConfig_resetConfigAndCollections,
     useResourceConfig_resourceConfig,
     useResourceConfig_resourceConfigErrorsExist,
     useResourceConfig_restrictedDiscoveredCollections,
@@ -73,7 +74,8 @@ const trackEvent = (payload: any) => {
 function useDiscoverCapture(
     entityType: Entity,
     callFailed: Function,
-    postGenerateMutate: Function
+    postGenerateMutate: Function,
+    options?: { initiateRediscovery: boolean }
 ) {
     const supabaseClient = useClient();
 
@@ -128,6 +130,7 @@ function useDiscoverCapture(
         useResourceConfig_evaluateDiscoveredCollections();
     const resourceConfigHasErrors =
         useResourceConfig_resourceConfigErrorsExist();
+    const resetCollections = useResourceConfig_resetConfigAndCollections();
 
     const endpointConfigErrorFlag = editWorkflow
         ? endpointConfigErrorsExist
@@ -155,6 +158,10 @@ function useDiscoverCapture(
             }
 
             if (draftSpecsResponse.data && draftSpecsResponse.data.length > 0) {
+                if (options?.initiateRediscovery) {
+                    resetCollections();
+                }
+
                 setDiscoveredCollections(draftSpecsResponse.data[0]);
 
                 const supabaseConfig: SupabaseConfig | null =
@@ -167,7 +174,8 @@ function useDiscoverCapture(
                         draftSpecsResponse,
                         resourceConfigForDiscovery,
                         restrictedDiscoveredCollections,
-                        supabaseConfig
+                        supabaseConfig,
+                        options?.initiateRediscovery
                     );
 
                 if (updatedDraftSpecsResponse.error) {
@@ -190,10 +198,10 @@ function useDiscoverCapture(
                             .connector.config,
                     });
                 }
-            }
 
-            setDraftId(newDraftId);
-            setPersistedDraftId(newDraftId);
+                setDraftId(newDraftId);
+                setPersistedDraftId(newDraftId);
+            }
         },
         [
             evaluateDiscoveredCollections,

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -1,0 +1,399 @@
+import { discover } from 'api/discovers';
+import { createEntityDraft } from 'api/drafts';
+import { getDraftSpecsBySpecType } from 'api/draftSpecs';
+import {
+    useEditorStore_isSaving,
+    useEditorStore_resetState,
+    useEditorStore_setId,
+    useEditorStore_setPersistedDraftId,
+} from 'components/editor/Store/hooks';
+import { useEntityWorkflow } from 'context/Workflow';
+import useGlobalSearchParams, {
+    GlobalSearchParams,
+} from 'hooks/searchParams/useGlobalSearchParams';
+import { useClient } from 'hooks/supabase-swr';
+import { isEmpty } from 'lodash';
+import LogRocket from 'logrocket';
+import { useCallback, useMemo } from 'react';
+import { CustomEvents } from 'services/logrocket';
+import {
+    DEFAULT_FILTER,
+    jobStatusPoller,
+    JOB_STATUS_POLLER_ERROR,
+    TABLES,
+} from 'services/supabase';
+import {
+    useDetailsForm_connectorImage_connectorId,
+    useDetailsForm_connectorImage_id,
+    useDetailsForm_details_entityName,
+    useDetailsForm_errorsExist,
+    useDetailsForm_setDraftedEntityName,
+} from 'stores/DetailsForm';
+import {
+    useEndpointConfigStore_encryptedEndpointConfig_data,
+    useEndpointConfigStore_endpointConfig_data,
+    useEndpointConfigStore_endpointSchema,
+    useEndpointConfigStore_errorsExist,
+    useEndpointConfigStore_setEncryptedEndpointConfig,
+    useEndpointConfigStore_setPreviousEndpointConfig,
+    useEndpointConfig_serverUpdateRequired,
+} from 'stores/EndpointConfig';
+import {
+    useFormStateStore_isActive,
+    useFormStateStore_messagePrefix,
+    useFormStateStore_setFormState,
+    useFormStateStore_updateStatus,
+} from 'stores/FormState/hooks';
+import { FormStatus } from 'stores/FormState/types';
+import {
+    useResourceConfig_evaluateDiscoveredCollections,
+    useResourceConfig_resourceConfig,
+    useResourceConfig_resourceConfigErrorsExist,
+    useResourceConfig_restrictedDiscoveredCollections,
+    useResourceConfig_setDiscoveredCollections,
+} from 'stores/ResourceConfig/hooks';
+import { ResourceConfigDictionary } from 'stores/ResourceConfig/types';
+import { Entity } from 'types';
+import { encryptEndpointConfig } from 'utils/sops-utils';
+import {
+    modifyDiscoveredDraftSpec,
+    SupabaseConfig,
+} from 'utils/workflow-utils';
+
+const trackEvent = (payload: any) => {
+    LogRocket.track(CustomEvents.CAPTURE_DISCOVER, {
+        name: payload.capture_name ?? DEFAULT_FILTER,
+        id: payload.id ?? DEFAULT_FILTER,
+        draft_id: payload.draft_id ?? DEFAULT_FILTER,
+        logs_token: payload.logs_token ?? DEFAULT_FILTER,
+        status: payload.job_status?.type ?? DEFAULT_FILTER,
+    });
+};
+
+function useDiscoverCapture(
+    entityType: Entity,
+    callFailed: Function,
+    postGenerateMutate: Function
+) {
+    const supabaseClient = useClient();
+
+    const [initialConnectorId, lastPubId] = useGlobalSearchParams([
+        GlobalSearchParams.CONNECTOR_ID,
+        GlobalSearchParams.LAST_PUB_ID,
+    ]);
+
+    const workflow = useEntityWorkflow();
+    const editWorkflow = workflow === 'capture_edit';
+
+    // Draft Editor Store
+    const setDraftId = useEditorStore_setId();
+
+    // Editor Store
+    const isSaving = useEditorStore_isSaving();
+    const resetEditorState = useEditorStore_resetState();
+    const setPersistedDraftId = useEditorStore_setPersistedDraftId();
+
+    // Form State Store
+    const formActive = useFormStateStore_isActive();
+    const setFormState = useFormStateStore_setFormState();
+    const updateFormStatus = useFormStateStore_updateStatus();
+    const messagePrefix = useFormStateStore_messagePrefix();
+
+    // Details Form Store
+    const entityName = useDetailsForm_details_entityName();
+    const detailsFormsHasErrors = useDetailsForm_errorsExist();
+    const imageConnectorId = useDetailsForm_connectorImage_connectorId();
+    const imageConnectorTagId = useDetailsForm_connectorImage_id();
+    const setDraftedEntityName = useDetailsForm_setDraftedEntityName();
+
+    // Endpoint Config Store
+    const setEncryptedEndpointConfig =
+        useEndpointConfigStore_setEncryptedEndpointConfig();
+    const endpointSchema = useEndpointConfigStore_endpointSchema();
+    const endpointConfigData = useEndpointConfigStore_endpointConfig_data();
+    const serverEndpointConfigData =
+        useEndpointConfigStore_encryptedEndpointConfig_data();
+    const endpointConfigErrorsExist = useEndpointConfigStore_errorsExist();
+    const serverUpdateRequired = useEndpointConfig_serverUpdateRequired();
+    const setPreviousEndpointConfig =
+        useEndpointConfigStore_setPreviousEndpointConfig();
+
+    // Resource Config Store
+    const resourceConfig = useResourceConfig_resourceConfig();
+    const restrictedDiscoveredCollections =
+        useResourceConfig_restrictedDiscoveredCollections();
+    const setDiscoveredCollections =
+        useResourceConfig_setDiscoveredCollections();
+    const evaluateDiscoveredCollections =
+        useResourceConfig_evaluateDiscoveredCollections();
+    const resourceConfigHasErrors =
+        useResourceConfig_resourceConfigErrorsExist();
+
+    const endpointConfigErrorFlag = editWorkflow
+        ? endpointConfigErrorsExist
+        : endpointConfigErrorsExist || isEmpty(endpointConfigData);
+
+    const storeDiscoveredCollections = useCallback(
+        async (
+            newDraftId: string,
+            resourceConfigForDiscovery: ResourceConfigDictionary
+        ) => {
+            // TODO (optimization | typing): Narrow the columns selected from the draft_specs_ext table.
+            //   More columns are selected than required to appease the typing of the editor store.
+            const draftSpecsResponse = await getDraftSpecsBySpecType(
+                newDraftId,
+                entityType
+            );
+
+            if (draftSpecsResponse.error) {
+                return callFailed({
+                    error: {
+                        title: 'captureCreate.generate.failedErrorTitle',
+                        error: draftSpecsResponse.error,
+                    },
+                });
+            }
+
+            if (draftSpecsResponse.data && draftSpecsResponse.data.length > 0) {
+                setDiscoveredCollections(draftSpecsResponse.data[0]);
+
+                const supabaseConfig: SupabaseConfig | null =
+                    editWorkflow && lastPubId
+                        ? { catalogName: entityName, lastPubId }
+                        : null;
+
+                const updatedDraftSpecsResponse =
+                    await modifyDiscoveredDraftSpec(
+                        draftSpecsResponse,
+                        resourceConfigForDiscovery,
+                        restrictedDiscoveredCollections,
+                        supabaseConfig
+                    );
+
+                if (updatedDraftSpecsResponse.error) {
+                    return callFailed({
+                        error: {
+                            title: 'captureCreate.generate.failedErrorTitle',
+                            error: updatedDraftSpecsResponse.error,
+                        },
+                    });
+                }
+
+                if (
+                    updatedDraftSpecsResponse.data &&
+                    updatedDraftSpecsResponse.data.length > 0
+                ) {
+                    evaluateDiscoveredCollections(updatedDraftSpecsResponse);
+
+                    setEncryptedEndpointConfig({
+                        data: updatedDraftSpecsResponse.data[0].spec.endpoint
+                            .connector.config,
+                    });
+                }
+            }
+
+            setDraftId(newDraftId);
+            setPersistedDraftId(newDraftId);
+        },
+        [
+            evaluateDiscoveredCollections,
+            setDiscoveredCollections,
+            setDraftId,
+            setEncryptedEndpointConfig,
+            setPersistedDraftId,
+            callFailed,
+            entityType,
+            restrictedDiscoveredCollections,
+        ]
+    );
+
+    const jobFailed = useCallback(
+        (errorTitle: string) => {
+            setFormState({
+                error: {
+                    title: errorTitle,
+                },
+                status: FormStatus.FAILED,
+            });
+        },
+        [setFormState]
+    );
+
+    const createDiscoversSubscription = useCallback(
+        (
+            discoverDraftId: string,
+            existingEndpointConfig: any, // JsonFormsData,
+            resourceConfigForDiscover: ResourceConfigDictionary
+        ) => {
+            setDraftId(null);
+
+            jobStatusPoller(
+                supabaseClient
+                    .from(TABLES.DISCOVERS)
+                    .select(
+                        `
+                        capture_name,
+                        draft_id,
+                        job_status,
+                        created_at
+                    `
+                    )
+                    .match({
+                        draft_id: discoverDraftId,
+                    })
+                    .order('created_at', { ascending: false }),
+                async (payload: any) => {
+                    await storeDiscoveredCollections(
+                        payload.draft_id,
+                        resourceConfigForDiscover
+                    );
+
+                    void postGenerateMutate();
+
+                    setDraftedEntityName(payload.capture_name);
+
+                    setPreviousEndpointConfig({ data: existingEndpointConfig });
+
+                    setFormState({
+                        status: FormStatus.GENERATED,
+                    });
+
+                    trackEvent(payload);
+                },
+                (payload: any) => {
+                    if (payload.error === JOB_STATUS_POLLER_ERROR) {
+                        jobFailed(payload.error);
+                    } else {
+                        jobFailed(`${messagePrefix}.test.failedErrorTitle`);
+                    }
+                }
+            );
+        },
+        [
+            jobFailed,
+            setDraftId,
+            setDraftedEntityName,
+            setFormState,
+            setPreviousEndpointConfig,
+            storeDiscoveredCollections,
+            messagePrefix,
+            postGenerateMutate,
+            supabaseClient,
+        ]
+    );
+
+    const generateCatalog = useCallback(
+        async (event: React.MouseEvent<HTMLElement>) => {
+            event.preventDefault();
+            updateFormStatus(FormStatus.GENERATING);
+
+            if (
+                detailsFormsHasErrors ||
+                endpointConfigErrorFlag ||
+                resourceConfigHasErrors
+            ) {
+                return setFormState({
+                    status: FormStatus.FAILED,
+                    displayValidation: true,
+                });
+            } else {
+                resetEditorState(true);
+
+                const draftsResponse = await createEntityDraft(entityName);
+                if (draftsResponse.error) {
+                    return callFailed({
+                        error: {
+                            title: 'captureCreate.generate.failedErrorTitle',
+                            error: draftsResponse.error,
+                        },
+                    });
+                }
+
+                const draftId = draftsResponse.data[0].id;
+
+                const selectedEndpointConfig = serverUpdateRequired
+                    ? endpointConfigData
+                    : serverEndpointConfigData;
+
+                const encryptedEndpointConfig = await encryptEndpointConfig(
+                    selectedEndpointConfig,
+                    endpointSchema,
+                    serverUpdateRequired,
+                    imageConnectorId,
+                    imageConnectorTagId,
+                    callFailed,
+                    { overrideJsonFormDefaults: true }
+                );
+
+                let catalogName = entityName;
+
+                if (editWorkflow && imageConnectorId === initialConnectorId) {
+                    // The discovery RPC will insert a row into the draft spec-related tables for the given task with verbiage
+                    // identifying the external source appended to the task name (e.g., '/source-postgres'). To limit duplication
+                    // of draft spec-related data, the aforementioned external source identifier is removed from the task name
+                    // prior to executing the discovery RPC.
+                    const lastSlashIndex = entityName.lastIndexOf('/');
+
+                    if (lastSlashIndex !== -1) {
+                        catalogName = entityName.slice(0, lastSlashIndex);
+                    }
+                }
+
+                const discoverResponse = await discover(
+                    catalogName,
+                    encryptedEndpointConfig.data,
+                    imageConnectorTagId,
+                    draftId
+                );
+                if (discoverResponse.error) {
+                    return callFailed({
+                        error: {
+                            title: 'captureCreate.generate.failedErrorTitle',
+                            error: discoverResponse.error,
+                        },
+                    });
+                }
+                createDiscoversSubscription(
+                    draftId,
+                    endpointConfigData,
+                    resourceConfig
+                );
+
+                setFormState({
+                    logToken: discoverResponse.data[0].logs_token,
+                });
+            }
+        },
+        [
+            createDiscoversSubscription,
+            resetEditorState,
+            setFormState,
+            updateFormStatus,
+            callFailed,
+            detailsFormsHasErrors,
+            editWorkflow,
+            endpointConfigData,
+            endpointConfigErrorFlag,
+            endpointSchema,
+            entityName,
+            imageConnectorId,
+            imageConnectorTagId,
+            initialConnectorId,
+            resourceConfig,
+            resourceConfigHasErrors,
+            serverEndpointConfigData,
+            serverUpdateRequired,
+        ]
+    );
+
+    return useMemo(() => {
+        return {
+            isSaving,
+            formActive,
+            generateCatalog,
+            discoversSubscription: createDiscoversSubscription,
+        };
+    }, [createDiscoversSubscription, generateCatalog, formActive, isSaving]);
+}
+
+export default useDiscoverCapture;

--- a/src/components/collection/Config.tsx
+++ b/src/components/collection/Config.tsx
@@ -4,6 +4,7 @@ import BindingsMultiEditor from 'components/editor/Bindings';
 import AlertBox from 'components/shared/AlertBox';
 import WrapperWithHeader from 'components/shared/Entity/WrapperWithHeader';
 import { DraftSpecQuery } from 'hooks/useDraftSpecs';
+import { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useFormStateStore_messagePrefix } from 'stores/FormState/hooks';
 import {
@@ -15,9 +16,14 @@ import {
 interface Props {
     draftSpecs: DraftSpecQuery[];
     readOnly?: boolean;
+    RediscoverButton?: ReactNode;
 }
 
-function CollectionConfig({ draftSpecs, readOnly = false }: Props) {
+function CollectionConfig({
+    draftSpecs,
+    readOnly = false,
+    RediscoverButton,
+}: Props) {
     // Form State Store
     const messagePrefix = useFormStateStore_messagePrefix();
 
@@ -63,6 +69,7 @@ function CollectionConfig({ draftSpecs, readOnly = false }: Props) {
                 <BindingsMultiEditor
                     draftSpecs={draftSpecs}
                     readOnly={readOnly}
+                    RediscoverButton={RediscoverButton}
                 />
             )}
         </WrapperWithHeader>

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -19,6 +19,7 @@ import {
 } from '@mui/x-data-grid';
 import CollectionPicker from 'components/collection/Picker';
 import SelectorEmpty from 'components/editor/Bindings/SelectorEmpty';
+import { useEditorStore_id } from 'components/editor/Store/hooks';
 import {
     alternativeDataGridHeader,
     slateOutline,
@@ -137,6 +138,9 @@ function BindingSelector({
     // Details Form Store
     const task = useDetailsForm_details_entityName();
 
+    // Draft Editor Store
+    const draftId = useEditorStore_id();
+
     // Form State Store
     const formActive = useFormStateStore_isActive();
 
@@ -224,14 +228,16 @@ function BindingSelector({
                     direction="row"
                     spacing={1}
                     divider={
-                        <Divider
-                            orientation="vertical"
-                            variant="middle"
-                            flexItem
-                        />
+                        draftId && RediscoverButton ? (
+                            <Divider
+                                orientation="vertical"
+                                variant="middle"
+                                flexItem
+                            />
+                        ) : null
                     }
                 >
-                    {RediscoverButton ?? null}
+                    {draftId && RediscoverButton ? RediscoverButton : null}
 
                     <Button
                         variant="text"

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -19,7 +19,6 @@ import {
 } from '@mui/x-data-grid';
 import CollectionPicker from 'components/collection/Picker';
 import SelectorEmpty from 'components/editor/Bindings/SelectorEmpty';
-import { useEditorStore_id } from 'components/editor/Store/hooks';
 import {
     alternativeDataGridHeader,
     slateOutline,
@@ -138,9 +137,6 @@ function BindingSelector({
     // Details Form Store
     const task = useDetailsForm_details_entityName();
 
-    // Draft Editor Store
-    const draftId = useEditorStore_id();
-
     // Form State Store
     const formActive = useFormStateStore_isActive();
 
@@ -230,7 +226,7 @@ function BindingSelector({
                     direction="row"
                     spacing={1}
                     divider={
-                        draftId && RediscoverButton ? (
+                        RediscoverButton ? (
                             <Divider
                                 orientation="vertical"
                                 variant="middle"
@@ -239,7 +235,7 @@ function BindingSelector({
                         ) : null
                     }
                 >
-                    {draftId && RediscoverButton ? RediscoverButton : null}
+                    {RediscoverButton ? RediscoverButton : null}
 
                     <Button
                         variant="text"

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -3,8 +3,10 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import {
     Box,
     Button,
+    Divider,
     IconButton,
     ListItemText,
+    Stack,
     Typography,
 } from '@mui/material';
 import {
@@ -45,6 +47,7 @@ interface BindingSelectorProps {
     loading: boolean;
     skeleton: ReactNode;
     readOnly?: boolean;
+    RediscoverButton?: ReactNode;
 }
 
 interface RowProps {
@@ -118,6 +121,7 @@ function BindingSelector({
     loading,
     skeleton,
     readOnly,
+    RediscoverButton,
 }: BindingSelectorProps) {
     const onSelectTimeOut = useRef<number | null>(null);
 
@@ -165,18 +169,7 @@ function BindingSelector({
             headerName: collectionsLabel,
             sortable: false,
             renderHeader: (params: GridColumnHeaderParams) => (
-                <>
-                    <Typography>{params.colDef.headerName}</Typography>
-
-                    <Button
-                        variant="text"
-                        disabled={formActive}
-                        onClick={handlers.removeAllCollections}
-                        sx={{ borderRadius: 0 }}
-                    >
-                        <FormattedMessage id="workflows.collectionSelector.cta.delete" />
-                    </Button>
-                </>
+                <Typography>{params.colDef.headerName}</Typography>
             ),
             renderCell: (params: GridRenderCellParams) => {
                 const currentConfig = resourceConfig[params.row];
@@ -221,6 +214,35 @@ function BindingSelector({
     ) : (
         <>
             <CollectionPicker readOnly={readOnly} />
+
+            <Box
+                sx={{
+                    marginLeft: 'auto',
+                }}
+            >
+                <Stack
+                    direction="row"
+                    spacing={1}
+                    divider={
+                        <Divider
+                            orientation="vertical"
+                            variant="middle"
+                            flexItem
+                        />
+                    }
+                >
+                    {RediscoverButton ?? null}
+
+                    <Button
+                        variant="text"
+                        disabled={formActive}
+                        onClick={handlers.removeAllCollections}
+                        sx={{ borderRadius: 0 }}
+                    >
+                        <FormattedMessage id="workflows.collectionSelector.cta.delete" />
+                    </Button>
+                </Stack>
+            </Box>
 
             <Box sx={{ height: 280 }}>
                 <DataGrid

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -221,7 +221,9 @@ function BindingSelector({
 
             <Box
                 sx={{
-                    marginLeft: 'auto',
+                    ml: 'auto',
+                    borderTop: slateOutline,
+                    borderLeft: slateOutline,
                 }}
             >
                 <Stack

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, useTheme } from '@mui/material';
+import { Typography, useTheme } from '@mui/material';
 import {
     BindingsEditorSkeleton,
     BindingsSelectorSkeleton,
@@ -155,30 +155,11 @@ function BindingsMultiEditor({
 
     return (
         <>
-            {/* {entityType === 'capture' ? ( */}
-            <Box
-                sx={{
-                    mb: 1,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                }}
-            >
-                <Typography variant="h5">
-                    <FormattedMessage
-                        id={`${messagePrefix}.collectionSelector.heading`}
-                    />
-                </Typography>
-
-                {RediscoverButton ?? null}
-            </Box>
-            {/* ) : (
-                <Typography variant="h5" sx={{ mb: 1 }}>
-                    <FormattedMessage
-                        id={`${messagePrefix}.collectionSelector.heading`}
-                    />
-                </Typography>
-            )} */}
+            <Typography variant="h5" sx={{ mb: 1 }}>
+                <FormattedMessage
+                    id={`${messagePrefix}.collectionSelector.heading`}
+                />
+            </Typography>
 
             <Typography sx={{ mb: 2 }}>
                 <FormattedMessage
@@ -192,6 +173,7 @@ function BindingsMultiEditor({
                         loading={fetchingSpecs}
                         skeleton={<BindingsSelectorSkeleton />}
                         readOnly={readOnly}
+                        RediscoverButton={RediscoverButton}
                     />
                 }
                 details={

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -1,4 +1,4 @@
-import { Typography, useTheme } from '@mui/material';
+import { Box, Typography, useTheme } from '@mui/material';
 import {
     BindingsEditorSkeleton,
     BindingsSelectorSkeleton,
@@ -16,7 +16,7 @@ import useConnectorTag from 'hooks/useConnectorTag';
 import { DraftSpecQuery } from 'hooks/useDraftSpecs';
 import useLiveSpecs from 'hooks/useLiveSpecs';
 import { isEqual } from 'lodash';
-import { useEffect, useMemo } from 'react';
+import { ReactNode, useEffect, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
     useDetailsForm_connectorImage,
@@ -36,9 +36,14 @@ import { Schema } from 'types';
 interface Props {
     draftSpecs: DraftSpecQuery[];
     readOnly?: boolean;
+    RediscoverButton?: ReactNode;
 }
 
-function BindingsMultiEditor({ draftSpecs = [], readOnly = false }: Props) {
+function BindingsMultiEditor({
+    draftSpecs = [],
+    readOnly = false,
+    RediscoverButton,
+}: Props) {
     const theme = useTheme();
 
     const connectorId = useGlobalSearchParams(GlobalSearchParams.CONNECTOR_ID);
@@ -150,11 +155,30 @@ function BindingsMultiEditor({ draftSpecs = [], readOnly = false }: Props) {
 
     return (
         <>
-            <Typography variant="h5" sx={{ mb: 1 }}>
-                <FormattedMessage
-                    id={`${messagePrefix}.collectionSelector.heading`}
-                />
-            </Typography>
+            {/* {entityType === 'capture' ? ( */}
+            <Box
+                sx={{
+                    mb: 1,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                }}
+            >
+                <Typography variant="h5">
+                    <FormattedMessage
+                        id={`${messagePrefix}.collectionSelector.heading`}
+                    />
+                </Typography>
+
+                {RediscoverButton ?? null}
+            </Box>
+            {/* ) : (
+                <Typography variant="h5" sx={{ mb: 1 }}>
+                    <FormattedMessage
+                        id={`${messagePrefix}.collectionSelector.heading`}
+                    />
+                </Typography>
+            )} */}
 
             <Typography sx={{ mb: 2 }}>
                 <FormattedMessage

--- a/src/components/shared/Entity/Create.tsx
+++ b/src/components/shared/Entity/Create.tsx
@@ -52,6 +52,7 @@ interface Props {
     resetState: () => void;
     toolbar: ReactNode;
     errorSummary: ReactNode;
+    RediscoverButton?: ReactNode;
 }
 
 function EntityCreate({
@@ -61,6 +62,7 @@ function EntityCreate({
     resetState,
     errorSummary,
     toolbar,
+    RediscoverButton,
 }: Props) {
     useBrowserTitle(title);
 
@@ -215,7 +217,10 @@ function EntityCreate({
 
                         {displayResourceConfig ? (
                             <ErrorBoundryWrapper>
-                                <CollectionConfig draftSpecs={taskDraftSpec} />
+                                <CollectionConfig
+                                    draftSpecs={taskDraftSpec}
+                                    RediscoverButton={RediscoverButton}
+                                />
                             </ErrorBoundryWrapper>
                         ) : null}
 

--- a/src/components/shared/Entity/Edit.tsx
+++ b/src/components/shared/Entity/Edit.tsx
@@ -82,6 +82,7 @@ interface Props {
     resetState: () => void;
     errorSummary: ReactNode;
     toolbar: ReactNode;
+    RediscoverButton?: ReactNode;
     showCollections?: boolean;
 }
 
@@ -236,6 +237,7 @@ function EntityEdit({
     resetState,
     errorSummary,
     toolbar,
+    RediscoverButton,
     showCollections,
 }: Props) {
     useBrowserTitle(title);
@@ -437,6 +439,7 @@ function EntityEdit({
                             <CollectionConfig
                                 draftSpecs={taskDraftSpec}
                                 readOnly={readOnly.resourceConfigForm}
+                                RediscoverButton={RediscoverButton}
                             />
                         </ErrorBoundryWrapper>
                     ) : null}

--- a/src/context/Confirmation.tsx
+++ b/src/context/Confirmation.tsx
@@ -6,7 +6,11 @@ import {
     DialogContent,
     DialogTitle,
 } from '@mui/material';
-import { glassBkgWithoutBlur, slate } from 'context/Theme';
+import {
+    glassBkgWithoutBlur,
+    secondaryButtonBackground,
+    secondaryButtonHoverBackground,
+} from 'context/Theme';
 import { createContext, ReactNode, useContext, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { BaseComponentProps } from 'types';
@@ -108,15 +112,13 @@ const ConfirmationModalContextProvider = ({ children }: BaseComponentProps) => {
                     <Button
                         onClick={handlers.dismiss}
                         sx={{
-                            'backgroundColor': (themes) =>
-                                themes.palette.mode === 'dark'
-                                    ? slate[50]
-                                    : slate[100],
+                            'backgroundColor': (theme) =>
+                                secondaryButtonBackground[theme.palette.mode],
                             '&:hover': {
-                                backgroundColor: (themes) =>
-                                    themes.palette.mode === 'dark'
-                                        ? slate[100]
-                                        : slate[200],
+                                backgroundColor: (theme) =>
+                                    secondaryButtonHoverBackground[
+                                        theme.palette.mode
+                                    ],
                             },
                         }}
                     >

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -253,6 +253,16 @@ export const logDialogBackground = {
     dark: slate[800],
 };
 
+export const secondaryButtonBackground = {
+    light: slate[100],
+    dark: slate[50],
+};
+
+export const secondaryButtonHoverBackground = {
+    light: slate[200],
+    dark: slate[100],
+};
+
 const expandedRowBgColor = {
     light: slate[50],
     dark: slate[800],

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -681,7 +681,7 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.collectionSelector.label.discoveredCollections': `Discovered Collections`,
     'workflows.collectionSelector.label.existingCollections': `Existing Collections`,
     'workflows.collectionSelector.cta.delete': `Remove All`,
-    'workflows.collectionSelector.cta.rediscover': `Rediscover All`,
+    'workflows.collectionSelector.cta.rediscover': `Refresh`,
 
     'workflows.collectionSelector.rediscoverDialog.title': `Are you sure?`,
     'workflows.collectionSelector.rediscoverDialog.message1': `Rediscovering a capture will replace the current capture configuration with one generated automatically by Flow. Discovery identifies one or more resources — tables, data streams, or the equivalent — and generates bindings so that each will be mapped to a data collection in Flow.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -682,6 +682,10 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.collectionSelector.label.existingCollections': `Existing Collections`,
     'workflows.collectionSelector.cta.delete': `Remove All`,
     'workflows.collectionSelector.cta.rediscover': `Rediscover`,
+
+    'workflows.collectionSelector.rediscoverDialog.title': `Are you sure?`,
+    'workflows.collectionSelector.rediscoverDialog.message1': `Rediscovering a capture will replace the current capture configuration with one generated automatically by Flow. Discovery identifies one or more resources — tables, data streams, or the equivalent — and generates bindings so that each will be mapped to a data collection in Flow.`,
+    'workflows.collectionSelector.rediscoverDialog.message2': `If there are any aspects of your current capture configuration you would like to preserve, take note of them before proceeding with this action.`,
 };
 
 const ShardStatus: ResolvedIntlConfig['messages'] = {

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -681,7 +681,7 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.collectionSelector.label.discoveredCollections': `Discovered Collections`,
     'workflows.collectionSelector.label.existingCollections': `Existing Collections`,
     'workflows.collectionSelector.cta.delete': `Remove All`,
-    'workflows.collectionSelector.cta.rediscover': `Rediscover`,
+    'workflows.collectionSelector.cta.rediscover': `Rediscover All`,
 
     'workflows.collectionSelector.rediscoverDialog.title': `Are you sure?`,
     'workflows.collectionSelector.rediscoverDialog.message1': `Rediscovering a capture will replace the current capture configuration with one generated automatically by Flow. Discovery identifies one or more resources — tables, data streams, or the equivalent — and generates bindings so that each will be mapped to a data collection in Flow.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -684,7 +684,7 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.collectionSelector.cta.rediscover': `Refresh`,
 
     'workflows.collectionSelector.rediscoverDialog.title': `Are you sure?`,
-    'workflows.collectionSelector.rediscoverDialog.message1': `Rediscovering a capture will replace the current capture configuration with one generated automatically by Flow. Discovery identifies one or more resources — tables, data streams, or the equivalent — and generates bindings so that each will be mapped to a data collection in Flow.`,
+    'workflows.collectionSelector.rediscoverDialog.message1': `Proceeding with this action will replace the current capture configuration with one generated automatically by Flow. Discovery identifies one or more resources — tables, data streams, or the equivalent — and generates bindings so that each will be mapped to a data collection in Flow.`,
     'workflows.collectionSelector.rediscoverDialog.message2': `If there are any aspects of your current capture configuration you would like to preserve, take note of them before proceeding with this action.`,
 };
 

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -104,6 +104,7 @@ const CTAs: ResolvedIntlConfig['messages'] = {
     'cta.disable': `Disable`,
     'cta.testConfig': `Test`,
     'cta.generateCatalog.capture': `Next`,
+    'cta.rediscoverCatalog.capture': `Rediscover`,
     'cta.generateCatalog.materialization': `Next`,
     'cta.expandToEdit': `Expand to edit`,
     'cta.refresh': `Refresh`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -104,7 +104,6 @@ const CTAs: ResolvedIntlConfig['messages'] = {
     'cta.disable': `Disable`,
     'cta.testConfig': `Test`,
     'cta.generateCatalog.capture': `Next`,
-    'cta.rediscoverCatalog.capture': `Rediscover`,
     'cta.generateCatalog.materialization': `Next`,
     'cta.expandToEdit': `Expand to edit`,
     'cta.refresh': `Refresh`,
@@ -682,6 +681,7 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.collectionSelector.label.discoveredCollections': `Discovered Collections`,
     'workflows.collectionSelector.label.existingCollections': `Existing Collections`,
     'workflows.collectionSelector.cta.delete': `Remove All`,
+    'workflows.collectionSelector.cta.rediscover': `Rediscover`,
 };
 
 const ShardStatus: ResolvedIntlConfig['messages'] = {

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -265,6 +265,21 @@ const getInitialState = (
         );
     },
 
+    resetConfigAndCollections: () => {
+        set(
+            produce((state: ResourceConfigState) => {
+                state.currentCollection = null;
+                state.collections = [];
+
+                state.restrictedDiscoveredCollections = [];
+
+                state.resourceConfig = {};
+            }),
+            false,
+            'Resource Config and Collections Reset'
+        );
+    },
+
     setCurrentCollection: (value) => {
         set(
             produce((state: ResourceConfigState) => {

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -92,7 +92,7 @@ const getInitialStateData = (): Pick<
     hydrated: false,
     hydrationErrorsExist: false,
     resourceConfig: {},
-    resourceConfigErrorsExist: true,
+    resourceConfigErrorsExist: false,
     resourceConfigErrors: [],
     resourceSchema: {},
     restrictedDiscoveredCollections: [],

--- a/src/stores/ResourceConfig/hooks.ts
+++ b/src/stores/ResourceConfig/hooks.ts
@@ -68,6 +68,15 @@ export const useResourceConfig_removeAllCollections = () => {
     >(getStoreName(entityType), (state) => state.removeAllCollections);
 };
 
+export const useResourceConfig_resetConfigAndCollections = () => {
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        ResourceConfigState,
+        ResourceConfigState['resetConfigAndCollections']
+    >(getStoreName(entityType), (state) => state.resetConfigAndCollections);
+};
+
 export const useResourceConfig_collectionErrorsExist = () => {
     const entityType = useEntityType();
 

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -28,6 +28,7 @@ export interface ResourceConfigState {
         workflow: EntityWorkflow | null,
         catalogName: string
     ) => void;
+    resetConfigAndCollections: () => void;
 
     collectionRemovalMetadata: {
         selectedCollection: string | null;

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -42,20 +42,27 @@ export const modifyDiscoveredDraftSpec = async (
     },
     resourceConfig: ResourceConfigDictionary,
     restrictedDiscoveredCollections: string[],
-    supabaseConfig?: SupabaseConfig | null
+    supabaseConfig?: SupabaseConfig | null,
+    rediscoveryInitiated?: boolean
 ): Promise<CallSupabaseResponse<any>> => {
     const draftSpecData = response.data[0];
 
-    const mergedResourceConfig = mergeResourceConfigs(
-        draftSpecData,
-        resourceConfig,
-        restrictedDiscoveredCollections
-    );
+    const mergedResourceConfig = rediscoveryInitiated
+        ? null
+        : mergeResourceConfigs(
+              draftSpecData,
+              resourceConfig,
+              restrictedDiscoveredCollections
+          );
 
     const mergedDraftSpec = generateCaptureDraftSpec(
-        mergedResourceConfig,
-        draftSpecData.spec.endpoint
+        draftSpecData.spec.endpoint,
+        mergedResourceConfig
     );
+
+    if (rediscoveryInitiated) {
+        mergedDraftSpec.bindings = draftSpecData.spec.bindings;
+    }
 
     return modifyDraftSpec(
         mergedDraftSpec,

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -30,6 +30,11 @@ const mergeResourceConfigs = (
     return mergedResourceConfig;
 };
 
+export interface SupabaseConfig {
+    catalogName: string;
+    lastPubId: string;
+}
+
 export const modifyDiscoveredDraftSpec = async (
     response: {
         data: DraftSpecQuery[];
@@ -37,7 +42,7 @@ export const modifyDiscoveredDraftSpec = async (
     },
     resourceConfig: ResourceConfigDictionary,
     restrictedDiscoveredCollections: string[],
-    supabaseConfig?: { catalogName: string; lastPubId: string }
+    supabaseConfig?: SupabaseConfig | null
 ): Promise<CallSupabaseResponse<any>> => {
     const draftSpecData = response.data[0];
 


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Introduce a _Rediscover All_ CTA to the _Output Collections_ section of the capture forms. A confirmation modal will open when the _Rediscover All_ CTA is clicked, informing the user of the ramifications of this action and providing an escape hatch. If the user does proceed with the _rediscovery_ operation, their capture configuration is replaced with that generated by the discovery RPC.

1. Create a shared hook that handles the generation of the discovery subscription used in the captures workflows.

## Tests

_Describe the approach to testing._

## Content

The flowing pieces of content are introduced by this PR:

* The label attributed to the _Output Collections_ form section CTA responsible for rediscovering a capture.

* All of the content within the _rediscovery confirmation_ dialog. Rediscovering a capture using this CTA will completely replace a user's capture configuration with that generated by Flow. Since

## Screenshots

**Capture Edit | Default**

<img width="960" alt="pr_screenshot-409-rediscover_cta-capture_edit-default" src="https://user-images.githubusercontent.com/77648584/206527511-8077e3cf-5053-4a90-8d7b-31f6ceb39317.PNG">

<br />

**Capture Edit | Rediscovery Confirmation Modal**

<img width="959" alt="pr_screenshot-409-rediscover_cta-capture_edit-rediscovery_confirmation_dialog" src="https://user-images.githubusercontent.com/77648584/206527583-ddc26869-1164-4fa8-bdda-2fe3a9aae4d5.PNG">

<br />

**Capture Edit | Rediscovery In Progress**

<img width="958" alt="pr_screenshot-409-rediscover_cta-capture_edit-rediscovery_in_progress" src="https://user-images.githubusercontent.com/77648584/206527622-05d46ff5-e58b-4cf2-ab0d-d4b658cf1de3.PNG">

<br />

**_Output Collections_ CTAs | Materialization Workflows**

<img width="879" alt="pr_screenshot-409-rediscover_cta-capture_edit-revised_cta_styling-single" src="https://user-images.githubusercontent.com/77648584/206492799-28b71ea4-7b66-4cb0-88f0-512f53f40216.PNG">