### PR TITLE
fix: generalize logic relating to discovered collection names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9039,7 +9039,7 @@
         "node_modules/data-plane-gateway": {
             "version": "0.0.0",
             "resolved": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-/pXFiS29P1P6PhsxGG2J53zAAxm1gaIbwaK+CcnIWvZwqklaEgL3lq1jFR/qbc3Rbe3yGoT4W1yyA5j/gqsbKg==",
+            "integrity": "sha512-PHF0HtRndoDI0OD8wSqwNeCBIf4Qm1737w66SI9GN1ZtzduIzDuXQtgtCw6gd3bY29jOYehnnMLAfEz0kZCwew==",
             "license": "MIT"
         },
         "node_modules/data-urls": {
@@ -33235,7 +33235,7 @@
         },
         "data-plane-gateway": {
             "version": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-/pXFiS29P1P6PhsxGG2J53zAAxm1gaIbwaK+CcnIWvZwqklaEgL3lq1jFR/qbc3Rbe3yGoT4W1yyA5j/gqsbKg=="
+            "integrity": "sha512-PHF0HtRndoDI0OD8wSqwNeCBIf4Qm1737w66SI9GN1ZtzduIzDuXQtgtCw6gd3bY29jOYehnnMLAfEz0kZCwew=="
         },
         "data-urls": {
             "version": "2.0.0",

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -78,10 +78,7 @@ function useDiscoverCapture(
 ) {
     const supabaseClient = useClient();
 
-    const [initialConnectorId, lastPubId] = useGlobalSearchParams([
-        GlobalSearchParams.CONNECTOR_ID,
-        GlobalSearchParams.LAST_PUB_ID,
-    ]);
+    const [lastPubId] = useGlobalSearchParams([GlobalSearchParams.LAST_PUB_ID]);
 
     const workflow = useEntityWorkflow();
     const editWorkflow = workflow === 'capture_edit';
@@ -359,24 +356,22 @@ function useDiscoverCapture(
             }
         },
         [
-            createDiscoversSubscription,
-            resetEditorState,
-            setFormState,
-            updateFormStatus,
             callFailed,
+            createDiscoversSubscription,
             detailsFormsHasErrors,
-            editWorkflow,
             endpointConfigData,
             endpointConfigErrorsExist,
             endpointSchema,
             entityName,
             imageConnectorId,
             imageConnectorTagId,
-            initialConnectorId,
+            resetEditorState,
             resourceConfig,
             resourceConfigHasErrors,
             serverEndpointConfigData,
             serverUpdateRequired,
+            setFormState,
+            updateFormStatus,
         ]
     );
 

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -333,22 +333,8 @@ function useDiscoverCapture(
                     { overrideJsonFormDefaults: true }
                 );
 
-                let catalogName = entityName;
-
-                if (editWorkflow && imageConnectorId === initialConnectorId) {
-                    // The discovery RPC will insert a row into the draft spec-related tables for the given task with verbiage
-                    // identifying the external source appended to the task name (e.g., '/source-postgres'). To limit duplication
-                    // of draft spec-related data, the aforementioned external source identifier is removed from the task name
-                    // prior to executing the discovery RPC.
-                    const lastSlashIndex = entityName.lastIndexOf('/');
-
-                    if (lastSlashIndex !== -1) {
-                        catalogName = entityName.slice(0, lastSlashIndex);
-                    }
-                }
-
                 const discoverResponse = await discover(
-                    catalogName,
+                    entityName,
                     encryptedEndpointConfig.data,
                     imageConnectorTagId,
                     draftId

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -41,7 +41,7 @@ import {
 } from 'stores/ResourceConfig/hooks';
 import { EntityWorkflow } from 'types';
 import useConstant from 'use-constant';
-import { hasLength, truncateCatalogName } from 'utils/misc-utils';
+import { hasLength } from 'utils/misc-utils';
 
 interface BindingSelectorProps {
     loading: boolean;
@@ -74,10 +74,7 @@ function Row({ collection, task, workflow, disabled }: RowProps) {
                 workflow === 'capture_edit' &&
                 !hasLength(discoveredCollections)
             ) {
-                const catalogName = truncateCatalogName(task);
-
-                const nativeCollectionDetected =
-                    collection.includes(catalogName);
+                const nativeCollectionDetected = collection.includes(task);
 
                 nativeCollectionDetected
                     ? setRestrictedDiscoveredCollections(

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -120,21 +120,10 @@ function BindingsMultiEditor({
             discoveredCollections.length > 0 &&
             draftSpecs.length > 0
         ) {
-            let truncatedServerCatalogName: string | null = null;
-
             const catalogNameOnServer = draftSpecs[0].catalog_name;
 
-            const lastSlashIndex = catalogNameOnServer.lastIndexOf('/');
-
-            if (lastSlashIndex !== -1) {
-                truncatedServerCatalogName = catalogNameOnServer.slice(
-                    0,
-                    lastSlashIndex
-                );
-            }
-
-            return truncatedServerCatalogName
-                ? truncatedServerCatalogName !== catalogName
+            return catalogNameOnServer
+                ? !catalogNameOnServer.startsWith(catalogName)
                 : false;
         } else {
             return false;

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -18,7 +18,7 @@ import {
 import { createJSONFormDefaults } from 'services/ajv';
 import { ResourceConfigStoreNames } from 'stores/names';
 import { Schema } from 'types';
-import { hasLength, truncateCatalogName } from 'utils/misc-utils';
+import { hasLength } from 'utils/misc-utils';
 import { devtoolsOptions } from 'utils/store-utils';
 import create, { StoreApi } from 'zustand';
 import { devtools, NamedSet } from 'zustand/middleware';
@@ -238,10 +238,8 @@ const getInitialState = (
                                 )
                         );
                 } else if (workflow === 'capture_edit' && collections) {
-                    const catalogName = truncateCatalogName(task);
-
                     const nativeCollections = collections.filter((collection) =>
-                        collection.includes(catalogName)
+                        collection.includes(task)
                     );
 
                     additionalRestrictedCollections = nativeCollections.filter(

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -12,12 +12,6 @@ export const stripPathing = (stringVal: string) => {
     );
 };
 
-export const truncateCatalogName = (value: string): string => {
-    const lastOccurrence = value.lastIndexOf('/');
-
-    return lastOccurrence === -1 ? value : value.slice(0, lastOccurrence);
-};
-
 export const hasLength = (val: string | any[] | null | undefined): boolean => {
     return Boolean(val && val.length > 0);
 };


### PR DESCRIPTION
Discovered collections no longer must live underneath the capture that discovered them, so logic that made that assumption needs to be updated.

I'm fairly sure this isn't the only place that needs to be updated, it's just the specific place that was causing the trouble I was able to find.

## Changes

My intent with this change was to make the logic work both for the current setup where `aliceCo/my-capture` results in collections of `aliceCo/my-capture/my-collection`, as well as the future setup where the collections will be `aliceCo/my-collection`

## Issues

#434
Related to https://github.com/estuary/flow/pull/860

## Screenshots

![Screen Shot 2023-01-04 at 12 15 11](https://user-images.githubusercontent.com/4368270/210613636-f0112b37-5034-4e48-a5bc-89c5a833c5ad.png)
_Nested collections_

![Screen Shot 2023-01-04 at 12 24 43](https://user-images.githubusercontent.com/4368270/210613676-b0311808-03d4-4494-bd98-c7f89683ec90.png)
_Un-nested collections_
