### PR TITLE
Query newest collections first

### DIFF
--- a/src/hooks/useLiveSpecs.ts
+++ b/src/hooks/useLiveSpecs.ts
@@ -6,6 +6,8 @@ import { useQuery, useSelect } from './supabase-swr/';
 export interface LiveSpecsQuery {
     catalog_name: string;
     spec_type: string;
+    // Filtering only
+    updated_at: undefined;
 }
 
 const queryColumns = ['catalog_name', 'spec_type'];
@@ -17,7 +19,10 @@ function useLiveSpecs(specType: string) {
         TABLES.LIVE_SPECS_EXT,
         {
             columns: queryColumns,
-            filter: (query) => query.eq('spec_type', specType),
+            filter: (query) =>
+                query.eq('spec_type', specType).order('updated_at', {
+                    ascending: false,
+                }),
         },
         [specType]
     );
@@ -31,9 +36,8 @@ function useLiveSpecs(specType: string) {
     };
 }
 
-export interface LiveSpecsQuery_spec {
+export interface LiveSpecsQuery_spec extends LiveSpecsQuery {
     id: string;
-    catalog_name: string;
     spec: {
         schema: {
             properties: Record<string, any>;
@@ -41,7 +45,6 @@ export interface LiveSpecsQuery_spec {
         };
         key: string[];
     };
-    spec_type: string;
 }
 const specQuery = ['id', 'catalog_name', 'spec', 'spec_type'];
 

--- a/src/hooks/useLiveSpecs.ts
+++ b/src/hooks/useLiveSpecs.ts
@@ -46,7 +46,7 @@ export interface LiveSpecsQuery_spec extends LiveSpecsQuery {
         key: string[];
     };
 }
-const specQuery = ['id', 'catalog_name', 'spec', 'spec_type'];
+const specQuery = queryColumns.concat(['id', 'spec']);
 
 const withKey =
     (key: string) =>


### PR DESCRIPTION
## Changes

While we work on rebuilding the collection selector in general... we can sort by `updated_at` do the newest collections are first.

## Tests

Manually tested

## Issues

Progress https://github.com/estuary/ui/issues/358 

## Content

N/A

## Screenshots

N/A
