### PR TITLE
Add custom Date and Time Controls

### DIFF
--- a/src/forms/renderers/Overrides/material/controls/MaterialDateControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialDateControl.tsx
@@ -49,7 +49,8 @@ import { Patterns } from 'types/jsonforms';
 
 const INVALID_DATE = 'Invalid Date';
 
-// This is pretty customized. Look at MaterialDateTimeControl for extra notes
+// This is pretty customized
+//  Look at MaterialDateTimeControl for extra notes
 //  as this is based on that but made to support Date Picker
 export const Custom_MaterialDateControl = (props: ControlProps) => {
     const { data, id, visible, enabled, path, handleChange, label } = props;

--- a/src/forms/renderers/Overrides/material/controls/MaterialDateControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialDateControl.tsx
@@ -1,0 +1,149 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import {
+    ControlProps,
+    isDateControl,
+    RankedTester,
+    rankWith,
+} from '@jsonforms/core';
+import {
+    MaterialInputControl,
+    MuiInputText,
+} from '@jsonforms/material-renderers';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import EventIcon from '@mui/icons-material/Event';
+import { Box, Hidden, IconButton, Popover, Stack } from '@mui/material';
+import { LocalizationProvider, StaticDatePicker } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { format } from 'date-fns';
+import {
+    bindPopover,
+    bindTrigger,
+    usePopupState,
+} from 'material-ui-popup-state/hooks';
+import { useIntl } from 'react-intl';
+import { Patterns } from 'types/jsonforms';
+
+const INVALID_DATE = 'Invalid Date';
+
+// This is pretty customized. Look at MaterialDateTimeControl for extra notes
+//  as this is based on that but made to support Date Picker
+export const Custom_MaterialDateControl = (props: ControlProps) => {
+    const { data, id, visible, enabled, path, handleChange, label } = props;
+
+    const intl = useIntl();
+    const popupState = usePopupState({
+        variant: 'popover',
+        popupId: `date-picker-${id}`,
+    });
+
+    const formatDate = (value: Date) => {
+        try {
+            return format(value, Patterns.date);
+        } catch (e: unknown) {
+            return INVALID_DATE;
+        }
+    };
+
+    const onChange = (value: any, keyboardInput?: string | undefined) => {
+        if (value) {
+            const formattedValue = formatDate(value);
+            if (formattedValue && formattedValue !== INVALID_DATE) {
+                return handleChange(path, formattedValue);
+            }
+        }
+
+        // Default to setting to what user typed
+        //  This is a super backup as with the Date Fn adapter
+        //  it never fell through to this... but wanted to be safe
+        return handleChange(path, keyboardInput);
+    };
+
+    return (
+        <Hidden xsUp={!visible}>
+            <Stack
+                sx={{
+                    alignItems: 'top',
+                }}
+                direction="row"
+            >
+                <MaterialInputControl input={MuiInputText} {...props} />
+                <Box sx={{ paddingTop: 2 }}>
+                    <IconButton
+                        aria-label={intl.formatMessage(
+                            {
+                                id: 'datePicker.button.ariaLabel',
+                            },
+                            {
+                                label,
+                            }
+                        )}
+                        disabled={!enabled}
+                        {...bindTrigger(popupState)}
+                    >
+                        <EventIcon />
+                    </IconButton>
+                </Box>
+
+                <Popover
+                    {...bindPopover(popupState)}
+                    anchorOrigin={{
+                        vertical: 'center',
+                        horizontal: 'left',
+                    }}
+                    transformOrigin={{
+                        vertical: 'center',
+                        horizontal: 'right',
+                    }}
+                >
+                    <LocalizationProvider dateAdapter={AdapterDateFns}>
+                        <StaticDatePicker
+                            ignoreInvalidInputs
+                            disableMaskedInput
+                            displayStaticWrapperAs="desktop"
+                            openTo="day"
+                            disabled={!enabled}
+                            value={data}
+                            onChange={onChange}
+                            onAccept={popupState.close}
+                            closeOnSelect={true}
+                            // We don't need an input
+                            // eslint-disable-next-line react/jsx-no-useless-fragment
+                            renderInput={() => <></>}
+                        />
+                    </LocalizationProvider>
+                </Popover>
+            </Stack>
+        </Hidden>
+    );
+};
+
+export const materialDateControlTester: RankedTester = rankWith(
+    10,
+    isDateControl
+);
+
+export default withJsonFormsControlProps(Custom_MaterialDateControl);

--- a/src/forms/renderers/Overrides/material/controls/MaterialDateTimeControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialDateTimeControl.tsx
@@ -80,7 +80,7 @@ export const Custom_MaterialDateTimeControl = (props: ControlProps) => {
     const intl = useIntl();
     const popupState = usePopupState({
         variant: 'popover',
-        popupId: `date-time-${id}`,
+        popupId: `date-time-picker-${id}`,
     });
 
     // We have a special handler that formats the date so that
@@ -132,7 +132,7 @@ export const Custom_MaterialDateTimeControl = (props: ControlProps) => {
                     <IconButton
                         aria-label={intl.formatMessage(
                             {
-                                id: 'datePicker.buttom.ariaLabel',
+                                id: 'dateTimePicker.button.ariaLabel',
                             },
                             {
                                 label,

--- a/src/forms/renderers/Overrides/material/controls/MaterialTimeControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialTimeControl.tsx
@@ -1,0 +1,174 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import {
+    ControlProps,
+    isTimeControl,
+    RankedTester,
+    rankWith,
+} from '@jsonforms/core';
+import {
+    MaterialInputControl,
+    MuiInputText,
+} from '@jsonforms/material-renderers';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import { Box, Hidden, IconButton, Popover, Stack } from '@mui/material';
+import { LocalizationProvider, StaticTimePicker } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { format } from 'date-fns';
+import {
+    bindPopover,
+    bindTrigger,
+    usePopupState,
+} from 'material-ui-popup-state/hooks';
+import { useMemo, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { Patterns } from 'types/jsonforms';
+import { hasLength } from 'utils/misc-utils';
+
+const INVALID_TIME = 'Invalid Time';
+
+// This is pretty customized
+//  Look at MaterialDateTimeControl for extra notes
+//  as this is based on that but made to support Date Picker
+export const Custom_MaterialTimeControl = (props: ControlProps) => {
+    const { data, id, visible, enabled, path, handleChange, label } = props;
+
+    const intl = useIntl();
+    const popupState = usePopupState({
+        variant: 'popover',
+        popupId: `time-picker-${id}`,
+    });
+
+    // Need to set the default time for both create and edit
+    //  This attempts to parse the current value and use it
+    //  to set the defaultTime's hours, minutes, and seconds
+    const defaultTime = useMemo(() => {
+        let args: [number, number?, number?];
+        const defaultValue = new Date();
+        if (hasLength(data)) {
+            args = data.split(':').map((val: string) => {
+                const response = Number.parseInt(val, 10);
+
+                return isNaN(response) ? 0 : response;
+            });
+        } else {
+            args = [1, 0, 0];
+        }
+
+        defaultValue.setHours(...args);
+
+        return defaultValue;
+    }, []);
+
+    const [timePickerValue, setTimePickerValue] = useState(defaultTime);
+
+    const formatDate = (value: Date) => {
+        try {
+            return format(value, Patterns.time);
+        } catch (e: unknown) {
+            return INVALID_TIME;
+        }
+    };
+
+    const onChange = (value: any, keyboardInput?: string | undefined) => {
+        if (value) {
+            const formattedValue = formatDate(value);
+            if (formattedValue && formattedValue !== INVALID_TIME) {
+                setTimePickerValue(value);
+                return handleChange(path, formattedValue);
+            }
+        }
+
+        // Default to setting to what user typed
+        //  This is a super backup as with the Date Fn adapter
+        //  it never fell through to this... but wanted to be safe
+        return handleChange(path, keyboardInput);
+    };
+
+    return (
+        <Hidden xsUp={!visible}>
+            <Stack
+                sx={{
+                    alignItems: 'top',
+                }}
+                direction="row"
+            >
+                <MaterialInputControl input={MuiInputText} {...props} />
+                <Box sx={{ paddingTop: 2 }}>
+                    <IconButton
+                        aria-label={intl.formatMessage(
+                            {
+                                id: 'dateTimePicker.button.ariaLabel',
+                            },
+                            {
+                                label,
+                            }
+                        )}
+                        disabled={!enabled}
+                        {...bindTrigger(popupState)}
+                    >
+                        <ScheduleIcon />
+                    </IconButton>
+                </Box>
+
+                <Popover
+                    {...bindPopover(popupState)}
+                    anchorOrigin={{
+                        vertical: 'center',
+                        horizontal: 'left',
+                    }}
+                    transformOrigin={{
+                        vertical: 'center',
+                        horizontal: 'right',
+                    }}
+                >
+                    <LocalizationProvider dateAdapter={AdapterDateFns}>
+                        <StaticTimePicker
+                            displayStaticWrapperAs="desktop"
+                            ampm={false}
+                            disabled={!enabled}
+                            value={timePickerValue}
+                            onChange={onChange}
+                            onAccept={popupState.close}
+                            closeOnSelect={true}
+                            // We don't need an input
+                            // eslint-disable-next-line react/jsx-no-useless-fragment
+                            renderInput={() => <></>}
+                        />
+                    </LocalizationProvider>
+                </Popover>
+            </Stack>
+        </Hidden>
+    );
+};
+
+export const materialTimeControlTester: RankedTester = rankWith(
+    10,
+    isTimeControl
+);
+
+export default withJsonFormsControlProps(Custom_MaterialTimeControl);

--- a/src/forms/renderers/Overrides/material/controls/MaterialTimeControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialTimeControl.tsx
@@ -82,6 +82,9 @@ export const Custom_MaterialTimeControl = (props: ControlProps) => {
         defaultValue.setHours(...args);
 
         return defaultValue;
+
+        // We only really care to set this once on load
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const [timePickerValue, setTimePickerValue] = useState(defaultTime);
@@ -122,7 +125,7 @@ export const Custom_MaterialTimeControl = (props: ControlProps) => {
                     <IconButton
                         aria-label={intl.formatMessage(
                             {
-                                id: 'dateTimePicker.button.ariaLabel',
+                                id: 'timePicker.button.ariaLabel',
                             },
                             {
                                 label,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -746,6 +746,7 @@ const Tenant: ResolvedIntlConfig['messages'] = {
 const CustomRenderers: ResolvedIntlConfig['messages'] = {
     'dateTimePicker.button.ariaLabel': `Open date time picker for {label}`,
     'datePicker.button.ariaLabel': `Open date picker for {label}`,
+    'timePicker.button.ariaLabel': `Open time picker for {label}`,
 };
 
 const enUSMessages: ResolvedIntlConfig['messages'] = {

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -743,8 +743,9 @@ const Tenant: ResolvedIntlConfig['messages'] = {
     'tenant.docs.message.link': `https://docs.estuary.dev/concepts/catalogs/#namespace`,
 };
 
-const DateTimeRenderer: ResolvedIntlConfig['messages'] = {
-    'datePicker.buttom.ariaLabel': `Open date time picker for {label}`,
+const CustomRenderers: ResolvedIntlConfig['messages'] = {
+    'dateTimePicker.button.ariaLabel': `Open date time picker for {label}`,
+    'datePicker.button.ariaLabel': `Open date picker for {label}`,
 };
 
 const enUSMessages: ResolvedIntlConfig['messages'] = {
@@ -789,7 +790,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...Workflows,
     ...Legal,
     ...Tenant,
-    ...DateTimeRenderer,
+    ...CustomRenderers,
 };
 
 export default enUSMessages;

--- a/src/services/jsonforms/defaultRenderers.ts
+++ b/src/services/jsonforms/defaultRenderers.ts
@@ -23,6 +23,9 @@ import MaterialDateControl, {
 import MaterialDateTimeControl, {
     materialDateTimeControlTester,
 } from 'forms/renderers/Overrides/material/controls/MaterialDateTimeControl';
+import MaterialTimeControl, {
+    materialTimeControlTester,
+} from 'forms/renderers/Overrides/material/controls/MaterialTimeControl';
 
 const defaultRenderers = [
     ...materialRenderers,
@@ -38,6 +41,10 @@ const defaultRenderers = [
     {
         renderer: MaterialDateControl,
         tester: materialDateControlTester,
+    },
+    {
+        renderer: MaterialTimeControl,
+        tester: materialTimeControlTester,
     },
 
     // Custom layouts

--- a/src/services/jsonforms/defaultRenderers.ts
+++ b/src/services/jsonforms/defaultRenderers.ts
@@ -17,6 +17,9 @@ import { oAuthProviderTester, OAuthType } from 'forms/renderers/OAuth';
 import MaterialOneOfRenderer_Discriminator, {
     materialOneOfControlTester_Discriminator,
 } from 'forms/renderers/Overrides/material/complex/MaterialOneOfRenderer_Discriminator';
+import MaterialDateControl, {
+    materialDateControlTester,
+} from 'forms/renderers/Overrides/material/controls/MaterialDateControl';
 import MaterialDateTimeControl, {
     materialDateTimeControlTester,
 } from 'forms/renderers/Overrides/material/controls/MaterialDateTimeControl';
@@ -31,6 +34,10 @@ const defaultRenderers = [
     {
         renderer: MaterialDateTimeControl,
         tester: materialDateTimeControlTester,
+    },
+    {
+        renderer: MaterialDateControl,
+        tester: materialDateControlTester,
     },
 
     // Custom layouts

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -42,7 +42,7 @@ import { concat, includes, orderBy } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import keys from 'lodash/keys';
 import startCase from 'lodash/startCase';
-import { Annotations, Formats, Options, Patterns } from 'types/jsonforms';
+import { Annotations, Formats, Options } from 'types/jsonforms';
 import { ADVANCED, CONTAINS_REQUIRED_FIELDS } from './shared';
 
 /////////////////////////////////////////////////////////
@@ -499,10 +499,6 @@ const generateUISchema = (
         addOption(controlObject, Options.format, Formats.date);
     } else if (isTimeText(jsonSchema)) {
         addOption(controlObject, Options.format, Formats.time);
-        if (controlObject.options) {
-            controlObject.options.timeFormat = Patterns.time;
-            controlObject.options.timeSaveFormat = Patterns.time;
-        }
     }
 
     switch (types[0]) {

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -497,10 +497,6 @@ const generateUISchema = (
         addOption(controlObject, Options.format, Formats.dateTime);
     } else if (isDateText(jsonSchema)) {
         addOption(controlObject, Options.format, Formats.date);
-        if (controlObject.options) {
-            controlObject.options.dateFormat = Patterns.date;
-            controlObject.options.dateSaveFormat = Patterns.date;
-        }
     } else if (isTimeText(jsonSchema)) {
         addOption(controlObject, Options.format, Formats.time);
         if (controlObject.options) {


### PR DESCRIPTION
## Changes

1. Added a Date picker control
2. Added a Time picker control

## Tests

Manually tested

## Issues

Fixes https://github.com/estuary/ui/issues/419

## Content

Same as previous control

## Screenshots

Date picker for Bing
![image](https://user-images.githubusercontent.com/270078/207447682-0b1a8851-c2c3-40b7-a02f-0ba2e12fa31b.png)

Faked the time picker by updating the type for Bing
![image](https://user-images.githubusercontent.com/270078/207498870-a3bf41d6-37da-4906-a439-be6a4da8abf3.png)
