### PR TITLE
fix: Allow submitting empty connector configs

### DIFF
--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -132,9 +132,14 @@ function useDiscoverCapture(
         useResourceConfig_resourceConfigErrorsExist();
     const resetCollections = useResourceConfig_resetConfigAndCollections();
 
+    // Errors if:
+    // * If we're in the edit workflow, defer to state
+    // * If we're in create workflow
+    //   * If we have an empty config, then there's no error
+    //   * If we don't have an empty config, defer to state
     const endpointConfigErrorFlag = editWorkflow
         ? endpointConfigErrorsExist
-        : endpointConfigErrorsExist || isEmpty(endpointConfigData);
+        : !isEmpty(endpointConfigData) && endpointConfigErrorsExist;
 
     const storeDiscoveredCollections = useCallback(
         async (

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -12,7 +12,6 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import { useClient } from 'hooks/supabase-swr';
-import { isEmpty } from 'lodash';
 import LogRocket from 'logrocket';
 import { useCallback, useMemo } from 'react';
 import { CustomEvents } from 'services/logrocket';
@@ -131,15 +130,6 @@ function useDiscoverCapture(
     const resourceConfigHasErrors =
         useResourceConfig_resourceConfigErrorsExist();
     const resetCollections = useResourceConfig_resetConfigAndCollections();
-
-    // Errors if:
-    // * If we're in the edit workflow, defer to state
-    // * If we're in create workflow
-    //   * If we have an empty config, then there's no error
-    //   * If we don't have an empty config, defer to state
-    const endpointConfigErrorFlag = editWorkflow
-        ? endpointConfigErrorsExist
-        : !isEmpty(endpointConfigData) && endpointConfigErrorsExist;
 
     const storeDiscoveredCollections = useCallback(
         async (
@@ -307,7 +297,7 @@ function useDiscoverCapture(
 
             if (
                 detailsFormsHasErrors ||
-                endpointConfigErrorFlag ||
+                endpointConfigErrorsExist ||
                 resourceConfigHasErrors
             ) {
                 return setFormState({
@@ -391,7 +381,7 @@ function useDiscoverCapture(
             detailsFormsHasErrors,
             editWorkflow,
             endpointConfigData,
-            endpointConfigErrorFlag,
+            endpointConfigErrorsExist,
             endpointSchema,
             entityName,
             imageConnectorId,

--- a/src/stores/EndpointConfig.tsx
+++ b/src/stores/EndpointConfig.tsx
@@ -215,6 +215,14 @@ const getInitialState = (
         set(
             produce((state) => {
                 state.endpointSchema = val;
+
+                const { endpointConfig, endpointCustomErrors } = get();
+
+                populateEndpointConfigErrors(
+                    endpointConfig,
+                    endpointCustomErrors,
+                    state
+                );
             }),
             false,
             'Endpoint Schema Set'
@@ -279,7 +287,7 @@ const getInitialState = (
                     : endpointConfig;
 
                 populateEndpointConfigErrors(
-                    endpointConfig,
+                    state.endpointConfig,
                     endpointCustomErrors,
                     state
                 );


### PR DESCRIPTION
## Changes

There's still something weird about this. #392 claims that the connector was updated, but I'm actually still getting an error about missing config once applying this change to allow the UI to submit an empty config object

<img width="1675" alt="Screen Shot 2022-12-12 at 22 53 58" src="https://user-images.githubusercontent.com/4368270/207222953-f9711212-f5b8-4350-b871-a2c33d2f568f.png">

## Issues

Fixes #392Fixes #416 (I think?)