### PR TITLE
Updating tenant guard to allow multiple tenant creation

### DIFF
--- a/.env
+++ b/.env
@@ -11,6 +11,7 @@ REACT_APP_GATEWAY_AUTH_TOKEN_URL=https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v
 
 # These settings require an application restart to enable right now
 REACT_APP_SHOW_EMAIL_LOGIN=true
+REACT_APP_ALLOW_EMAIL_REGISTER=false
 REACT_APP_URLS_PRIVACY_POLICY=https://www.estuary.dev/privacy-policy/
 REACT_APP_URLS_TERMS_OF_SERVICE=https://www.estuary.dev/terms/
 

--- a/.env.development.local
+++ b/.env.development.local
@@ -6,6 +6,8 @@ REACT_APP_SUPABASE_URL=http://localhost:5431
 REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs
 REACT_APP_GATEWAY_AUTH_TOKEN_URL=http://localhost:5431/rest/v1/rpc/gateway_auth_token
 
+REACT_APP_ALLOW_EMAIL_REGISTER=true
+
 # Sops Encryption settings
 REACT_APP_ENCRYPTION_URL=http://localhost:8765/v1/encrypt-config
 

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -8,10 +8,10 @@ import Navigation from './components/navigation/Navigation';
 function AppLayout() {
     const [navigationConfig, setNavigationConfig] = useLocalStorage(
         LocalStorageKeys.NAVIGATION_SETTINGS,
-        { open: false }
+        { open: true }
     );
 
-    const navigationOpen = navigationConfig?.open ?? false;
+    const navigationOpen = navigationConfig?.open ?? true;
     const navigationWidth: NavWidths = navigationConfig?.open
         ? NavWidths.FULL
         : NavWidths.RAIL;

--- a/src/app/guards/OnboardGuard.tsx
+++ b/src/app/guards/OnboardGuard.tsx
@@ -13,15 +13,18 @@ const SELECTED_DIRECTIVE = 'betaOnboard';
 //  stop passing in the grantsMutate and pass the directiveGuard mutate.
 interface Props extends BaseComponentProps {
     grantsMutate: any;
+    forceDisplay?: boolean;
 }
 
-function OnboardGuard({ children, grantsMutate }: Props) {
-    const { directive, loading, status } =
-        useDirectiveGuard(SELECTED_DIRECTIVE);
+function OnboardGuard({ children, forceDisplay, grantsMutate }: Props) {
+    const { directive, loading, status } = useDirectiveGuard(
+        SELECTED_DIRECTIVE,
+        forceDisplay
+    );
 
     if (loading || status === null) {
         return <FullPageSpinner />;
-    } else if (status !== 'fulfilled') {
+    } else if (forceDisplay || status !== 'fulfilled') {
         return (
             <FullPageWrapper>
                 <BetaOnboard

--- a/src/app/guards/TenantGuard.tsx
+++ b/src/app/guards/TenantGuard.tsx
@@ -3,7 +3,7 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import useCombinedGrantsExt from 'hooks/useCombinedGrantsExt';
-import NoGrants from 'pages/NoGrants';
+import { useMemo } from 'react';
 import { BaseComponentProps } from 'types';
 import OnboardGuard from './OnboardGuard';
 
@@ -12,7 +12,13 @@ import OnboardGuard from './OnboardGuard';
 const hiddenSearchParam = 'please_show';
 
 function TenantGuard({ children }: BaseComponentProps) {
-    const showBeta = useGlobalSearchParams(GlobalSearchParams.HIDDEN_SHOW_BETA);
+    const showTenantCreation = useGlobalSearchParams(
+        GlobalSearchParams.HIDDEN_SHOW_BETA
+    );
+    const showBeta = useMemo(
+        () => showTenantCreation === hiddenSearchParam,
+        [showTenantCreation]
+    );
 
     const {
         combinedGrants,
@@ -24,12 +30,8 @@ function TenantGuard({ children }: BaseComponentProps) {
 
     if (checkingGrants) {
         return <FullPageSpinner />;
-    } else if (combinedGrants.length === 0) {
-        if (showBeta === hiddenSearchParam) {
-            return <OnboardGuard grantsMutate={mutate} />;
-        } else {
-            return <NoGrants />;
-        }
+    } else if (combinedGrants.length === 0 || showBeta) {
+        return <OnboardGuard grantsMutate={mutate} forceDisplay={showBeta} />;
     } else {
         // eslint-disable-next-line react/jsx-no-useless-fragment
         return <>{children}</>;

--- a/src/app/guards/hooks.ts
+++ b/src/app/guards/hooks.ts
@@ -35,6 +35,8 @@ const useDirectiveGuard = (
 
     useEffect(() => {
         // Need to exchange for a fresh directive because:
+        //   new&fulfilled : user has submitted a tenant but wants to try to submit another
+        //      The backend checks if they are allowed to create multiple tenants
         //   unfulfilled : user never exchanged a token before
         //   outdated    : user has exchanged AND submitted something before
         if (

--- a/src/app/guards/hooks.ts
+++ b/src/app/guards/hooks.ts
@@ -7,7 +7,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { AppliedDirective } from 'types';
 
-const useDirectiveGuard = (selectedDirective: keyof typeof DIRECTIVES) => {
+const useDirectiveGuard = (
+    selectedDirective: keyof typeof DIRECTIVES,
+    forceNew?: boolean
+) => {
     const intl = useIntl();
     const { enqueueSnackbar } = useSnackbar();
 
@@ -34,7 +37,11 @@ const useDirectiveGuard = (selectedDirective: keyof typeof DIRECTIVES) => {
         // Need to exchange for a fresh directive because:
         //   unfulfilled : user never exchanged a token before
         //   outdated    : user has exchanged AND submitted something before
-        if (directiveState === 'unfulfilled' || directiveState === 'outdated') {
+        if (
+            (forceNew && directiveState === 'fulfilled') ||
+            directiveState === 'unfulfilled' ||
+            directiveState === 'outdated'
+        ) {
             const fetchDirective = async () => {
                 return exchangeBearerToken(DIRECTIVES[selectedDirective].token);
             };
@@ -64,7 +71,7 @@ const useDirectiveGuard = (selectedDirective: keyof typeof DIRECTIVES) => {
                 }
             );
         }
-    }, [directiveState, enqueueSnackbar, intl, selectedDirective]);
+    }, [directiveState, enqueueSnackbar, forceNew, intl, selectedDirective]);
 
     return useMemo(() => {
         if (directiveState === null) {

--- a/src/components/login/MagicLink.tsx
+++ b/src/components/login/MagicLink.tsx
@@ -6,11 +6,14 @@ import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { custom_generateDefaultUISchema } from 'services/jsonforms';
 import useConstant from 'use-constant';
+import { getLoginSettings } from 'utils/env-utils';
 
 // TODO (routes) This is hardcoded because unauthenticated routes is not yet invoked
 //   need to move the routes to a single location. Also... just need to make the route
 //   settings in all JSON probably.
 const redirectToBase = `${window.location.origin}/auth`;
+
+const loginSettings = getLoginSettings();
 
 const MagicLink = () => {
     const [showTokenValidation, setShowTokenValidation] = useState(false);
@@ -101,6 +104,8 @@ const MagicLink = () => {
                             },
                             {
                                 redirectTo,
+                                shouldCreateUser:
+                                    loginSettings.enableEmailRegister,
                             }
                         );
                     }}

--- a/src/components/login/OIDCs.tsx
+++ b/src/components/login/OIDCs.tsx
@@ -50,6 +50,7 @@ function OIDCs({ isRegister }: Props) {
                 },
                 {
                     redirectTo,
+                    shouldCreateUser: isRegister,
                 }
             );
             if (error) loginFailed(provider);

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -37,8 +37,11 @@ export const getAPIPath = () => {
 
 export const getLoginSettings = () => {
     const showEmail = process.env.REACT_APP_SHOW_EMAIL_LOGIN === ENABLED;
+    const enableEmailRegister =
+        process.env.REACT_APP_ALLOW_EMAIL_REGISTER === ENABLED;
 
     return {
+        enableEmailRegister,
         showEmail,
     };
 };


### PR DESCRIPTION
## Changes

1. Display the tenant creation page no matter what when the URL param is used
2. No longer hide the tenant creation page behind 
3. No longer auto create user when logging in

## Tests

Manually tested 

## Issues

[1-2]Fixes https://github.com/estuary/ui/issues/442

## Content

N/A

## Screenshots

Logged in as new user 111 with a tenant
![image](https://user-images.githubusercontent.com/270078/212232106-b57f5899-9a6e-4e23-8ee0-4b1508d81c1a.png)

Allowed to show the tenant creation form
![image](https://user-images.githubusercontent.com/270078/212232169-6c7f60be-cfe9-48c6-b0ec-7bddbf5c6261.png)

Error when trying to create another tenant when I already have one
![image](https://user-images.githubusercontent.com/270078/212232265-1a7bf16a-b1da-4532-ade3-9a9915fd2d13.png)

No longer allowing users to sign up with Magic Link
![image](https://user-images.githubusercontent.com/270078/212235622-ff9fc65c-9ae5-45e4-952e-d8f547b37bb5.png)
