### PR TITLE
fix: Handle invalid schema properties

### DIFF
--- a/src/forms/renderers/NullType.tsx
+++ b/src/forms/renderers/NullType.tsx
@@ -1,13 +1,26 @@
-import { RankedTester, rankWith, schemaTypeIs } from '@jsonforms/core';
+import { LayoutProps, RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
 import { withJsonFormsLayoutProps } from '@jsonforms/react';
-import { Hidden } from '@mui/material';
+import { Hidden, Typography } from '@mui/material';
 
-export const nullTypeTester: RankedTester = rankWith(999, schemaTypeIs('null'));
+export const nullTypeTester: RankedTester = rankWith(999, uiTypeIs('NullType'));
 
 // This is blank on purpose. For right now we can just show null settings are nothing
-const NullTypeRenderer = (props: any) => {
-    const { visible } = props;
-    return <Hidden xsUp={!visible}> </Hidden>;
+const NullTypeRenderer = (props: LayoutProps) => {
+    const {
+        visible,
+        path,
+        uischema: { options: schemaOptions },
+    } = props;
+    return (
+        <Hidden xsUp={!visible}>
+            <Typography variant="body1" color="error">
+                Error: Invalid field definition at{' '}
+                <code>
+                    {path}: {schemaOptions?.ref}
+                </code>
+            </Typography>
+        </Hidden>
+    );
 };
 
 export const NullType = withJsonFormsLayoutProps(NullTypeRenderer);

--- a/src/forms/renderers/NullType.tsx
+++ b/src/forms/renderers/NullType.tsx
@@ -1,6 +1,6 @@
 import { LayoutProps, RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
 import { withJsonFormsLayoutProps } from '@jsonforms/react';
-import { Hidden, Typography } from '@mui/material';
+import { Alert, Hidden } from '@mui/material';
 
 export const nullTypeTester: RankedTester = rankWith(999, uiTypeIs('NullType'));
 
@@ -13,12 +13,12 @@ const NullTypeRenderer = (props: LayoutProps) => {
     } = props;
     return (
         <Hidden xsUp={!visible}>
-            <Typography variant="body1" color="error">
+            <Alert severity="error">
                 Error: Invalid field definition at{' '}
                 <code>
                     {path}: {schemaOptions?.ref}
                 </code>
-            </Typography>
+            </Alert>
         </Hidden>
     );
 };

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -405,6 +405,7 @@ const generateUISchema = (
         // TODO (jsonforms)
         // This happens when there is a type "null" INSIDE of a combinator
         // need more work but this keeps the form from blowing up at least.
+        console.error(`Likely invalid schema at ${currentRef}`, jsonSchema);
         // @ts-expect-error see above
         return null;
     }
@@ -451,29 +452,38 @@ const generateUISchema = (
             const nextRef: string = `${currentRef}/properties`;
 
             // Step through the ordered properties
-            layout.elements = orderedProps.map((propName) => {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                let value: JsonSchema = jsonSchema.properties![propName];
-                const ref = `${nextRef}/${encode(propName)}`;
+            layout.elements = orderedProps
+                .map((propName) => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    let value: JsonSchema = jsonSchema.properties![propName];
+                    const ref = `${nextRef}/${encode(propName)}`;
 
-                if (value.$ref !== undefined) {
-                    value = resolveSchema(
-                        rootSchema as JsonSchema,
-                        value.$ref,
-                        rootSchema as JsonSchema
+                    if (value.$ref !== undefined) {
+                        value = resolveSchema(
+                            rootSchema as JsonSchema,
+                            value.$ref,
+                            rootSchema as JsonSchema
+                        );
+                    }
+
+                    return generateUISchema(
+                        value,
+                        layout.elements,
+                        ref,
+                        propName,
+                        layoutType,
+                        rootGenerating,
+                        rootSchema
                     );
-                }
-
-                return generateUISchema(
-                    value,
-                    layout.elements,
-                    ref,
-                    propName,
-                    layoutType,
-                    rootGenerating,
-                    rootSchema
-                );
-            });
+                })
+                // Comment above explains when this could be null, basically
+                // it happens if you have a field that doesn't define a `"type"`
+                // and the logic here doesn't know what to do with you.
+                // If we didn't filter this out, then the nulls will cause
+                // strange artifacts when rendering. Generally "silent" failures
+                // aren't a good idea, but we are error-logging above
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                .filter((element) => element !== null);
         }
 
         return layout;


### PR DESCRIPTION
## Changes

Rather than rendering broken-looking forms full of error messages about missing renderers, let's filter out invalid fields, and log an error when we see them 

## Issues

Related to #389