### PR TITLE
fix: Large documents causing excessive network traffic

### DIFF
--- a/src/components/collection/DataPreview/ListView.tsx
+++ b/src/components/collection/DataPreview/ListView.tsx
@@ -98,6 +98,7 @@ function ListView({
                             }}
                         >
                             <ReactJson
+                                style={{ wordBreak: 'break-all' }}
                                 quotesOnKeys={false}
                                 src={rowsByKey[selectedKey]}
                                 theme={jsonTheme}

--- a/src/components/collection/DataPreview/index.tsx
+++ b/src/components/collection/DataPreview/index.tsx
@@ -129,9 +129,10 @@ export function DataPreview({ collectionName }: Props) {
                         <FormattedMessage id="collectionsPreview.tooManyBytes.message" />
                     </AlertBox>
                 </Box>
-            ) : (
+            ) : null}
+            {(journalData.data?.documents.length ?? 0) > 0 ? (
                 <ListView journalData={journalData} spec={spec} />
-            )}
+            ) : null}
             {/*             : (
                 <TableView journalData={journalData} spec={spec} />
             )}*/}

--- a/src/hooks/useJournalData.ts
+++ b/src/hooks/useJournalData.ts
@@ -219,6 +219,7 @@ function isJournalRecord(val: any): val is JournalRecord {
 const useJournalData = (
     journalName?: string,
     desiredCount: number = 50,
+    // 16mb, which is the max document size, ensuring we'll always get at least 1 doc if it exists
     maxBytes: number = 16 * 10 ** 6
 ) => {
     const [gatewayConfig] = useLocalStorage(

--- a/src/hooks/useJournalData.ts
+++ b/src/hooks/useJournalData.ts
@@ -119,7 +119,7 @@ async function* streamAsyncIterator<T>(stream: ReadableStream<T>) {
 
 // We increment the read window by this many bytes every time we get back
 // fewer than the desired number of rows.
-const INCREMENT = 1024 * 10;
+const INCREMENT = 1024 * 1024;
 
 async function readAllDocuments<T>(stream: ReadableStream<T>) {
     const accum: T[] = [];
@@ -171,12 +171,15 @@ async function loadDocuments({
 
     let documents: JournalRecord[] = [];
 
+    let attempt = 0;
+
     while (
         documents.length < documentCount &&
         start > 0 &&
         head - start < maxBytes
     ) {
-        start = Math.max(0, start - INCREMENT);
+        attempt += 1;
+        start = Math.max(0, start - INCREMENT * attempt);
         const stream = (
             await client.read({
                 journal: journalName,
@@ -216,7 +219,7 @@ function isJournalRecord(val: any): val is JournalRecord {
 const useJournalData = (
     journalName?: string,
     desiredCount: number = 50,
-    maxBytes: number = 5 * 10 ** 6
+    maxBytes: number = 16 * 10 ** 6
 ) => {
     const [gatewayConfig] = useLocalStorage(
         LocalStorageKeys.GATEWAY,
@@ -243,7 +246,7 @@ const useJournalData = (
 
     useEffect(() => {
         void (async () => {
-            if (journalName && journalClient) {
+            if (journalName && journalClient && !loading && !data) {
                 try {
                     setLoading(true);
                     const docs = await loadDocuments({
@@ -260,7 +263,15 @@ const useJournalData = (
                 }
             }
         })();
-    }, [desiredCount, journalClient, journalName, maxBytes, refreshCount]);
+    }, [
+        desiredCount,
+        journalClient,
+        journalName,
+        maxBytes,
+        refreshCount,
+        loading,
+        data,
+    ]);
 
     return {
         data,


### PR DESCRIPTION
## Changes

* Bump the range grow rate to start at 1mb
* Grow request  exponentially rather than linearly up to the limit
* Bump limit to 16mb, which is the max document size, ensuring we'll always get at least 1 doc if it exists

Also fixed:
* Display data preview even if there are warnings so long as there is any data to display
* Wrap long lines in the JSON preview editor, preventing excessively wide table rows

## Issues

Fixes #374

## Screenshots

![Screen Shot 2022-12-12 at 14 41 57](https://user-images.githubusercontent.com/4368270/207139039-d6719300-e099-4a45-a329-f3b585b53dad.png)
![Screen Shot 2022-12-12 at 14.43.19](https://user-images.githubusercontent.com/4368270/207139894-1f30c1ac-3465-4304-a7c1-eb5eea05b9f1.png)
