### PR TITLE
refactor: Only request required grants for DPG access tokens

### DIFF
--- a/src/app/Authenticated.tsx
+++ b/src/app/Authenticated.tsx
@@ -12,7 +12,6 @@ import AuthenticatedOnlyContext from 'context/Authenticated';
 import { EntityContextProvider } from 'context/EntityContext';
 import { WorkflowContextProvider } from 'context/Workflow';
 import { OAuthPopup } from 'hooks/forks/react-use-oauth2/components';
-import useGatewayAuthToken from 'hooks/useGatewayAuthToken';
 import Admin from 'pages/Admin';
 import Auth from 'pages/Auth';
 import Captures from 'pages/Captures';
@@ -27,10 +26,6 @@ import { isProduction } from 'utils/env-utils';
 import { authenticatedRoutes, unauthenticatedRoutes } from './routes';
 
 const Authenticated = () => {
-    // TODO: Determine whether a context provider or a hook should be used to fetch the initial auth gateway URL and token.
-    // The context provider results in a duped, gateway auth token API call.
-    useGatewayAuthToken();
-
     return (
         <AuthenticatedOnlyContext>
             <Routes>

--- a/src/components/collection/DataPreview/index.tsx
+++ b/src/components/collection/DataPreview/index.tsx
@@ -4,7 +4,7 @@ import { AlertTitle, Box, Stack, Typography } from '@mui/material';
 import ListView from 'components/collection/DataPreview/ListView';
 import AlertBox from 'components/shared/AlertBox';
 import { useJournalData, useJournalsForCollection } from 'hooks/useJournalData';
-import { useLiveSpecs_spec } from 'hooks/useLiveSpecs';
+import { LiveSpecsQuery_spec, useLiveSpecs_spec } from 'hooks/useLiveSpecs';
 import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { hasLength } from 'utils/misc-utils';
@@ -31,17 +31,18 @@ export function DataPreview({ collectionName }: Props) {
         `datapreview-${collectionName}`,
         [collectionName]
     );
-    const spec = useMemo(() => publicationSpecs[0], [publicationSpecs]);
+    const spec = useMemo(
+        () => publicationSpecs[0] as LiveSpecsQuery_spec | undefined,
+        [publicationSpecs]
+    );
 
-    // TODO (typing) we need to fix typing
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const journals = useJournalsForCollection(spec?.catalog_name);
     const { data: journalsData, isValidating: journalsLoading } = journals;
 
     // TODO (typing) we need to fix typing
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const journal = useMemo(() => journalsData?.journals?.[0], [journalsData]);
-    const journalData = useJournalData(journal?.name, 20);
+    const journalData = useJournalData(journal?.name, 20, collectionName);
     const isLoading = journalsLoading || journalData.loading;
 
     return (
@@ -130,7 +131,7 @@ export function DataPreview({ collectionName }: Props) {
                     </AlertBox>
                 </Box>
             ) : null}
-            {(journalData.data?.documents.length ?? 0) > 0 ? (
+            {(journalData.data?.documents.length ?? 0) > 0 && spec ? (
                 <ListView journalData={journalData} spec={spec} />
             ) : null}
             {/*             : (

--- a/src/hooks/useJournalData.ts
+++ b/src/hooks/useJournalData.ts
@@ -1,19 +1,13 @@
 /* eslint-disable no-await-in-loop */
 import { Auth } from '@supabase/ui';
-import { useGrantDetails } from 'context/fetcher/GrantDetails';
 import {
     JournalClient,
     JournalSelector,
     parseJournalDocuments,
 } from 'data-plane-gateway';
+import useGatewayAuthToken from 'hooks/useGatewayAuthToken';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocalStorage } from 'react-use';
-import getGatewayAuthConfig from 'services/gateway-auth-config';
 import useSWR from 'swr';
-import {
-    getStoredGatewayAuthConfig,
-    LocalStorageKeys,
-} from 'utils/localStorage-utils';
 
 enum ErrorFlags {
     TOKEN_NOT_FOUND = 'Unauthenticated',
@@ -21,14 +15,11 @@ enum ErrorFlags {
     OPERATION_INVALID = 'Unauthorized',
 }
 
-const useJournalsForCollection = (collectionName: string) => {
+const useJournalsForCollection = (collectionName: string | undefined) => {
     const { session } = Auth.useUser();
-    const grantDetails = useGrantDetails();
 
-    const [gatewayConfig, setGatewayConfig] = useLocalStorage(
-        LocalStorageKeys.GATEWAY,
-        getStoredGatewayAuthConfig()
-    );
+    const { data: gatewayConfig, refresh: refreshAuthToken } =
+        useGatewayAuthToken(collectionName ? [collectionName] : []);
 
     const journalClient = useMemo(() => {
         if (gatewayConfig?.gateway_url && gatewayConfig.token) {
@@ -73,21 +64,13 @@ const useJournalsForCollection = (collectionName: string) => {
             errorRetryInterval: undefined,
             refreshInterval: undefined,
             revalidateOnFocus: false,
-            onError: (error) => {
+            onError: async (error) => {
                 if (
                     session &&
                     (`${error}`.includes(ErrorFlags.TOKEN_INVALID) ||
                         `${error}`.includes(ErrorFlags.TOKEN_NOT_FOUND))
                 ) {
-                    const prefixes: string[] = grantDetails.map(
-                        ({ object_role }) => object_role
-                    );
-
-                    getGatewayAuthConfig(prefixes, session.access_token)
-                        .then(([response]) => {
-                            setGatewayConfig(response);
-                        })
-                        .catch((configError) => Promise.reject(configError));
+                    await refreshAuthToken();
                 }
 
                 console.error(error);
@@ -219,12 +202,12 @@ function isJournalRecord(val: any): val is JournalRecord {
 const useJournalData = (
     journalName?: string,
     desiredCount: number = 50,
+    collectionName?: string,
     // 16mb, which is the max document size, ensuring we'll always get at least 1 doc if it exists
     maxBytes: number = 16 * 10 ** 6
 ) => {
-    const [gatewayConfig] = useLocalStorage(
-        LocalStorageKeys.GATEWAY,
-        getStoredGatewayAuthConfig()
+    const { data: gatewayConfig } = useGatewayAuthToken(
+        collectionName ? [collectionName] : []
     );
 
     const journalClient = useMemo(() => {

--- a/src/hooks/useShardsList.ts
+++ b/src/hooks/useShardsList.ts
@@ -1,16 +1,10 @@
 import { Auth } from '@supabase/ui';
-import { useGrantDetails } from 'context/fetcher/GrantDetails';
 import { ShardClient, ShardSelector } from 'data-plane-gateway';
+import useGatewayAuthToken from 'hooks/useGatewayAuthToken';
 import LogRocket from 'logrocket';
 import { useMemo } from 'react';
-import { useLocalStorage } from 'react-use';
-import getGatewayAuthConfig from 'services/gateway-auth-config';
 import useSWR from 'swr';
 import { LiveSpecsExtBaseQuery } from 'types';
-import {
-    getStoredGatewayAuthConfig,
-    LocalStorageKeys,
-} from 'utils/localStorage-utils';
 
 enum ErrorFlags {
     TOKEN_NOT_FOUND = 'Unauthenticated',
@@ -23,11 +17,9 @@ const INTERVAL = 30000;
 
 const useShardsList = <T extends LiveSpecsExtBaseQuery>(specs: T[]) => {
     const { session } = Auth.useUser();
-    const grantDetails = useGrantDetails();
 
-    const [gatewayConfig, setGatewayConfig] = useLocalStorage(
-        LocalStorageKeys.GATEWAY,
-        getStoredGatewayAuthConfig()
+    const { data: gatewayConfig, refresh: refreshAccess } = useGatewayAuthToken(
+        specs.map((spec) => spec.catalog_name)
     );
 
     const shardClient = useMemo(() => {
@@ -41,74 +33,62 @@ const useShardsList = <T extends LiveSpecsExtBaseQuery>(specs: T[]) => {
         }
     }, [gatewayConfig]);
 
-    if (shardClient !== null && session) {
-        const taskSelector = new ShardSelector();
+    const taskSelector = new ShardSelector();
 
-        specs
-            .map((spec) => spec.catalog_name)
-            .forEach((name) => taskSelector.task(name));
+    specs
+        .map((spec) => spec.catalog_name)
+        .forEach((name) => taskSelector.task(name));
 
-        const fetcher = (_url: string) => {
-            return shardClient.list(taskSelector).then(
-                (result) => {
-                    const shards = result.unwrap();
+    const fetcher = async (_url: string) => {
+        if (!(shardClient && session)) {
+            return { shards: [], error: null };
+        }
+        try {
+            const result = await shardClient.list(taskSelector);
+            const shards = result.unwrap();
 
-                    return {
-                        shards: shards.length > 0 ? shards : [],
-                        error: null,
-                    };
-                },
-                (error: any) => {
-                    LogRocket.log('ShardsList : error : ', error);
+            return {
+                shards: shards.length > 0 ? shards : [],
+                error: null,
+            };
+            // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
+        } catch (error: any) {
+            LogRocket.log('ShardsList : error : ', error);
 
-                    return {
-                        shards: [],
-                        error: error.message ?? error,
-                    };
+            return {
+                shards: [],
+                error: error?.message ?? error,
+            };
+        }
+    };
+
+    return useSWR(
+        specs.length > 0
+            ? `shards-${
+                  gatewayConfig?.gateway_url ?? '__missing_gateway_url__'
+              }-${specs.map((spec) => spec.id).join('-')}`
+            : null,
+        fetcher,
+        {
+            errorRetryInterval: INTERVAL / 2,
+            refreshInterval: INTERVAL,
+            revalidateOnFocus: false, // We're already refreshing and these status do not change often
+            onError: async (error: string | Error) => {
+                if (typeof error === 'object') {
+                    return Promise.reject(error.message);
                 }
-            );
-        };
 
-        return useSWR(
-            specs.length > 0
-                ? `shards-${
-                      gatewayConfig?.gateway_url ?? '__missing_gateway_url__'
-                  }-${specs.map((spec) => spec.id).join('-')}`
-                : null,
-            fetcher,
-            {
-                errorRetryInterval: INTERVAL / 2,
-                refreshInterval: INTERVAL,
-                revalidateOnFocus: false, // We're already refreshing and these status do not change often
-                onError: (error: string | Error) => {
-                    if (typeof error === 'object') {
-                        return Promise.reject(error.message);
-                    }
+                if (
+                    error.includes(ErrorFlags.TOKEN_INVALID) ||
+                    error.includes(ErrorFlags.TOKEN_NOT_FOUND)
+                ) {
+                    await refreshAccess();
+                }
 
-                    if (
-                        error.includes(ErrorFlags.TOKEN_INVALID) ||
-                        error.includes(ErrorFlags.TOKEN_NOT_FOUND)
-                    ) {
-                        const prefixes: string[] = grantDetails.map(
-                            ({ object_role }) => object_role
-                        );
-
-                        getGatewayAuthConfig(prefixes, session.access_token)
-                            .then(([response]) => {
-                                setGatewayConfig(response);
-                            })
-                            .catch((configError) =>
-                                Promise.reject(configError)
-                            );
-                    }
-
-                    return Promise.reject(error);
-                },
-            }
-        );
-    } else {
-        throw Error('Unable to fetch shards due to missing data');
-    }
+                return Promise.reject(error);
+            },
+        }
+    );
 };
 
 export default useShardsList;


### PR DESCRIPTION
Fixes #451
Related to https://github.com/estuary/flow/issues/688

For example, on prod when issuing a read request to the DPG for data preview, the decoded JWT has all of my grants in it, despite only needing the single prefix that the read is for:

<img width="421" alt="Screen Shot 2023-01-17 at 20 00 18" src="https://user-images.githubusercontent.com/4368270/213055436-71533d0b-7e05-4c83-a692-4ce9fe989b2b.png">

Whereas locally even though I have 4 collections:
<img width="1611" alt="Screen Shot 2023-01-17 at 20 03 24" src="https://user-images.githubusercontent.com/4368270/213055507-e5161ab6-eb53-47c9-bd3f-690e4b6524a3.png">

When I open the data preview for `aliceCo/greetings`, the token only contains:

<img width="424" alt="Screen Shot 2023-01-17 at 20 03 12" src="https://user-images.githubusercontent.com/4368270/213055612-48268578-44d4-4636-b431-6250d15a27c8.png">
