### PR TITLE
Add storage mapping to Admin page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9039,7 +9039,7 @@
         "node_modules/data-plane-gateway": {
             "version": "0.0.0",
             "resolved": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-/pXFiS29P1P6PhsxGG2J53zAAxm1gaIbwaK+CcnIWvZwqklaEgL3lq1jFR/qbc3Rbe3yGoT4W1yyA5j/gqsbKg==",
+            "integrity": "sha512-PHF0HtRndoDI0OD8wSqwNeCBIf4Qm1737w66SI9GN1ZtzduIzDuXQtgtCw6gd3bY29jOYehnnMLAfEz0kZCwew==",
             "license": "MIT"
         },
         "node_modules/data-urls": {
@@ -33235,7 +33235,7 @@
         },
         "data-plane-gateway": {
             "version": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-/pXFiS29P1P6PhsxGG2J53zAAxm1gaIbwaK+CcnIWvZwqklaEgL3lq1jFR/qbc3Rbe3yGoT4W1yyA5j/gqsbKg=="
+            "integrity": "sha512-PHF0HtRndoDI0OD8wSqwNeCBIf4Qm1737w66SI9GN1ZtzduIzDuXQtgtCw6gd3bY29jOYehnnMLAfEz0kZCwew=="
         },
         "data-urls": {
             "version": "2.0.0",

--- a/src/api/combinedGrantsExt.ts
+++ b/src/api/combinedGrantsExt.ts
@@ -6,8 +6,41 @@ import {
 } from 'services/supabase';
 import { Grants } from 'types';
 
-// Used to display all the grants for everything in the admin page
+// Used to display prefix grants in admin page
 const getGrants = (
+    pagination: any,
+    searchQuery: any,
+    sorting: SortingProps<any>[]
+) => {
+    let queryBuilder = supabaseClient
+        .from(TABLES.COMBINED_GRANTS_EXT)
+        .select(
+            `
+            id, 
+            subject_role, 
+            object_role, 
+            capability,
+            updated_at
+        `,
+            {
+                count: 'exact',
+            }
+        )
+        .neq('subject_role', null);
+
+    queryBuilder = defaultTableFilter(
+        queryBuilder,
+        ['subject_role', 'object_role'],
+        searchQuery,
+        sorting,
+        pagination
+    );
+
+    return queryBuilder;
+};
+
+// Used to display user grants in admin page
+const getGrants_Users = (
     pagination: any,
     searchQuery: any,
     sorting: SortingProps<any>[]
@@ -15,7 +48,6 @@ const getGrants = (
     let queryBuilder = supabaseClient.from(TABLES.COMBINED_GRANTS_EXT).select(
         `
             id, 
-            subject_role, 
             object_role, 
             capability,
             user_avatar_url,
@@ -30,7 +62,7 @@ const getGrants = (
 
     queryBuilder = defaultTableFilter(
         queryBuilder,
-        ['user_full_name', 'subject_role', 'object_role'],
+        ['user_full_name', 'user_email', 'object_role'],
         searchQuery,
         sorting,
         pagination
@@ -59,4 +91,4 @@ const getGrantsForAuthToken = () => {
         .select(`id, object_role`);
 };
 
-export { getGrantsForAuthToken, getGrants, getGrantsForUser };
+export { getGrantsForAuthToken, getGrants, getGrants_Users, getGrantsForUser };

--- a/src/api/combinedGrantsExt.ts
+++ b/src/api/combinedGrantsExt.ts
@@ -45,8 +45,10 @@ const getGrants_Users = (
     searchQuery: any,
     sorting: SortingProps<any>[]
 ) => {
-    let queryBuilder = supabaseClient.from(TABLES.COMBINED_GRANTS_EXT).select(
-        `
+    let queryBuilder = supabaseClient
+        .from(TABLES.COMBINED_GRANTS_EXT)
+        .select(
+            `
             id, 
             object_role, 
             capability,
@@ -55,10 +57,11 @@ const getGrants_Users = (
             user_email,
             updated_at
         `,
-        {
-            count: 'exact',
-        }
-    );
+            {
+                count: 'exact',
+            }
+        )
+        .or('user_email.neq.null,user_full_name.neq.null');
 
     queryBuilder = defaultTableFilter(
         queryBuilder,

--- a/src/api/storageMappings.ts
+++ b/src/api/storageMappings.ts
@@ -1,7 +1,40 @@
-import { supabaseClient, TABLES } from 'services/supabase';
+import {
+    defaultTableFilter,
+    Pagination,
+    SortingProps,
+    supabaseClient,
+    TABLES,
+} from 'services/supabase';
 import { StorageMappings } from 'types';
 
-const getStorageMappings = () => {
+const getStorageMappings = (
+    pagination: Pagination,
+    searchQuery: any,
+    sorting: SortingProps<any>[]
+) => {
+    let queryBuilder = supabaseClient
+        .from<StorageMappings>(TABLES.STORAGE_MAPPINGS)
+        .select(
+            `
+            id,
+            spec,
+            catalog_prefix,
+            updated_at
+        `
+        );
+
+    queryBuilder = defaultTableFilter(
+        queryBuilder,
+        ['catalog_prefix'],
+        searchQuery,
+        sorting,
+        pagination
+    );
+
+    return queryBuilder;
+};
+
+const getStorageMapping = (catalog_prefix: string) => {
     const queryBuilder = supabaseClient
         .from<StorageMappings>(TABLES.STORAGE_MAPPINGS)
         .select(
@@ -10,9 +43,10 @@ const getStorageMappings = () => {
             catalog_prefix,
             updated_at
         `
-        );
+        )
+        .eq('catalog_prefix', catalog_prefix);
 
     return queryBuilder;
 };
 
-export { getStorageMappings };
+export { getStorageMappings, getStorageMapping };

--- a/src/api/storageMappings.ts
+++ b/src/api/storageMappings.ts
@@ -1,0 +1,18 @@
+import { supabaseClient, TABLES } from 'services/supabase';
+import { StorageMappings } from 'types';
+
+const getStorageMappings = () => {
+    const queryBuilder = supabaseClient
+        .from<StorageMappings>(TABLES.STORAGE_MAPPINGS)
+        .select(
+            `    
+            spec,
+            catalog_prefix,
+            updated_at
+        `
+        );
+
+    return queryBuilder;
+};
+
+export { getStorageMappings };

--- a/src/app/Authenticated.tsx
+++ b/src/app/Authenticated.tsx
@@ -3,6 +3,7 @@ import AccessGrants from 'components/admin/AccessGrants';
 import AdminApi from 'components/admin/Api';
 import AdminConnectors from 'components/admin/Connectors';
 import AdminCookies from 'components/admin/Cookies';
+import StorageMappings from 'components/admin/StorageMappings';
 import CaptureCreate from 'components/capture/Create';
 import CaptureEdit from 'components/capture/Edit';
 import MaterializationCreate from 'components/materialization/Create';
@@ -22,6 +23,7 @@ import Home from 'pages/Home';
 import Materializations from 'pages/Materializations';
 import { Route, Routes } from 'react-router';
 import { EndpointConfigProvider } from 'stores/EndpointConfig';
+import StorageMappingsHydrator from 'stores/StorageMappings/Hydrator';
 import { isProduction } from 'utils/env-utils';
 import { authenticatedRoutes, unauthenticatedRoutes } from './routes';
 
@@ -154,6 +156,16 @@ const Authenticated = () => {
                         <Route
                             path={authenticatedRoutes.admin.cookies.path}
                             element={<AdminCookies />}
+                        />
+                        <Route
+                            path={
+                                authenticatedRoutes.admin.storageMappings.path
+                            }
+                            element={
+                                <StorageMappingsHydrator>
+                                    <StorageMappings />
+                                </StorageMappingsHydrator>
+                            }
                         />
                     </Route>
 

--- a/src/app/Authenticated.tsx
+++ b/src/app/Authenticated.tsx
@@ -23,7 +23,6 @@ import Home from 'pages/Home';
 import Materializations from 'pages/Materializations';
 import { Route, Routes } from 'react-router';
 import { EndpointConfigProvider } from 'stores/EndpointConfig';
-import StorageMappingsHydrator from 'stores/StorageMappings/Hydrator';
 import { isProduction } from 'utils/env-utils';
 import { authenticatedRoutes, unauthenticatedRoutes } from './routes';
 
@@ -161,11 +160,7 @@ const Authenticated = () => {
                             path={
                                 authenticatedRoutes.admin.storageMappings.path
                             }
-                            element={
-                                <StorageMappingsHydrator>
-                                    <StorageMappings />
-                                </StorageMappingsHydrator>
-                            }
+                            element={<StorageMappings />}
                         />
                     </Route>
 

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -40,6 +40,11 @@ export const authenticatedRoutes = {
             path: 'cookies',
             fullPath: '/admin/cookies',
         },
+        storageMappings: {
+            title: 'routeTitle.admin.storageMappings',
+            path: 'storage-mappings',
+            fullPath: '/admin/storage-mappings',
+        },
     },
     captures: {
         title: 'routeTitle.captures',

--- a/src/components/admin/AccessGrants.tsx
+++ b/src/components/admin/AccessGrants.tsx
@@ -34,6 +34,7 @@ function AccessGrants() {
                 <Divider />
             </Stack>
 
+            <AccessGrantsTable showUser />
             <AccessGrantsTable />
         </PageContainer>
     );

--- a/src/components/admin/StorageMappings.tsx
+++ b/src/components/admin/StorageMappings.tsx
@@ -2,7 +2,7 @@ import { Divider, Stack, Typography } from '@mui/material';
 import { authenticatedRoutes } from 'app/routes';
 import AdminTabs from 'components/admin/Tabs';
 import PageContainer from 'components/shared/PageContainer';
-import Form from 'components/storageMappings/Form';
+import StorageMappingsTable from 'components/tables/StorageMappings';
 import useBrowserTitle from 'hooks/useBrowserTitle';
 import { FormattedMessage } from 'react-intl';
 
@@ -14,7 +14,7 @@ function StorageMappings() {
             pageTitleProps={{
                 header: authenticatedRoutes.admin.storageMappings.title,
                 headerLink:
-                    'https://docs.estuary.dev/concepts/#storage-mappings',
+                    'https://docs.estuary.dev/concepts/storage-mappings/',
             }}
         >
             <AdminTabs />
@@ -28,9 +28,12 @@ function StorageMappings() {
                 >
                     <FormattedMessage id="storageMappings.header" />
                 </Typography>
+                <Typography>
+                    <FormattedMessage id="storageMappings.message" />
+                </Typography>
                 <Divider />
-                <Form />
             </Stack>
+            <StorageMappingsTable />
         </PageContainer>
     );
 }

--- a/src/components/admin/StorageMappings.tsx
+++ b/src/components/admin/StorageMappings.tsx
@@ -1,0 +1,38 @@
+import { Divider, Stack, Typography } from '@mui/material';
+import { authenticatedRoutes } from 'app/routes';
+import AdminTabs from 'components/admin/Tabs';
+import PageContainer from 'components/shared/PageContainer';
+import Form from 'components/storageMappings/Form';
+import useBrowserTitle from 'hooks/useBrowserTitle';
+import { FormattedMessage } from 'react-intl';
+
+function StorageMappings() {
+    useBrowserTitle('browserTitle.admin.storageMappings');
+
+    return (
+        <PageContainer
+            pageTitleProps={{
+                header: authenticatedRoutes.admin.storageMappings.title,
+                headerLink:
+                    'https://docs.estuary.dev/concepts/#storage-mappings',
+            }}
+        >
+            <AdminTabs />
+            <Stack direction="column" spacing={2} sx={{ m: 2 }}>
+                <Typography
+                    component="span"
+                    variant="h6"
+                    sx={{
+                        alignItems: 'center',
+                    }}
+                >
+                    <FormattedMessage id="storageMappings.header" />
+                </Typography>
+                <Divider />
+                <Form />
+            </Stack>
+        </PageContainer>
+    );
+}
+
+export default StorageMappings;

--- a/src/components/admin/Tabs.tsx
+++ b/src/components/admin/Tabs.tsx
@@ -23,6 +23,11 @@ function AdminTabs() {
                 path: authenticatedRoutes.admin.accessGrants.fullPath,
             },
             {
+                label: 'admin.tabs.storageMappings',
+                icon: GroupIcon,
+                path: authenticatedRoutes.admin.storageMappings.fullPath,
+            },
+            {
                 label: 'admin.tabs.connectors',
                 icon: MediationIcon,
                 path: authenticatedRoutes.admin.connectors.fullPath,

--- a/src/components/admin/Tabs.tsx
+++ b/src/components/admin/Tabs.tsx
@@ -1,3 +1,4 @@
+import BackupIcon from '@mui/icons-material/Backup';
 import CookieIcon from '@mui/icons-material/Cookie';
 import GroupIcon from '@mui/icons-material/Group';
 import MediationIcon from '@mui/icons-material/Mediation';
@@ -24,7 +25,7 @@ function AdminTabs() {
             },
             {
                 label: 'admin.tabs.storageMappings',
-                icon: GroupIcon,
+                icon: BackupIcon,
                 path: authenticatedRoutes.admin.storageMappings.fullPath,
             },
             {
@@ -76,7 +77,12 @@ function AdminTabs() {
 
     return (
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-            <Tabs value={selectedTab} aria-label="basic tabs example">
+            <Tabs
+                allowScrollButtonsMobile
+                variant="scrollable"
+                scrollButtons="auto"
+                value={selectedTab}
+            >
                 {tabs}
             </Tabs>
         </Box>

--- a/src/components/connectors/card/index.tsx
+++ b/src/components/connectors/card/index.tsx
@@ -1,39 +1,13 @@
-import { Box, Grid, Paper, Stack } from '@mui/material';
+import { Box, Grid, Stack } from '@mui/material';
 import ExternalLink from 'components/shared/ExternalLink';
+import Tile from 'components/shared/Tile';
 import {
     connectorImageBackgroundRadius,
     connectorImageBackgroundSx,
-    semiTransparentBackground,
-    semiTransparentBackgroundIntensified,
     teal,
 } from 'context/Theme';
 import { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { BaseComponentProps } from 'types';
-
-type TileProps = BaseComponentProps;
-function Tile({ children }: TileProps) {
-    return (
-        <Paper
-            elevation={0}
-            sx={{
-                'borderRadius': 5,
-                'maxWidth': 500,
-                'flexGrow': 1,
-                'background': (theme) =>
-                    semiTransparentBackgroundIntensified[theme.palette.mode],
-                'padding': 1,
-                'height': '100%',
-                '&:hover': {
-                    background: (theme) =>
-                        semiTransparentBackground[theme.palette.mode],
-                },
-            }}
-        >
-            {children}
-        </Paper>
-    );
-}
 
 interface Props {
     logo: ReactNode;

--- a/src/components/shared/Tile.tsx
+++ b/src/components/shared/Tile.tsx
@@ -1,0 +1,32 @@
+import { Paper } from '@mui/material';
+import {
+    semiTransparentBackground,
+    semiTransparentBackgroundIntensified,
+} from 'context/Theme';
+import { BaseComponentProps } from 'types';
+
+type TileProps = BaseComponentProps;
+function Tile({ children }: TileProps) {
+    return (
+        <Paper
+            elevation={0}
+            sx={{
+                'borderRadius': 5,
+                'maxWidth': 500,
+                'flexGrow': 1,
+                'background': (theme) =>
+                    semiTransparentBackgroundIntensified[theme.palette.mode],
+                'padding': 1,
+                'height': '100%',
+                '&:hover': {
+                    background: (theme) =>
+                        semiTransparentBackground[theme.palette.mode],
+                },
+            }}
+        >
+            {children}
+        </Paper>
+    );
+}
+
+export default Tile;

--- a/src/components/storageMappings/Form.tsx
+++ b/src/components/storageMappings/Form.tsx
@@ -12,6 +12,8 @@ import {
 import ProviderSelector from './ProviderSelector';
 import useFormSchema from './useFormSchema';
 
+// TODO (storage mapping edit) - this is not used right now but will be when we add
+//  storage mapping editing.
 function Form() {
     const loading = useStorageMappingsStore_loading();
     const storageMappingSpecs = useStorageMappingsStore_spec();

--- a/src/components/storageMappings/Form.tsx
+++ b/src/components/storageMappings/Form.tsx
@@ -1,0 +1,58 @@
+import { materialCells } from '@jsonforms/material-renderers';
+import { JsonForms } from '@jsonforms/react';
+import { Skeleton, Stack, StyledEngineProvider } from '@mui/material';
+import { jsonFormsPadding } from 'context/Theme';
+import { useEffect, useState } from 'react';
+import defaultRenderers from 'services/jsonforms/defaultRenderers';
+import { defaultOptions } from 'services/jsonforms/shared';
+import {
+    useStorageMappingsStore_loading,
+    useStorageMappingsStore_spec,
+} from 'stores/StorageMappings/hooks';
+import ProviderSelector from './ProviderSelector';
+import useFormSchema from './useFormSchema';
+
+function Form() {
+    const loading = useStorageMappingsStore_loading();
+    const storageMappingSpecs = useStorageMappingsStore_spec();
+    const { schema, uiSchema } = useFormSchema();
+
+    const [formData, setFormData] = useState({});
+
+    useEffect(() => {
+        if (storageMappingSpecs) {
+            setFormData(storageMappingSpecs);
+        }
+    }, [storageMappingSpecs]);
+
+    if (loading) {
+        return <Skeleton />;
+    }
+
+    if (!storageMappingSpecs) {
+        return <>No Spec to display</>;
+    }
+
+    return (
+        <StyledEngineProvider injectFirst>
+            <Stack
+                sx={{
+                    ...jsonFormsPadding,
+                }}
+            >
+                <ProviderSelector />
+                <JsonForms
+                    readonly={true}
+                    schema={schema}
+                    uischema={uiSchema}
+                    data={formData}
+                    renderers={defaultRenderers}
+                    cells={materialCells}
+                    config={defaultOptions}
+                />
+            </Stack>
+        </StyledEngineProvider>
+    );
+}
+
+export default Form;

--- a/src/components/storageMappings/ProviderSelector.tsx
+++ b/src/components/storageMappings/ProviderSelector.tsx
@@ -1,5 +1,7 @@
 import Tile from 'components/shared/Tile';
 
+// TODO (storage mapping edit) - this is not used right now but will be when we add
+//  storage mapping editing.
 function ProviderSelector() {
     return <Tile>Provider Card</Tile>;
 }

--- a/src/components/storageMappings/ProviderSelector.tsx
+++ b/src/components/storageMappings/ProviderSelector.tsx
@@ -1,0 +1,7 @@
+import Tile from 'components/shared/Tile';
+
+function ProviderSelector() {
+    return <Tile>Provider Card</Tile>;
+}
+
+export default ProviderSelector;

--- a/src/components/storageMappings/useFormSchema.ts
+++ b/src/components/storageMappings/useFormSchema.ts
@@ -1,0 +1,71 @@
+import { useIntl } from 'react-intl';
+import useConstant from 'use-constant';
+
+function useFormSchema() {
+    const intl = useIntl();
+
+    const schema = useConstant(() => {
+        return {
+            type: 'object',
+            required: ['bucket', 'lastUpdate', 'prefix'],
+            properties: {
+                bucket: {
+                    description: intl.formatMessage({
+                        id: 'storageMappings.bucket.description',
+                    }),
+                    type: 'string',
+                },
+                lastUpdated: {
+                    type: 'string',
+                },
+                prefix: {
+                    description: intl.formatMessage({
+                        id: 'storageMappings.prefix.description',
+                    }),
+                    type: 'string',
+                },
+            },
+        };
+    });
+
+    const uiSchema = useConstant(() => {
+        return {
+            elements: [
+                {
+                    elements: [
+                        {
+                            label: intl.formatMessage({
+                                id: 'common.tenant',
+                            }),
+                            scope: `#/properties/prefix`,
+                            type: 'Control',
+                        },
+                        {
+                            label: intl.formatMessage({
+                                id: 'storageMappings.bucket.label',
+                            }),
+                            scope: `#/properties/bucket`,
+                            type: 'Control',
+                        },
+                        {
+                            label: intl.formatMessage({
+                                id: 'storageMappings.lastUpdated.label',
+                            }),
+                            scope: '#/properties/lastUpdated',
+                            type: 'Control',
+                        },
+                    ],
+                    type: 'VerticalLayout',
+                },
+            ],
+            type: 'VerticalLayout',
+        };
+    });
+
+    return {
+        schema,
+        uiSchema,
+    };
+}
+
+export default useFormSchema;

--- a/src/components/storageMappings/useFormSchema.ts
+++ b/src/components/storageMappings/useFormSchema.ts
@@ -1,6 +1,8 @@
 import { useIntl } from 'react-intl';
 import useConstant from 'use-constant';
 
+// TODO (storage mapping edit) - this is not used right now but will be when we add
+//  storage mapping editing.
 function useFormSchema() {
     const intl = useIntl();
 

--- a/src/components/tables/AccessGrants/Rows.tsx
+++ b/src/components/tables/AccessGrants/Rows.tsx
@@ -36,7 +36,7 @@ export const userTableColumns = [
 export const prefixTableColumns = [
     {
         field: 'subject_role',
-        headerIntlKey: 'entityTable.data.prefix',
+        headerIntlKey: 'entityTable.data.catalogPrefix',
     },
 ].concat(commonTableColumns);
 

--- a/src/components/tables/AccessGrants/Rows.tsx
+++ b/src/components/tables/AccessGrants/Rows.tsx
@@ -8,13 +8,10 @@ interface RowProps {
 
 interface RowsProps {
     data: any[];
+    showUser?: boolean;
 }
 
-export const tableColumns = [
-    {
-        field: 'user_full_name',
-        headerIntlKey: 'entityTable.data.userFullName',
-    },
+const commonTableColumns = [
     {
         field: 'capability',
         headerIntlKey: 'entityTable.data.capability',
@@ -28,6 +25,20 @@ export const tableColumns = [
         headerIntlKey: 'entityTable.data.lastUpdated',
     },
 ];
+
+export const userTableColumns = [
+    {
+        field: 'user_full_name',
+        headerIntlKey: 'entityTable.data.userFullName',
+    },
+].concat(commonTableColumns);
+
+export const prefixTableColumns = [
+    {
+        field: 'subject_role',
+        headerIntlKey: 'entityTable.data.prefix',
+    },
+].concat(commonTableColumns);
 
 function Row({ row }: RowProps) {
     return (
@@ -55,12 +66,23 @@ function Row({ row }: RowProps) {
     );
 }
 
-function Rows({ data }: RowsProps) {
+function Rows({ data, showUser }: RowsProps) {
     return (
         <>
-            {data.map((row) => (
-                <Row row={row} key={row.id} />
-            ))}
+            {data.map((row) => {
+                const isUser = row.user_full_name || row.user_email;
+                if (showUser) {
+                    if (isUser) {
+                        return <Row row={row} key={row.id} />;
+                    } else {
+                        return null;
+                    }
+                } else if (isUser) {
+                    return null;
+                } else {
+                    return <Row row={row} key={row.id} />;
+                }
+            })}
         </>
     );
 }

--- a/src/components/tables/AccessGrants/index.tsx
+++ b/src/components/tables/AccessGrants/index.tsx
@@ -1,13 +1,17 @@
 import { Box } from '@mui/material';
-import { getGrants } from 'api/combinedGrantsExt';
-import Rows, { tableColumns } from 'components/tables/AccessGrants/Rows';
+import { getGrants, getGrants_Users } from 'api/combinedGrantsExt';
+import Rows, { userTableColumns } from 'components/tables/AccessGrants/Rows';
 import EntityTable from 'components/tables/EntityTable';
 import { useMemo } from 'react';
 import { SelectTableStoreNames } from 'stores/names';
 import TableHydrator from 'stores/Tables/Hydrator';
 import useTableState from '../hooks';
 
-function AccessGrantsTable() {
+interface Props {
+    showUser?: boolean;
+}
+
+function AccessGrantsTable({ showUser }: Props) {
     const {
         pagination,
         setPagination,
@@ -17,22 +21,42 @@ function AccessGrantsTable() {
         setSortDirection,
         columnToSort,
         setColumnToSort,
-    } = useTableState('user_full_name');
+    } = useTableState(showUser ? 'user_full_name' : 'subject_role');
 
     const query = useMemo(() => {
-        return getGrants(pagination, searchQuery, [
-            {
-                col: columnToSort,
-                direction: sortDirection,
-            },
-        ]);
-    }, [columnToSort, pagination, searchQuery, sortDirection]);
+        if (showUser) {
+            return getGrants_Users(pagination, searchQuery, [
+                {
+                    col: columnToSort,
+                    direction: sortDirection,
+                },
+            ]);
+        } else {
+            return getGrants(pagination, searchQuery, [
+                {
+                    col: columnToSort,
+                    direction: sortDirection,
+                },
+            ]);
+        }
+    }, [columnToSort, pagination, searchQuery, showUser, sortDirection]);
+
+    const headerKey = showUser
+        ? 'accessGrantsTable.users.title'
+        : 'accessGrantsTable.prefixes.title';
+    const filterKey = showUser
+        ? 'accessGrantsTable.users.filterLabel'
+        : 'accessGrantsTable.prefixes.filterLabel';
 
     return (
         <Box>
             <TableHydrator
                 query={query}
-                selectableTableStoreName={SelectTableStoreNames.ACCESS_GRANTS}
+                selectableTableStoreName={
+                    showUser
+                        ? SelectTableStoreNames.ACCESS_GRANTS_USERS
+                        : SelectTableStoreNames.ACCESS_GRANTS_PREFIXES
+                }
             >
                 <EntityTable
                     noExistingDataContentIds={{
@@ -40,18 +64,22 @@ function AccessGrantsTable() {
                         message: 'accessGrants.message2',
                         disableDoclink: true,
                     }}
-                    columns={tableColumns}
-                    renderTableRows={(data) => <Rows data={data} />}
+                    columns={userTableColumns}
+                    renderTableRows={(data) => (
+                        <Rows data={data} showUser={showUser} />
+                    )}
                     setPagination={setPagination}
                     setSearchQuery={setSearchQuery}
                     sortDirection={sortDirection}
                     setSortDirection={setSortDirection}
                     columnToSort={columnToSort}
                     setColumnToSort={setColumnToSort}
-                    header="accessGrantsTable.title"
-                    filterLabel="accessGrantsTable.filterLabel"
+                    header={headerKey}
+                    filterLabel={filterKey}
                     selectableTableStoreName={
-                        SelectTableStoreNames.ACCESS_GRANTS
+                        showUser
+                            ? SelectTableStoreNames.ACCESS_GRANTS_USERS
+                            : SelectTableStoreNames.ACCESS_GRANTS_PREFIXES
                     }
                 />
             </TableHydrator>

--- a/src/components/tables/AccessGrants/index.tsx
+++ b/src/components/tables/AccessGrants/index.tsx
@@ -1,6 +1,9 @@
 import { Box } from '@mui/material';
 import { getGrants, getGrants_Users } from 'api/combinedGrantsExt';
-import Rows, { userTableColumns } from 'components/tables/AccessGrants/Rows';
+import Rows, {
+    prefixTableColumns,
+    userTableColumns,
+} from 'components/tables/AccessGrants/Rows';
 import EntityTable from 'components/tables/EntityTable';
 import { useMemo } from 'react';
 import { SelectTableStoreNames } from 'stores/names';
@@ -64,7 +67,7 @@ function AccessGrantsTable({ showUser }: Props) {
                         message: 'accessGrants.message2',
                         disableDoclink: true,
                     }}
-                    columns={userTableColumns}
+                    columns={showUser ? userTableColumns : prefixTableColumns}
                     renderTableRows={(data) => (
                         <Rows data={data} showUser={showUser} />
                     )}

--- a/src/components/tables/StorageMappings/Rows.tsx
+++ b/src/components/tables/StorageMappings/Rows.tsx
@@ -29,7 +29,7 @@ export const tableColumns = [
     },
     {
         field: null,
-        headerIntlKey: 'entityTable.data.prefix',
+        headerIntlKey: 'entityTable.data.storagePrefix',
     },
     {
         field: 'updated_at',

--- a/src/components/tables/StorageMappings/Rows.tsx
+++ b/src/components/tables/StorageMappings/Rows.tsx
@@ -1,0 +1,94 @@
+import { TableCell, TableRow } from '@mui/material';
+import TimeStamp from 'components/tables/cells/TimeStamp';
+import { StorageMappings, StorageMappingStore } from 'types';
+
+interface RowProps {
+    row: StorageMappings;
+}
+
+interface RowsProps {
+    data: StorageMappings[];
+}
+
+interface DataCellProps {
+    store: StorageMappingStore;
+}
+
+export const tableColumns = [
+    {
+        field: 'catalog_prefix',
+        headerIntlKey: 'entityTable.data.catalogPrefix',
+    },
+    {
+        field: null,
+        headerIntlKey: 'entityTable.data.provider',
+    },
+    {
+        field: null,
+        headerIntlKey: 'entityTable.data.bucket',
+    },
+    {
+        field: null,
+        headerIntlKey: 'entityTable.data.prefix',
+    },
+    {
+        field: 'updated_at',
+        headerIntlKey: 'entityTable.data.lastUpdated',
+    },
+];
+
+function DataCells({ store }: DataCellProps) {
+    const { provider, bucket, prefix } = store;
+    return (
+        <>
+            <TableCell>{provider}</TableCell>
+
+            <TableCell>{bucket}</TableCell>
+
+            <TableCell>{prefix}</TableCell>
+        </>
+    );
+}
+
+function Row({ row }: RowProps) {
+    const key = `StorageMappings-${row.id}`;
+    const multipleStores = row.spec.stores.length > 1;
+
+    if (multipleStores) {
+        return (
+            <>
+                <TableRow key={key}>
+                    <TableCell colSpan={4}>{row.catalog_prefix}</TableCell>
+                    <TimeStamp time={row.updated_at} enableRelative />
+                </TableRow>
+                {row.spec.stores.map((store) => (
+                    <TableRow key={key}>
+                        <TableCell />
+                        <DataCells store={store} />
+                        <TableCell />
+                    </TableRow>
+                ))}
+            </>
+        );
+    }
+
+    return (
+        <TableRow key={key}>
+            <TableCell>{row.catalog_prefix}</TableCell>
+            <DataCells store={row.spec.stores[0]} />
+            <TimeStamp time={row.updated_at} enableRelative />
+        </TableRow>
+    );
+}
+
+function Rows({ data }: RowsProps) {
+    return (
+        <>
+            {data.map((row) => (
+                <Row row={row} key={row.id} />
+            ))}
+        </>
+    );
+}
+
+export default Rows;

--- a/src/components/tables/StorageMappings/index.tsx
+++ b/src/components/tables/StorageMappings/index.tsx
@@ -1,0 +1,64 @@
+import { Box } from '@mui/material';
+import { getStorageMappings } from 'api/storageMappings';
+import EntityTable from 'components/tables/EntityTable';
+import { useMemo } from 'react';
+import { SelectTableStoreNames } from 'stores/names';
+import TableHydrator from 'stores/Tables/Hydrator';
+import useTableState from '../hooks';
+import Rows, { tableColumns } from './Rows';
+
+function StorageMappingsTable() {
+    const {
+        pagination,
+        setPagination,
+        searchQuery,
+        setSearchQuery,
+        sortDirection,
+        setSortDirection,
+        columnToSort,
+        setColumnToSort,
+    } = useTableState('catalog_prefix');
+
+    const query = useMemo(() => {
+        return getStorageMappings(pagination, searchQuery, [
+            {
+                col: columnToSort,
+                direction: sortDirection,
+            },
+        ]);
+    }, [columnToSort, pagination, searchQuery, sortDirection]);
+
+    return (
+        <Box>
+            <TableHydrator
+                query={query}
+                selectableTableStoreName={
+                    SelectTableStoreNames.STORAGE_MAPPINGS
+                }
+            >
+                <EntityTable
+                    noExistingDataContentIds={{
+                        header: 'storageMappingsTable.message1',
+                        message: 'storageMappingsTable.message2',
+                        disableDoclink: true,
+                    }}
+                    columns={tableColumns}
+                    renderTableRows={(data) => <Rows data={data} />}
+                    setPagination={setPagination}
+                    setSearchQuery={setSearchQuery}
+                    sortDirection={sortDirection}
+                    setSortDirection={setSortDirection}
+                    columnToSort={columnToSort}
+                    setColumnToSort={setColumnToSort}
+                    header="storageMappingsTable.title"
+                    filterLabel="storageMappingsTable.filterLabel"
+                    selectableTableStoreName={
+                        SelectTableStoreNames.STORAGE_MAPPINGS
+                    }
+                />
+            </TableHydrator>
+        </Box>
+    );
+}
+
+export default StorageMappingsTable;

--- a/src/context/Zustand/invariableStores.ts
+++ b/src/context/Zustand/invariableStores.ts
@@ -2,6 +2,7 @@ import { createEditorStore } from 'components/editor/Store/create';
 import { createSelectableTableStore } from 'components/tables/Store';
 import { createFormStateStore } from 'stores/FormState/Store';
 import {
+    AdminStoreNames,
     EditorStoreNames,
     FormStateStoreNames,
     ResourceConfigStoreNames,
@@ -10,6 +11,7 @@ import {
 } from 'stores/names';
 import { createResourceConfigStore } from 'stores/ResourceConfig/Store';
 import { createShardDetailStore } from 'stores/ShardDetail/Store';
+import { createStorageMappingsStore } from 'stores/StorageMappings/Store';
 import { MessagePrefixes } from 'types';
 
 const invariableStores = {
@@ -71,6 +73,11 @@ const invariableStores = {
     ),
     [SelectTableStoreNames.MATERIALIZATION]: createSelectableTableStore(
         SelectTableStoreNames.MATERIALIZATION
+    ),
+
+    // Admin Storage Mappings
+    [AdminStoreNames.STORAGE_MAPPINGS]: createStorageMappingsStore(
+        AdminStoreNames.STORAGE_MAPPINGS
     ),
 };
 

--- a/src/context/Zustand/invariableStores.ts
+++ b/src/context/Zustand/invariableStores.ts
@@ -59,8 +59,11 @@ const invariableStores = {
     ),
 
     // Select Table Store
-    [SelectTableStoreNames.ACCESS_GRANTS]: createSelectableTableStore(
-        SelectTableStoreNames.ACCESS_GRANTS
+    [SelectTableStoreNames.ACCESS_GRANTS_PREFIXES]: createSelectableTableStore(
+        SelectTableStoreNames.ACCESS_GRANTS_PREFIXES
+    ),
+    [SelectTableStoreNames.ACCESS_GRANTS_USERS]: createSelectableTableStore(
+        SelectTableStoreNames.ACCESS_GRANTS_USERS
     ),
     [SelectTableStoreNames.CAPTURE]: createSelectableTableStore(
         SelectTableStoreNames.CAPTURE
@@ -73,6 +76,9 @@ const invariableStores = {
     ),
     [SelectTableStoreNames.MATERIALIZATION]: createSelectableTableStore(
         SelectTableStoreNames.MATERIALIZATION
+    ),
+    [SelectTableStoreNames.STORAGE_MAPPINGS]: createSelectableTableStore(
+        SelectTableStoreNames.STORAGE_MAPPINGS
     ),
 
     // Admin Storage Mappings

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -171,6 +171,7 @@ const RouteTitles: ResolvedIntlConfig['messages'] = {
     'routeTitle.admin.api': `CLI - API`,
     'routeTitle.admin.connectors': `Connectors`,
     'routeTitle.admin.cookies': `Cookie Preferences`,
+    'routeTitle.admin.storageMappings': `Storage Mappings`,
     'routeTitle.captureCreate': `Create Capture`,
     'routeTitle.captureEdit': `Edit Capture`,
     'routeTitle.captures': `Captures`,
@@ -196,6 +197,7 @@ const BrowserTitles: ResolvedIntlConfig['messages'] = {
     'browserTitle.admin.api': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.admin.api']}`,
     'browserTitle.admin.connectors': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.admin.connectors']}`,
     'browserTitle.admin.cookies': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.admin.cookies']}`,
+    'browserTitle.admin.storageMappings': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.admin.storageMappings']}`,
     'browserTitle.captureCreate': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.captureCreate']}`,
     'browserTitle.captureEdit': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.captureEdit']}`,
     'browserTitle.captures': `${CommonMessages['common.browserTitle']} · ${RouteTitles['routeTitle.captures']}`,
@@ -381,6 +383,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.tabs.connectors': `Connectors`,
     'admin.tabs.api': `CLI-API`,
     'admin.tabs.cookies': `Cookie Preferences`,
+    'admin.tabs.storageMappings': `Storage Mappings`,
 };
 
 const Welcome: ResolvedIntlConfig['messages'] = {
@@ -393,6 +396,16 @@ const AccessGrants: ResolvedIntlConfig['messages'] = {
     'accessGrantsTable.filterLabel': `Filter User or Object`,
     'accessGrants.message1': `No results found.`,
     'accessGrants.message2': `We couldn't find any results matching your search. Please try a different filter.`,
+};
+
+const StorageMappings: ResolvedIntlConfig['messages'] = {
+    'storageMappings.header': `Cloud Storage`,
+    'storageMappings.prefix.description': `The Flow prefix you want to configure`,
+    'storageMappings.provider.label': `Provider`,
+    'storageMappings.provider.description': `The provider (ex: S3, GCP) you are using`,
+    'storageMappings.bucket.label': `Bucket`,
+    'storageMappings.bucket.description': `The name of the bucket you have setup to store data in.`,
+    'storageMappings.lastUpdated.label': `Last Updated`,
 };
 
 const ConnectorsPage: ResolvedIntlConfig['messages'] = {
@@ -795,6 +808,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...Legal,
     ...Tenant,
     ...CustomRenderers,
+    ...StorageMappings,
 };
 
 export default enUSMessages;

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -334,10 +334,11 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.data.capability': `Capability`,
     'entityTable.data.objectRole': `Object`,
     'entityTable.data.lastPubUserFullName': `Last Updated By`,
-    'entityTable.data.catalogPrefix': `Prefix`,
+    'entityTable.data.catalogPrefix': `Flow Prefix`,
     'entityTable.data.provider': `Provider`,
     'entityTable.data.bucket': `Bucket`,
     'entityTable.data.prefix': `Prefix`,
+    'entityTable.data.storagePrefix': `Storage Prefix`,
 
     'entityTable.stats.bytes_read': `Bytes Read`,
     'entityTable.stats.docs_read': `Docs Read`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -334,11 +334,11 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.data.capability': `Capability`,
     'entityTable.data.objectRole': `Object`,
     'entityTable.data.lastPubUserFullName': `Last Updated By`,
-    'entityTable.data.catalogPrefix': `Flow Prefix`,
+    'entityTable.data.catalogPrefix': `Catalog Prefix`,
     'entityTable.data.provider': `Provider`,
     'entityTable.data.bucket': `Bucket`,
     'entityTable.data.prefix': `Prefix`,
-    'entityTable.data.storagePrefix': `Storage Prefix`,
+    'entityTable.data.storagePrefix': `Prefix`,
 
     'entityTable.stats.bytes_read': `Bytes Read`,
     'entityTable.stats.docs_read': `Docs Read`,
@@ -418,7 +418,7 @@ const StorageMappings: ResolvedIntlConfig['messages'] = {
     'storageMappings.bucket.label': `Bucket`,
     'storageMappings.bucket.description': `The name of the bucket you have setup to store data in.`,
     'storageMappings.lastUpdated.label': `Last Updated`,
-    'storageMappings.message': `Below are all the ${CommonMessages['terms.storageMapping']} that you have read or admin access to. These are the locations that your data is stored. If you have admin access you can edit them below`,
+    'storageMappings.message': `Below are all the ${CommonMessages['terms.storageMapping']} that you have read or admin access to. These are the locations that your data is stored. You currently cannot edit these in the UI. If you need an update please contact support.`,
 };
 
 const ConnectorsPage: ResolvedIntlConfig['messages'] = {

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -43,6 +43,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'terms.materialization': `Materialization`,
     'terms.capture': `Capture`,
     'terms.documentation': `Docs`,
+    'terms.storageMapping': `Storage Mappings`,
 
     // Common fields
     'entityPrefix.label': `Prefix`,
@@ -171,7 +172,7 @@ const RouteTitles: ResolvedIntlConfig['messages'] = {
     'routeTitle.admin.api': `CLI - API`,
     'routeTitle.admin.connectors': `Connectors`,
     'routeTitle.admin.cookies': `Cookie Preferences`,
-    'routeTitle.admin.storageMappings': `Storage Mappings`,
+    'routeTitle.admin.storageMappings': `${CommonMessages['terms.storageMapping']}`,
     'routeTitle.captureCreate': `Create Capture`,
     'routeTitle.captureEdit': `Edit Capture`,
     'routeTitle.captures': `Captures`,
@@ -333,6 +334,10 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.data.capability': `Capability`,
     'entityTable.data.objectRole': `Object`,
     'entityTable.data.lastPubUserFullName': `Last Updated By`,
+    'entityTable.data.catalogPrefix': `Prefix`,
+    'entityTable.data.provider': `Provider`,
+    'entityTable.data.bucket': `Bucket`,
+    'entityTable.data.prefix': `Prefix`,
 
     'entityTable.stats.bytes_read': `Bytes Read`,
     'entityTable.stats.docs_read': `Docs Read`,
@@ -383,7 +388,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.tabs.connectors': `Connectors`,
     'admin.tabs.api': `CLI-API`,
     'admin.tabs.cookies': `Cookie Preferences`,
-    'admin.tabs.storageMappings': `Storage Mappings`,
+    'admin.tabs.storageMappings': `${CommonMessages['terms.storageMapping']}`,
 };
 
 const Welcome: ResolvedIntlConfig['messages'] = {
@@ -392,20 +397,27 @@ const Welcome: ResolvedIntlConfig['messages'] = {
 
 const AccessGrants: ResolvedIntlConfig['messages'] = {
     'accessGrantsTable.header': `Captures`,
-    'accessGrantsTable.title': `Users`,
-    'accessGrantsTable.filterLabel': `Filter User or Object`,
+    'accessGrantsTable.users.title': `Users`,
+    'accessGrantsTable.prefixes.title': `Prefixes`,
+    'accessGrantsTable.users.filterLabel': `Filter User or Object`,
+    'accessGrantsTable.prefixes.filterLabel': `Filter Prefix or Object`,
     'accessGrants.message1': `No results found.`,
     'accessGrants.message2': `We couldn't find any results matching your search. Please try a different filter.`,
 };
 
 const StorageMappings: ResolvedIntlConfig['messages'] = {
     'storageMappings.header': `Cloud Storage`,
+    'storageMappingsTable.title': `Storage Locations`,
+    'storageMappingsTable.filterLabel': `Filter by Prefix`,
+    'storageMappingsTable.message1': `No results found.`,
+    'storageMappingsTable.message2': `We couldn't find any results matching your search. Please try a different filter.`,
     'storageMappings.prefix.description': `The Flow prefix you want to configure`,
     'storageMappings.provider.label': `Provider`,
     'storageMappings.provider.description': `The provider (ex: S3, GCP) you are using`,
     'storageMappings.bucket.label': `Bucket`,
     'storageMappings.bucket.description': `The name of the bucket you have setup to store data in.`,
     'storageMappings.lastUpdated.label': `Last Updated`,
+    'storageMappings.message': `Below are all the ${CommonMessages['terms.storageMapping']} that you have read or admin access to. These are the locations that your data is stored. If you have admin access you can edit them below`,
 };
 
 const ConnectorsPage: ResolvedIntlConfig['messages'] = {

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -89,13 +89,15 @@ export interface SortingProps<Data> {
     direction: SortDirection;
 }
 export const DEFAULT_POLLING_INTERVAL = 750;
+export type Pagination = { from: number; to: number };
+export type Protocol<Data> = { column: keyof Data; value: string | null };
 export const defaultTableFilter = <Data>(
     query: PostgrestFilterBuilder<Data>,
     searchParam: Array<keyof Data | any>, // TODO (typing) added any because of how Supabase handles keys. Hoping Supabase 2.0 fixes https://github.com/supabase/supabase-js/issues/170
     searchQuery: string | null,
     sorting: SortingProps<Data>[],
-    pagination?: { from: number; to: number },
-    protocol?: { column: keyof Data; value: string | null }
+    pagination?: Pagination,
+    protocol?: Protocol<Data>
 ) => {
     let queryBuilder = query;
 

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -53,6 +53,7 @@ export enum TABLES {
     PUBLICATION_SPECS_EXT = 'publication_specs_ext',
     PUBLICATIONS = 'publications',
     ROLE_GRANTS = 'role_grants',
+    STORAGE_MAPPINGS = 'storage_mappings',
     TASKS_BY_DAY = 'task_stats_by_day',
     TASKS_BY_HOUR = 'task_stats_by_hour',
     TASKS_BY_MINUTE = 'task_stats_by_minute',

--- a/src/stores/StorageMappings/Hydrator.tsx
+++ b/src/stores/StorageMappings/Hydrator.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { BaseComponentProps } from 'types';
+import { useStorageMappingsStore_hydrate } from './hooks';
+
+export const StorageMappingsHydrator = ({ children }: BaseComponentProps) => {
+    const hydrate = useStorageMappingsStore_hydrate();
+
+    useEffect(() => {
+        hydrate();
+    }, [hydrate]);
+
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <>{children}</>;
+};
+
+export default StorageMappingsHydrator;

--- a/src/stores/StorageMappings/Store.ts
+++ b/src/stores/StorageMappings/Store.ts
@@ -1,4 +1,4 @@
-import { getStorageMappings } from 'api/storageMappings';
+import { getStorageMapping } from 'api/storageMappings';
 import produce from 'immer';
 import { devtoolsOptions } from 'utils/store-utils';
 import create from 'zustand';
@@ -21,7 +21,7 @@ const getInitialState = (
     ...getInitialStateData(),
 
     hydrate: async () => {
-        const { data, error } = await getStorageMappings();
+        const { data, error } = await getStorageMapping('name goes here');
 
         if (error) {
             return set(

--- a/src/stores/StorageMappings/Store.ts
+++ b/src/stores/StorageMappings/Store.ts
@@ -1,0 +1,70 @@
+import { getStorageMappings } from 'api/storageMappings';
+import produce from 'immer';
+import { devtoolsOptions } from 'utils/store-utils';
+import create from 'zustand';
+import { devtools, NamedSet } from 'zustand/middleware';
+import { AdminStoreNames } from '../names';
+import { StorageMappingForm, StorageMappingsState } from './types';
+
+const getInitialStateData = (): Pick<
+    StorageMappingsState,
+    'spec' | 'loading'
+> => ({
+    spec: null,
+    loading: true,
+});
+
+const getInitialState = (
+    set: NamedSet<StorageMappingsState>
+    // get: StoreApi<StorageMappingsState>['getState'],
+): StorageMappingsState => ({
+    ...getInitialStateData(),
+
+    hydrate: async () => {
+        const { data, error } = await getStorageMappings();
+
+        if (error) {
+            return set(
+                produce((state) => {
+                    state.spec = null;
+                    state.loading = false;
+                }),
+                false,
+                'Table Store Hydration Failure'
+            );
+        }
+
+        // TODO (storage mappings) need to support multiple
+        const newSpec: StorageMappingForm = {
+            prefix: data[0].catalog_prefix,
+            lastUpdated: data[0].updated_at,
+            bucket: data[0].spec.stores[0].bucket,
+            provider: data[0].spec.stores[0].provider,
+        };
+
+        set(
+            produce((state: StorageMappingsState) => {
+                state.spec = newSpec;
+                state.loading = false;
+            }),
+            false,
+            'Form State Changed'
+        );
+    },
+
+    setSpec: (newState) => {
+        set(
+            produce((state: StorageMappingsState) => {
+                state.spec = newState;
+            }),
+            false,
+            'Form State Changed'
+        );
+    },
+});
+
+export const createStorageMappingsStore = (key: AdminStoreNames) => {
+    return create<StorageMappingsState>()(
+        devtools((set, _get) => getInitialState(set), devtoolsOptions(key))
+    );
+};

--- a/src/stores/StorageMappings/hooks.ts
+++ b/src/stores/StorageMappings/hooks.ts
@@ -1,0 +1,24 @@
+import { useZustandStore } from 'context/Zustand/provider';
+import { AdminStoreNames } from 'stores/names';
+import { StorageMappingsState } from './types';
+
+export const useStorageMappingsStore_spec = () => {
+    return useZustandStore<StorageMappingsState, StorageMappingsState['spec']>(
+        AdminStoreNames.STORAGE_MAPPINGS,
+        (state) => state.spec
+    );
+};
+
+export const useStorageMappingsStore_hydrate = () => {
+    return useZustandStore<
+        StorageMappingsState,
+        StorageMappingsState['hydrate']
+    >(AdminStoreNames.STORAGE_MAPPINGS, (state) => state.hydrate);
+};
+
+export const useStorageMappingsStore_loading = () => {
+    return useZustandStore<
+        StorageMappingsState,
+        StorageMappingsState['loading']
+    >(AdminStoreNames.STORAGE_MAPPINGS, (state) => state.loading);
+};

--- a/src/stores/StorageMappings/types.ts
+++ b/src/stores/StorageMappings/types.ts
@@ -1,0 +1,14 @@
+export interface StorageMappingForm {
+    prefix: string;
+    lastUpdated: string;
+    bucket: string;
+    provider: string;
+}
+
+export interface StorageMappingsState {
+    spec: StorageMappingForm | null;
+    setSpec: (val: StorageMappingsState['spec']) => void;
+
+    hydrate: () => void;
+    loading: boolean;
+}

--- a/src/stores/names.ts
+++ b/src/stores/names.ts
@@ -25,11 +25,13 @@ export enum ResourceConfigStoreNames {
 }
 
 export enum SelectTableStoreNames {
-    ACCESS_GRANTS = 'AccessGrants-Selectable-Table',
+    ACCESS_GRANTS_USERS = 'AccessGrants-Selectable-Table-Users',
+    ACCESS_GRANTS_PREFIXES = 'AccessGrants-Selectable-Table-Prefixes',
     CAPTURE = 'Captures-Selectable-Table',
     COLLECTION = 'Collections-Selectable-Table',
     CONNECTOR = 'Connectors-Selectable-Table',
     MATERIALIZATION = 'Materializations-Selectable-Table',
+    STORAGE_MAPPINGS = 'Storage-Mappings-Selectable-Table',
 }
 
 export enum ShardDetailStoreNames {

--- a/src/stores/names.ts
+++ b/src/stores/names.ts
@@ -38,6 +38,10 @@ export enum ShardDetailStoreNames {
     COLLECTION = 'Collection-Shard-Detail',
 }
 
+export enum AdminStoreNames {
+    STORAGE_MAPPINGS = 'Storage-Mappings',
+}
+
 export type StoreName =
     | DetailsFormStoreNames
     | EditorStoreNames
@@ -45,4 +49,5 @@ export type StoreName =
     | FormStateStoreNames
     | ResourceConfigStoreNames
     | SelectTableStoreNames
-    | ShardDetailStoreNames;
+    | ShardDetailStoreNames
+    | AdminStoreNames;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,6 +86,19 @@ export interface JoinedAppliedDirective extends AppliedDirective<any> {
     ['directives.spec->>type']: undefined;
 }
 
+export interface StorageMappingStore {
+    provider: string;
+    bucket: string;
+}
+export interface StorageMappings {
+    // id: string;
+    // detail: string;
+    catalog_prefix: string;
+    spec: { stores: StorageMappingStore[] };
+    // created_at: string;
+    updated_at: string;
+}
+
 export interface Tenants {
     id: string;
     tasks_quota: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,9 +89,10 @@ export interface JoinedAppliedDirective extends AppliedDirective<any> {
 export interface StorageMappingStore {
     provider: string;
     bucket: string;
+    prefix: string;
 }
 export interface StorageMappings {
-    // id: string;
+    id: string;
     // detail: string;
     catalog_prefix: string;
     spec: { stores: StorageMappingStore[] };


### PR DESCRIPTION
## Changes

1. Add the storage mapping table to the admin page
2. Split up Prefix/Users in the grants page

## Tests

1. manually tested

## Issues

Fixes: https://github.com/estuary/ui/issues/431

## Content

Some new messages that heavily lean on existing ones

## Screenshots

Now user/prefix are split into two tables
![image](https://user-images.githubusercontent.com/270078/210105816-a77874fe-f318-449f-8d2c-e4b9f81e3139.png)

Single store for single prefix display in a row
![image](https://user-images.githubusercontent.com/270078/210105836-9f928af4-09c7-458c-ac66-4a8fb56243ff.png)

Multiple stores for single prefix display nested
![image](https://user-images.githubusercontent.com/270078/210405026-c8cbf2b6-4df7-401d-bd93-c7e04abe1015.png)

Single store/prefix and Multiple stores/prefix
![image](https://user-images.githubusercontent.com/270078/210585123-e7f855a6-46ad-4f0f-9ffe-411ded360482.png)
