### PR TITLE
Logs UX Tweaks 1

### DIFF
--- a/src/components/editor/Bindings/SchemaEdit/Button.tsx
+++ b/src/components/editor/Bindings/SchemaEdit/Button.tsx
@@ -5,13 +5,16 @@ import ExistingSchemaCommands from 'components/editor/Bindings/SchemaEdit/Comman
 import EditCommandsWrapper from 'components/editor/Bindings/SchemaEdit/Commands/Wrapper';
 import { useBindingsEditorStore_collectionData } from 'components/editor/Bindings/Store/hooks';
 import ButtonWithPopper from 'components/shared/ButtonWithPopper';
+import { useFormStateStore_isActive } from 'stores/FormState/hooks';
 
 function SchemaEditButton() {
     // Bindings Editor Store
     const collectionData = useBindingsEditorStore_collectionData();
+    const isActive = useFormStateStore_isActive();
 
     return collectionData ? (
         <ButtonWithPopper
+            disabled={isActive}
             messageId="workflows.collectionSelector.cta.schemaEdit"
             popper={
                 <EditCommandsWrapper>

--- a/src/components/logs/Context.tsx
+++ b/src/components/logs/Context.tsx
@@ -163,14 +163,12 @@ const LogsContextProvider = ({
     }, [token, disableIntervalFetching, fetchAll]);
 
     useEffect(() => {
-        console.log('job completed effect');
         // If the job completed then we only want to check for logs
         //  2 more times and then stop
         if (jobCompleted) {
             setFetchingCanSafelyStop(true);
             stopCleanUp(MAX_EMPTY_CALLS - 2);
             start();
-            console.log('make it larger');
         }
         // We only if the job completed to kick off the final fetching
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/logs/Lines.tsx
+++ b/src/components/logs/Lines.tsx
@@ -5,13 +5,19 @@ import { hasLength } from 'utils/misc-utils';
 import { useLogsContext } from './Context';
 import LogLine from './Line';
 import Spinner from './Spinner';
+import { SpinnerOptions } from './types';
 
 interface Props {
     height: number;
-    disableSpinner?: boolean;
+    spinnerOptions?: SpinnerOptions;
 }
 
-function LogLines({ height, disableSpinner }: Props) {
+function LogLines({ height, spinnerOptions }: Props) {
+    const disableSpinner = spinnerOptions?.disable ?? false;
+    const runningKey = spinnerOptions?.messages?.runningKey ?? undefined;
+    const stoppedKey = spinnerOptions?.messages?.stoppedKey ?? undefined;
+    const severity = spinnerOptions?.severity ?? undefined;
+
     const { logs } = useLogsContext();
 
     const scrollElementRef = useRef<HTMLDivElement>(null);
@@ -49,7 +55,13 @@ function LogLines({ height, disableSpinner }: Props) {
                         lineNumber={index}
                     />
                 ))}
-                {!disableSpinner || !hasLength(logs) ? <Spinner /> : null}
+                {!disableSpinner || !hasLength(logs) ? (
+                    <Spinner
+                        stoppedKey={stoppedKey}
+                        runningKey={runningKey}
+                        severity={severity}
+                    />
+                ) : null}
             </List>
         </Paper>
     );

--- a/src/components/logs/Spinner.tsx
+++ b/src/components/logs/Spinner.tsx
@@ -16,15 +16,21 @@ interface Props {
 
 function Spinner({ severity, runningKey, stoppedKey }: Props) {
     const intl = useIntl();
-    const { stopped } = useLogsContext();
+    const { stopped, fetchingCanSafelyStop } = useLogsContext();
 
     const lineContent = useMemo(() => {
+        // We only want to show the custom stopped key when things are
+        //  safely stopping. Otherwise just show the paused message.
+        if (fetchingCanSafelyStop) {
+            return intl.formatMessage({
+                id: stoppedKey ?? 'logs.paused',
+            });
+        }
+
         return intl.formatMessage({
-            id: stopped
-                ? stoppedKey ?? 'logs.paused'
-                : runningKey ?? 'logs.default',
+            id: stopped ? 'logs.paused' : runningKey ?? 'logs.default',
         });
-    }, [intl, runningKey, stopped, stoppedKey]);
+    }, [fetchingCanSafelyStop, intl, runningKey, stopped, stoppedKey]);
 
     return (
         <LogLine

--- a/src/components/logs/Spinner.tsx
+++ b/src/components/logs/Spinner.tsx
@@ -1,63 +1,36 @@
-import { CircularProgress } from '@mui/material';
+import { AlertColor } from '@mui/material';
+import { useMemo } from 'react';
 // import { MutableRefObject, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useLogsContext } from './Context';
 // import { useInterval } from 'react-use';
-import LogLine, { lineNumberColor } from './Line';
+import LogLine from './Line';
+import SpinnerIcon from './SpinnerIcon';
+import { SpinnerMessageKeys } from './types';
 
-// TODO (Spinner) Leaving the custom animation stuff in for right now. Still want to use this
-//     spinner but not worth the peformance cost compared to a simple css animated spinner
+interface Props {
+    severity?: AlertColor;
+    runningKey?: SpinnerMessageKeys['runningKey'];
+    stoppedKey?: SpinnerMessageKeys['stoppedKey'];
+}
 
-// Spinner from https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json
-// const ANIMATION_PROPERTIES = {
-//  interval: 150,
-//  frames: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
-//  done: '⠿',
-// };
-
-// const getFrame = (frame: number) => {
-//  return ANIMATION_PROPERTIES.frames[frame];
-// };
-
-function Spinner() {
+function Spinner({ severity, runningKey, stoppedKey }: Props) {
     const intl = useIntl();
     const { stopped } = useLogsContext();
 
-    // const buildLogLine = (newFrame: MutableRefObject<number>) => {
-    //  return `${getFrame(newFrame.current)}`;
-    // };
-
-    // const frame = useRef(0);
-    // const [animationFrame, setAnimationFrame] = useState(buildLogLine(frame));
-
-    // useInterval(
-    //  () => {
-    //      const newFrame = frame.current + 1;
-    //      frame.current =
-    //          newFrame === ANIMATION_PROPERTIES.frames.length ? 0 : newFrame;
-    //      setAnimationFrame(buildLogLine(frame));
-    //      console.log('lineText', animationFrame);
-    //  },
-    //  stop ? null : ANIMATION_PROPERTIES.interval
-    // );
+    const lineContent = useMemo(() => {
+        return intl.formatMessage({
+            id: stopped
+                ? stoppedKey ?? 'logs.paused'
+                : runningKey ?? 'logs.default',
+        });
+    }, [intl, runningKey, stopped, stoppedKey]);
 
     return (
         <LogLine
             disableSelect
-            line={intl.formatMessage({
-                id: stopped ? 'logs.paused' : 'logs.default',
-            })}
-            lineNumber={
-                <CircularProgress
-                    variant={stopped ? 'determinate' : undefined}
-                    value={stopped ? 100 : undefined}
-                    size={18}
-                    sx={{
-                        alignSelf: 'end',
-                        color: lineNumberColor,
-                    }}
-                />
-            }
+            line={lineContent}
+            lineNumber={<SpinnerIcon severity={severity} stopped={stopped} />}
         />
     );
 }

--- a/src/components/logs/SpinnerIcon.tsx
+++ b/src/components/logs/SpinnerIcon.tsx
@@ -7,7 +7,6 @@ interface Props {
 }
 
 function SpinnerIcon({ severity, stopped }: Props) {
-    console.log('severity', severity);
     return (
         <CircularProgress
             variant={severity || stopped ? 'determinate' : undefined}

--- a/src/components/logs/SpinnerIcon.tsx
+++ b/src/components/logs/SpinnerIcon.tsx
@@ -1,0 +1,25 @@
+import { AlertColor, CircularProgress } from '@mui/material';
+import { lineNumberColor } from './Line';
+
+interface Props {
+    stopped: boolean;
+    severity?: AlertColor;
+}
+
+function SpinnerIcon({ severity, stopped }: Props) {
+    console.log('severity', severity);
+    return (
+        <CircularProgress
+            variant={severity || stopped ? 'determinate' : undefined}
+            value={severity || stopped ? 100 : undefined}
+            size={18}
+            color={severity}
+            sx={{
+                alignSelf: 'end',
+                color: !severity ? lineNumberColor : undefined,
+            }}
+        />
+    );
+}
+
+export default SpinnerIcon;

--- a/src/components/logs/StoppedAlert.tsx
+++ b/src/components/logs/StoppedAlert.tsx
@@ -5,10 +5,13 @@ import { FormattedMessage } from 'react-intl';
 import { useLogsContext } from './Context';
 
 function StoppedAlert() {
-    const { networkFailure, stopped, reset } = useLogsContext();
+    const { networkFailure, stopped, reset, fetchingCanSafelyStop } =
+        useLogsContext();
+
+    const showAlert = !fetchingCanSafelyStop && stopped;
 
     return (
-        <Collapse in={stopped}>
+        <Collapse in={showAlert}>
             <AlertBox severity="info" short>
                 <FormattedMessage
                     id={

--- a/src/components/logs/index.tsx
+++ b/src/components/logs/index.tsx
@@ -1,23 +1,34 @@
-import { Stack } from '@mui/material';
+import { AlertColor, Stack } from '@mui/material';
 import { useMemo } from 'react';
 import { LogsContextProvider } from './Context';
 import LogLines from './Lines';
 import StoppedAlert from './StoppedAlert';
+import { SpinnerMessageKeys } from './types';
 
 export interface LogProps {
     token: string | null;
+    loadingLineSeverity?: AlertColor | null;
     disableIntervalFetching?: boolean;
     fetchAll?: boolean;
     height?: number;
+    spinnerMessages?: SpinnerMessageKeys;
 }
 
-function Logs({ token, height, disableIntervalFetching, fetchAll }: LogProps) {
+function Logs({
+    token,
+    height,
+    loadingLineSeverity,
+    disableIntervalFetching,
+    fetchAll,
+    spinnerMessages,
+}: LogProps) {
     const heightVal = height ?? 200;
 
     return useMemo(() => {
         return (
             <LogsContextProvider
                 token={token}
+                jobCompleted={Boolean(loadingLineSeverity)}
                 disableIntervalFetching={disableIntervalFetching}
                 fetchAll={fetchAll}
             >
@@ -25,11 +36,25 @@ function Logs({ token, height, disableIntervalFetching, fetchAll }: LogProps) {
                     {!fetchAll && !disableIntervalFetching ? (
                         <StoppedAlert />
                     ) : null}
-                    <LogLines height={heightVal} disableSpinner={fetchAll} />
+                    <LogLines
+                        height={heightVal}
+                        spinnerOptions={{
+                            disable: fetchAll,
+                            messages: spinnerMessages,
+                            severity: loadingLineSeverity,
+                        }}
+                    />
                 </Stack>
             </LogsContextProvider>
         );
-    }, [disableIntervalFetching, fetchAll, heightVal, token]);
+    }, [
+        disableIntervalFetching,
+        fetchAll,
+        heightVal,
+        loadingLineSeverity,
+        spinnerMessages,
+        token,
+    ]);
 }
 
 export default Logs;

--- a/src/components/logs/types.ts
+++ b/src/components/logs/types.ts
@@ -1,0 +1,12 @@
+import { AlertColor } from '@mui/material';
+
+export interface SpinnerMessageKeys {
+    runningKey: string;
+    stoppedKey: string;
+}
+
+export interface SpinnerOptions {
+    disable?: boolean;
+    severity?: AlertColor | null;
+    messages?: SpinnerMessageKeys;
+}

--- a/src/components/shared/AlertBox.tsx
+++ b/src/components/shared/AlertBox.tsx
@@ -19,6 +19,7 @@ interface Props extends BaseComponentProps {
     short?: boolean;
     hideIcon?: boolean;
     title?: string | ReactNode;
+    onClose?: () => void;
 }
 
 const SHARED_STYLING = {
@@ -35,7 +36,7 @@ const HEADER_MESSAGE = {
 };
 
 const AlertBox = forwardRef<any, Props>(function NavLinkRef(
-    { short, severity, hideIcon, title, children },
+    { short, severity, hideIcon, title, children, onClose },
     ref
 ) {
     const iconComponentStyling = useMemo(
@@ -82,6 +83,7 @@ const AlertBox = forwardRef<any, Props>(function NavLinkRef(
                 info: <InfoOutlinedIcon sx={iconComponentStyling} />,
                 success: <TaskAltOutlinedIcon sx={iconComponentStyling} />,
             }}
+            onClose={onClose}
             sx={{
                 'backgroundColor': (theme) =>
                     alertBackground[theme.palette.mode],
@@ -92,6 +94,17 @@ const AlertBox = forwardRef<any, Props>(function NavLinkRef(
                 '& > .MuiAlert-message': {
                     p: 1,
                 },
+                '& > .MuiAlert-action': short
+                    ? {
+                          margin: 0,
+                          padding: 1,
+                          paddingTop: 0.5,
+                          alignItems: 'center',
+                      }
+                    : {
+                          margin: 0,
+                          padding: 1,
+                      },
                 '& > .MuiAlert-icon': short
                     ? {
                           ...SHARED_STYLING,

--- a/src/components/shared/ButtonWithPopper.tsx
+++ b/src/components/shared/ButtonWithPopper.tsx
@@ -6,11 +6,18 @@ import { FormattedMessage } from 'react-intl';
 interface Props {
     messageId: string;
     popper: ReactNode;
+    disabled?: boolean;
     startIcon?: ReactNode;
     buttonSx?: SxProps<Theme>;
 }
 
-function ButtonWithPopper({ messageId, popper, startIcon, buttonSx }: Props) {
+function ButtonWithPopper({
+    messageId,
+    popper,
+    disabled,
+    startIcon,
+    buttonSx,
+}: Props) {
     const [open, setOpen] = useState<boolean>(false);
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
@@ -21,7 +28,12 @@ function ButtonWithPopper({ messageId, popper, startIcon, buttonSx }: Props) {
 
     return (
         <>
-            <Button startIcon={startIcon} onClick={togglePopper} sx={buttonSx}>
+            <Button
+                disabled={disabled}
+                startIcon={startIcon}
+                onClick={togglePopper}
+                sx={buttonSx}
+            >
                 <FormattedMessage id={messageId} />
             </Button>
 

--- a/src/components/shared/Entity/Actions/TestButton.tsx
+++ b/src/components/shared/Entity/Actions/TestButton.tsx
@@ -51,7 +51,12 @@ function EntityTestButton({
                         id={`${messagePrefix}.test.waitMessage`}
                     />
                 }
-                actionComponent={<LogDialogActions close={closeLogs} />}
+                actionComponent={
+                    <LogDialogActions
+                        close={closeLogs}
+                        closeCtaKey="cta.dismiss"
+                    />
+                }
             />
             <EntityCreateSave
                 dryRun

--- a/src/components/shared/Entity/LogDialog.tsx
+++ b/src/components/shared/Entity/LogDialog.tsx
@@ -7,6 +7,7 @@ import {
 import Logs from 'components/logs';
 import { logDialogBackground } from 'context/Theme';
 import { ReactNode } from 'react';
+import { useFormStateStore_message } from 'stores/FormState/hooks';
 import ErrorBoundryWrapper from '../ErrorBoundryWrapper';
 
 interface Props {
@@ -19,6 +20,8 @@ interface Props {
 const TITLE_ID = 'logs-dialog-title';
 
 function LogDialog({ open, token, actionComponent, title }: Props) {
+    const { key, severity } = useFormStateStore_message();
+
     return (
         <Dialog
             open={open}
@@ -38,7 +41,19 @@ function LogDialog({ open, token, actionComponent, title }: Props) {
 
             <DialogContent>
                 <ErrorBoundryWrapper>
-                    <Logs token={token} height={350} />
+                    <Logs
+                        token={token}
+                        height={350}
+                        loadingLineSeverity={severity}
+                        spinnerMessages={
+                            key
+                                ? {
+                                      stoppedKey: key,
+                                      runningKey: key,
+                                  }
+                                : undefined
+                        }
+                    />
                 </ErrorBoundryWrapper>
             </DialogContent>
 

--- a/src/components/shared/Entity/LogDialogActions.tsx
+++ b/src/components/shared/Entity/LogDialogActions.tsx
@@ -6,13 +6,14 @@ import { FormStatus } from 'stores/FormState/types';
 
 interface Props {
     close: any;
+    closeCtaKey?: string;
     materialize?: {
         action: any;
         title: string;
     };
 }
 
-function LogDialogActions({ close, materialize }: Props) {
+function LogDialogActions({ close, closeCtaKey, materialize }: Props) {
     const formStatus = useFormStateStore_status();
 
     return (
@@ -23,7 +24,7 @@ function LogDialogActions({ close, materialize }: Props) {
 
             <Stack direction="row" spacing={2}>
                 <Button onClick={close}>
-                    <FormattedMessage id="cta.close" />
+                    <FormattedMessage id={closeCtaKey ?? 'cta.close'} />
                 </Button>
 
                 {materialize ? (

--- a/src/components/shared/Entity/Status.tsx
+++ b/src/components/shared/Entity/Status.tsx
@@ -1,43 +1,19 @@
-import { AlertColor, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
-import {
-    useFormStateStore_isActive,
-    useFormStateStore_status,
-} from 'stores/FormState/hooks';
-import { FormStatus } from 'stores/FormState/types';
+import { useFormStateStore_message } from 'stores/FormState/hooks';
 import AlertBox from '../AlertBox';
 
 function Status() {
-    const formStatus = useFormStateStore_status();
-    const isActive = useFormStateStore_isActive();
+    const { key, severity } = useFormStateStore_message();
 
-    let severity: AlertColor | undefined, messageKey;
-    if (formStatus === FormStatus.TESTED || formStatus === FormStatus.SAVED) {
-        messageKey = 'common.success';
-        severity = 'success';
-    } else if (formStatus === FormStatus.FAILED) {
-        messageKey = 'common.fail';
-        severity = 'error';
-    } else if (isActive) {
-        messageKey = 'common.running';
-    }
-
-    if (messageKey) {
-        if (severity) {
-            return (
-                <AlertBox severity={severity} short>
-                    <Typography sx={{ mr: 1 }}>
-                        <FormattedMessage id={messageKey} />
-                    </Typography>
-                </AlertBox>
-            );
-        } else {
-            return (
+    if (key && severity) {
+        return (
+            <AlertBox severity={severity} short>
                 <Typography sx={{ mr: 1 }}>
-                    <FormattedMessage id={messageKey} />
+                    <FormattedMessage id={key} />
                 </Typography>
-            );
-        }
+            </AlertBox>
+        );
     } else {
         return null;
     }

--- a/src/components/shared/PageContainer.tsx
+++ b/src/components/shared/PageContainer.tsx
@@ -61,7 +61,11 @@ function PageContainer({ children, hideBackground, pageTitleProps }: Props) {
                     autoHideDuration={7500}
                     onClose={handlers.notificationClose}
                 >
-                    <AlertBox severity={notification.severity} short>
+                    <AlertBox
+                        severity={notification.severity}
+                        short
+                        onClose={handlers.notificationClose}
+                    >
                         {`${notification.title}. ${notification.description}`}
                     </AlertBox>
                 </Snackbar>

--- a/src/components/shared/PageContainer.tsx
+++ b/src/components/shared/PageContainer.tsx
@@ -57,7 +57,7 @@ function PageContainer({ children, hideBackground, pageTitleProps }: Props) {
             {notification ? (
                 <Snackbar
                     open={displayAlert}
-                    autoHideDuration={5000}
+                    autoHideDuration={7500}
                     onClose={handlers.notificationClose}
                 >
                     <AlertBox severity={notification.severity} short>

--- a/src/components/shared/PageContainer.tsx
+++ b/src/components/shared/PageContainer.tsx
@@ -56,6 +56,7 @@ function PageContainer({ children, hideBackground, pageTitleProps }: Props) {
         >
             {notification ? (
                 <Snackbar
+                    anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                     open={displayAlert}
                     autoHideDuration={7500}
                     onClose={handlers.notificationClose}

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -16,6 +16,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'common.disabled': `Disabled`,
     'common.inProgress': `In Progress`,
     'common.done': `Done`,
+    'common.testing': `Testing`,
     'common.saving': `Saving`,
     'common.saved': `Saved`,
     'common.invalid': `Invalid`,
@@ -374,7 +375,7 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
 };
 
 const LogsDialog: ResolvedIntlConfig['messages'] = {
-    'logs.default': `Waiting for logs...`,
+    'logs.default': ` `,
     'logs.paused': `paused`,
     'logs.restartLink': `click here`,
     'logs.tooManyEmpty': `Logs for this build may have ended. {restartCTA} to start waiting for new logs again.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -17,8 +17,8 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'common.inProgress': `In Progress`,
     'common.done': `Done`,
     'common.testing': `Testing`,
-    'common.saving': `Saving`,
-    'common.saved': `Saved`,
+    'common.saving': `Publishing`,
+    'common.saved': `Published`,
     'common.invalid': `Invalid`,
     'common.fail': `Failed`,
     'common.success': `Success`,
@@ -91,6 +91,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
 const CTAs: ResolvedIntlConfig['messages'] = {
     'cta.cancel': `Cancel`,
     'cta.close': `Close`,
+    'cta.dismiss': `Dismiss`,
     'cta.continue': `Continue`,
     'cta.delete': `Delete`,
     'cta.download': `Download`,

--- a/src/stores/FormState/Store.ts
+++ b/src/stores/FormState/Store.ts
@@ -4,7 +4,7 @@ import { devtoolsOptions } from 'utils/store-utils';
 import create, { StoreApi } from 'zustand';
 import { devtools, NamedSet } from 'zustand/middleware';
 import { FormStateStoreNames } from '../names';
-import { EntityFormState, FormStatus } from './types';
+import { EntityFormState, FormState, FormStatus } from './types';
 
 const formActive = (status: FormStatus) => {
     return (
@@ -23,6 +23,40 @@ const formIdle = (status: FormStatus) => {
     );
 };
 
+const getMessageSettings = (
+    formStatus: FormStatus,
+    isActive: boolean
+): FormState['message'] => {
+    if (formStatus === FormStatus.TESTED || formStatus === FormStatus.SAVED) {
+        return {
+            key: 'common.success',
+            severity: 'success',
+        };
+    } else if (formStatus === FormStatus.FAILED) {
+        return {
+            key: 'common.fail',
+            severity: 'error',
+        };
+    } else if (isActive) {
+        let key = 'common.running';
+        if (formStatus === FormStatus.TESTING) {
+            key = 'common.testing';
+        } else if (formStatus === FormStatus.SAVING) {
+            key = 'common.saving';
+        }
+
+        return {
+            key,
+            severity: null,
+        };
+    }
+
+    return {
+        key: null,
+        severity: null,
+    };
+};
+
 const initialFormState = {
     displayValidation: false,
     status: FormStatus.INIT,
@@ -30,6 +64,10 @@ const initialFormState = {
     exitWhenLogsClose: false,
     logToken: null,
     error: null,
+    message: {
+        key: null,
+        severity: null,
+    },
 };
 
 const getInitialStateData = (
@@ -57,10 +95,15 @@ const getInitialState = (
         set(
             produce((state: EntityFormState) => {
                 const { formState } = get();
-
                 state.formState = { ...formState, ...newState };
                 state.isIdle = formIdle(state.formState.status);
-                state.isActive = formActive(state.formState.status);
+
+                const formIsActive = formActive(state.formState.status);
+                state.isActive = formIsActive;
+                state.formState.message = getMessageSettings(
+                    state.formState.status,
+                    formIsActive
+                );
             }),
             false,
             'Form State Changed'
@@ -73,7 +116,13 @@ const getInitialState = (
                 state.formState = { ...initialFormState };
                 state.formState.status = status;
                 state.isIdle = formIdle(status);
-                state.isActive = formActive(status);
+
+                const formIsActive = formActive(status);
+                state.isActive = formIsActive;
+                state.formState.message = getMessageSettings(
+                    state.formState.status,
+                    formIsActive
+                );
             }),
             false,
             'Form Status Updated'

--- a/src/stores/FormState/hooks.ts
+++ b/src/stores/FormState/hooks.ts
@@ -74,6 +74,15 @@ export const useFormStateStore_error = () => {
     >(storeName(workflow), (state) => state.formState.error);
 };
 
+export const useFormStateStore_message = () => {
+    const workflow = useEntityWorkflow();
+
+    return useZustandStore<
+        EntityFormState,
+        EntityFormState['formState']['message']
+    >(storeName(workflow), (state) => state.formState.message);
+};
+
 export const useFormStateStore_setFormState = () => {
     const workflow = useEntityWorkflow();
 

--- a/src/stores/FormState/types.ts
+++ b/src/stores/FormState/types.ts
@@ -1,3 +1,4 @@
+import { AlertColor } from '@mui/material';
 import { PostgrestError } from '@supabase/postgrest-js';
 import { MessagePrefixes } from 'types';
 
@@ -11,6 +12,10 @@ export interface FormState {
         title: string;
         error?: PostgrestError;
     } | null;
+    message: {
+        key: string | null;
+        severity: AlertColor | null;
+    };
 }
 
 export enum FormStatus {


### PR DESCRIPTION
## Changes

1. Display Testing/Saving inside logs while running
1. When a job is complete 
    - Check for logs for 2 more seconds
    - Stop loading indicator
    - Make loading indicator color of outcome (green for success, etc)
1. Do not allow schema edit button to be clicked while form is active
2. Allow users to close the notifications shown
3. Display notifications at the top of the page

## Tests

Manually tested

## Issues

Fixes: https://github.com/estuary/ui/issues/331

## Content

Tweaking `Saving` to `Publishing`

## Screenshots

Shows what task is running on the last line of the logs
![image](https://user-images.githubusercontent.com/270078/213292960-7beb42e1-2197-4630-9f7a-f7f4e806d3ef.png)
![image](https://user-images.githubusercontent.com/270078/213293111-37da5396-e618-4966-9c34-5fe9c8e017a9.png)


Show a completed circle inside the logs with the correct color and success message
![image](https://user-images.githubusercontent.com/270078/213293003-608f8667-6001-4348-a8b8-907d15b95995.png)

If the job runs a long time we still stop and show "paused"
![image](https://user-images.githubusercontent.com/270078/213294758-b3d39abb-9019-4e9a-9842-d1a138d624b6.png)


Moving notification to top of screen
![image](https://user-images.githubusercontent.com/270078/213547636-e014f36d-b0c9-4085-8e68-ed2696c2c32b.png)
