### PR TITLE
Schema inference possible fix

### DIFF
--- a/src/components/editor/Bindings/SchemaInference/Button.tsx
+++ b/src/components/editor/Bindings/SchemaInference/Button.tsx
@@ -54,33 +54,30 @@ function SchemaInferenceButton() {
                 .then(
                     (response) => {
                         let inferredSchema = null;
-                        if (!isEmpty(response.schema)) {
-                            if (
-                                Object.hasOwn(
-                                    collectionData.spec,
-                                    'writeSchema'
-                                )
-                            ) {
-                                const { ...additionalSpecKeys } =
-                                    collectionData.spec;
+                        if (Object.hasOwn(collectionData.spec, 'writeSchema')) {
+                            const { ...additionalSpecKeys } =
+                                collectionData.spec;
 
-                                inferredSchema = {
-                                    ...additionalSpecKeys,
-                                    writeSchema:
-                                        collectionData.spec.writeSchema,
-                                    readSchema: response.schema,
-                                };
-                            } else {
-                                // Need to remove schema from the keys
-                                const { schema, ...additionalSpecKeys } =
-                                    collectionData.spec;
+                            inferredSchema = !isEmpty(response.schema)
+                                ? {
+                                      ...additionalSpecKeys,
+                                      writeSchema:
+                                          collectionData.spec.writeSchema,
+                                      readSchema: response.schema,
+                                  }
+                                : null;
+                        } else {
+                            // Removing schema from the object
+                            const { schema, ...additionalSpecKeys } =
+                                collectionData.spec;
 
-                                inferredSchema = {
-                                    ...additionalSpecKeys,
-                                    writeSchema: collectionData.spec.schema,
-                                    readSchema: response.schema,
-                                };
-                            }
+                            inferredSchema = !isEmpty(response.schema)
+                                ? {
+                                      ...additionalSpecKeys,
+                                      writeSchema: collectionData.spec.schema,
+                                      readSchema: response.schema,
+                                  }
+                                : null;
                         }
 
                         setInferredSpec(inferredSchema);
@@ -88,6 +85,7 @@ function SchemaInferenceButton() {
                     },
                     (error) => {
                         setInferredSpec(error?.code === 404 ? null : undefined);
+
                         setDocumentsRead(undefined);
                     }
                 )

--- a/src/components/editor/Bindings/SchemaInference/Button.tsx
+++ b/src/components/editor/Bindings/SchemaInference/Button.tsx
@@ -53,41 +53,41 @@ function SchemaInferenceButton() {
             )
                 .then(
                     (response) => {
-                        if (Object.hasOwn(collectionData.spec, 'writeSchema')) {
-                            const { ...additionalSpecKeys } =
-                                collectionData.spec;
+                        let inferredSchema = null;
+                        if (!isEmpty(response.schema)) {
+                            if (
+                                Object.hasOwn(
+                                    collectionData.spec,
+                                    'writeSchema'
+                                )
+                            ) {
+                                const { ...additionalSpecKeys } =
+                                    collectionData.spec;
 
-                            setInferredSpec(
-                                !isEmpty(response.schema)
-                                    ? {
-                                          ...additionalSpecKeys,
-                                          writeSchema:
-                                              collectionData.spec.writeSchema,
-                                          readSchema: response.schema,
-                                      }
-                                    : null
-                            );
-                        } else {
-                            const { schema, ...additionalSpecKeys } =
-                                collectionData.spec;
+                                inferredSchema = {
+                                    ...additionalSpecKeys,
+                                    writeSchema:
+                                        collectionData.spec.writeSchema,
+                                    readSchema: response.schema,
+                                };
+                            } else {
+                                // Need to remove schema from the keys
+                                const { schema, ...additionalSpecKeys } =
+                                    collectionData.spec;
 
-                            setInferredSpec(
-                                !isEmpty(response.schema)
-                                    ? {
-                                          ...additionalSpecKeys,
-                                          writeSchema:
-                                              collectionData.spec.schema,
-                                          readSchema: response.schema,
-                                      }
-                                    : null
-                            );
+                                inferredSchema = {
+                                    ...additionalSpecKeys,
+                                    writeSchema: collectionData.spec.schema,
+                                    readSchema: response.schema,
+                                };
+                            }
                         }
 
+                        setInferredSpec(inferredSchema);
                         setDocumentsRead(response.documents_read);
                     },
                     (error) => {
                         setInferredSpec(error?.code === 404 ? null : undefined);
-
                         setDocumentsRead(undefined);
                     }
                 )

--- a/src/components/editor/Bindings/SchemaInference/Button.tsx
+++ b/src/components/editor/Bindings/SchemaInference/Button.tsx
@@ -53,12 +53,12 @@ function SchemaInferenceButton() {
             )
                 .then(
                     (response) => {
-                        let inferredSchema = null;
+                        let inferredSpec = null;
                         if (Object.hasOwn(collectionData.spec, 'writeSchema')) {
                             const { ...additionalSpecKeys } =
                                 collectionData.spec;
 
-                            inferredSchema = !isEmpty(response.schema)
+                            inferredSpec = !isEmpty(response.schema)
                                 ? {
                                       ...additionalSpecKeys,
                                       writeSchema:
@@ -71,7 +71,7 @@ function SchemaInferenceButton() {
                             const { schema, ...additionalSpecKeys } =
                                 collectionData.spec;
 
-                            inferredSchema = !isEmpty(response.schema)
+                            inferredSpec = !isEmpty(response.schema)
                                 ? {
                                       ...additionalSpecKeys,
                                       writeSchema: collectionData.spec.schema,
@@ -80,7 +80,7 @@ function SchemaInferenceButton() {
                                 : null;
                         }
 
-                        setInferredSpec(inferredSchema);
+                        setInferredSpec(inferredSpec);
                         setDocumentsRead(response.documents_read);
                     },
                     (error) => {

--- a/src/components/editor/Bindings/SchemaInference/Button.tsx
+++ b/src/components/editor/Bindings/SchemaInference/Button.tsx
@@ -54,16 +54,16 @@ function SchemaInferenceButton() {
                 .then(
                     (response) => {
                         if (Object.hasOwn(collectionData.spec, 'writeSchema')) {
-                            const { writeSchema, ...additionalSpecKeys } =
+                            const { ...additionalSpecKeys } =
                                 collectionData.spec;
 
                             setInferredSpec(
                                 !isEmpty(response.schema)
                                     ? {
+                                          ...additionalSpecKeys,
                                           writeSchema:
                                               collectionData.spec.writeSchema,
                                           readSchema: response.schema,
-                                          ...additionalSpecKeys,
                                       }
                                     : null
                             );
@@ -74,10 +74,10 @@ function SchemaInferenceButton() {
                             setInferredSpec(
                                 !isEmpty(response.schema)
                                     ? {
+                                          ...additionalSpecKeys,
                                           writeSchema:
                                               collectionData.spec.schema,
                                           readSchema: response.schema,
-                                          ...additionalSpecKeys,
                                       }
                                     : null
                             );
@@ -111,11 +111,7 @@ function SchemaInferenceButton() {
                     <FormattedMessage id="workflows.collectionSelector.cta.schemaInference" />
                 </Button>
 
-                <SchemaInferenceDialog
-                    collectionData={collectionData}
-                    open={open}
-                    setOpen={setOpen}
-                />
+                <SchemaInferenceDialog open={open} setOpen={setOpen} />
             </>
         ) : (
             <Skeleton variant="rectangular" width={125} />

--- a/src/components/editor/Bindings/SchemaInference/Dialog/DiffEditor/index.tsx
+++ b/src/components/editor/Bindings/SchemaInference/Dialog/DiffEditor/index.tsx
@@ -4,10 +4,10 @@ import { BindingsEditorSchemaSkeleton } from 'components/collection/CollectionSk
 import InferenceDiffEditorFooter from 'components/editor/Bindings/SchemaInference/Dialog/DiffEditor/Footer';
 import InferenceDiffEditorHeader from 'components/editor/Bindings/SchemaInference/Dialog/DiffEditor/Header';
 import {
+    useBindingsEditorStore_collectionData,
     useBindingsEditorStore_inferredSpec,
     useBindingsEditorStore_loadingInferredSchema,
 } from 'components/editor/Bindings/Store/hooks';
-import { CollectionData } from 'components/editor/Bindings/types';
 import { DEFAULT_HEIGHT } from 'components/editor/MonacoEditor';
 import AlertBox from 'components/shared/AlertBox';
 import {
@@ -15,22 +15,28 @@ import {
     monacoEditorComponentBackground,
     monacoEditorWidgetBackground,
 } from 'context/Theme';
+import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { stringifyJSON } from 'services/stringify';
 
 interface Props {
-    collectionData: CollectionData;
     height?: number;
 }
 
-function InferenceDiffEditor({
-    collectionData,
-    height = DEFAULT_HEIGHT,
-}: Props) {
+function InferenceDiffEditor({ height = DEFAULT_HEIGHT }: Props) {
     const theme = useTheme();
 
     // Bindings Editor Store
     const inferredSpec = useBindingsEditorStore_inferredSpec();
+    const collectionData = useBindingsEditorStore_collectionData();
+
+    const original = useMemo(() => {
+        if (collectionData) {
+            return stringifyJSON(collectionData.spec);
+        }
+
+        return null;
+    }, [collectionData]);
 
     const loadingInferredSchema =
         useBindingsEditorStore_loadingInferredSchema();
@@ -39,11 +45,11 @@ function InferenceDiffEditor({
         <Box sx={{ my: 3, border: defaultOutline[theme.palette.mode] }}>
             <InferenceDiffEditorHeader />
 
-            {inferredSpec ? (
+            {inferredSpec && original ? (
                 <>
                     <DiffEditor
                         height={`${height}px`}
-                        original={stringifyJSON(collectionData.spec)}
+                        original={original}
                         modified={stringifyJSON(inferredSpec)}
                         theme={
                             monacoEditorComponentBackground[theme.palette.mode]

--- a/src/components/editor/Bindings/SchemaInference/Dialog/UpdateSchemaButton.tsx
+++ b/src/components/editor/Bindings/SchemaInference/Dialog/UpdateSchemaButton.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@mui/material';
 import {
     useBindingsEditorStore_applyInferredSchema,
+    useBindingsEditorStore_collectionData,
     useBindingsEditorStore_inferredSpec,
     useBindingsEditorStore_loadingInferredSchema,
 } from 'components/editor/Bindings/Store/hooks';
-import { CollectionData } from 'components/editor/Bindings/types';
 import { useEditorStore_persistedDraftId } from 'components/editor/Store/hooks';
 import { isEqual } from 'lodash';
 import { Dispatch, SetStateAction, useMemo } from 'react';
@@ -12,18 +12,16 @@ import { FormattedMessage } from 'react-intl';
 import { useResourceConfig_currentCollection } from 'stores/ResourceConfig/hooks';
 
 interface Props {
-    collectionData: CollectionData;
     setOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-function UpdateSchemaButton({ collectionData, setOpen }: Props) {
+function UpdateSchemaButton({ setOpen }: Props) {
     // Bindings Editor Store
     const inferredSpec = useBindingsEditorStore_inferredSpec();
-
     const loadingInferredSchema =
         useBindingsEditorStore_loadingInferredSchema();
-
     const applyInferredSchema = useBindingsEditorStore_applyInferredSchema();
+    const collectionData = useBindingsEditorStore_collectionData();
 
     // Draft Editor Store
     const persistedDraftId = useEditorStore_persistedDraftId();
@@ -32,10 +30,22 @@ function UpdateSchemaButton({ collectionData, setOpen }: Props) {
     const currentCollection = useResourceConfig_currentCollection();
 
     const originalSchema = useMemo(() => {
+        if (!collectionData || !collectionData.spec) {
+            return {};
+        }
+
         return Object.hasOwn(collectionData.spec, 'readSchema')
             ? collectionData.spec.readSchema
             : collectionData.spec.schema;
-    }, [collectionData.spec]);
+    }, [collectionData]);
+
+    const disableUpdate = useMemo(() => {
+        return (
+            !inferredSpec ||
+            loadingInferredSchema ||
+            isEqual(originalSchema, inferredSpec.readSchema)
+        );
+    }, [inferredSpec, loadingInferredSchema, originalSchema]);
 
     const updateServer = (event: React.MouseEvent<HTMLElement>) => {
         event.preventDefault();
@@ -44,14 +54,7 @@ function UpdateSchemaButton({ collectionData, setOpen }: Props) {
     };
 
     return (
-        <Button
-            disabled={
-                !inferredSpec ||
-                isEqual(originalSchema, inferredSpec.readSchema) ||
-                loadingInferredSchema
-            }
-            onClick={updateServer}
-        >
+        <Button disabled={disableUpdate} onClick={updateServer}>
             <FormattedMessage id="workflows.collectionSelector.schemaInference.cta.continue" />
         </Button>
     );

--- a/src/components/editor/Bindings/SchemaInference/Dialog/index.tsx
+++ b/src/components/editor/Bindings/SchemaInference/Dialog/index.tsx
@@ -12,14 +12,12 @@ import SchemaApplicationErroredAlert from 'components/editor/Bindings/SchemaInfe
 import CancelButton from 'components/editor/Bindings/SchemaInference/Dialog/CancelButton';
 import InferenceDiffEditor from 'components/editor/Bindings/SchemaInference/Dialog/DiffEditor';
 import UpdateSchemaButton from 'components/editor/Bindings/SchemaInference/Dialog/UpdateSchemaButton';
-import { CollectionData } from 'components/editor/Bindings/types';
 import { glassBkgWithoutBlur } from 'context/Theme';
 import { Dispatch, SetStateAction } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useResourceConfig_currentCollection } from 'stores/ResourceConfig/hooks';
 
 interface Props {
-    collectionData: CollectionData;
     open: boolean;
     setOpen: Dispatch<SetStateAction<boolean>>;
     height?: number;
@@ -27,12 +25,7 @@ interface Props {
 
 const TITLE_ID = 'inferred-schema-dialog-title';
 
-function SchemaInferenceDialog({
-    collectionData,
-    open,
-    setOpen,
-    height,
-}: Props) {
+function SchemaInferenceDialog({ open, setOpen, height }: Props) {
     // Resource Config Store
     const currentCollection = useResourceConfig_currentCollection();
 
@@ -75,19 +68,13 @@ function SchemaInferenceDialog({
                     <LowDocumentCountAlert />
                 </Stack>
 
-                <InferenceDiffEditor
-                    collectionData={collectionData}
-                    height={height}
-                />
+                <InferenceDiffEditor height={height} />
             </DialogContent>
 
             <DialogActions>
                 <CancelButton setOpen={setOpen} />
 
-                <UpdateSchemaButton
-                    collectionData={collectionData}
-                    setOpen={setOpen}
-                />
+                <UpdateSchemaButton setOpen={setOpen} />
             </DialogActions>
         </Dialog>
     ) : null;


### PR DESCRIPTION
## Changes

1. No longer pass around object and read from store
2. Invert the spread operator so 

## Tests

Manually tested with injecting values in response

## Issues

Fixes: https://github.com/estuary/ui/issues/459

## Content

None

## Screenshots

First time response has value injected
![image](https://user-images.githubusercontent.com/270078/213811961-07f9005f-de8f-4abf-a073-729639107d3c.png)

Second time response is left alone
![image](https://user-images.githubusercontent.com/270078/213812023-de875b3a-83a3-4a94-837a-08769e5f842c.png)

Third time response as value injected
![image](https://user-images.githubusercontent.com/270078/213812206-c8282cd4-2645-4c9f-9ba1-7188fb20a5de.png)
