### PR TITLE
Display create new task option first on existing entity check page

### DIFF
--- a/src/components/shared/Entity/ExistingEntityCards/index.tsx
+++ b/src/components/shared/Entity/ExistingEntityCards/index.tsx
@@ -125,6 +125,14 @@ function ExistingEntityCards() {
                     />
                 </Grid>
 
+                <Grid item xs={12}>
+                    <NewEntityCard />
+                </Grid>
+
+                <Grid item xs={12} sx={{ my: 2 }}>
+                    <Divider flexItem />
+                </Grid>
+
                 {queryData && queryData.length > 0 ? (
                     queryData.map((data, index) => (
                         <Grid
@@ -189,14 +197,6 @@ function ExistingEntityCards() {
                         </Paper>
                     </Grid>
                 )}
-
-                <Grid item xs={12} sx={{ my: 2 }}>
-                    <Divider flexItem />
-                </Grid>
-
-                <Grid item xs={12}>
-                    <NewEntityCard />
-                </Grid>
             </Grid>
         </Box>
     );


### PR DESCRIPTION
## Changes

On the existing entity check page, the create new task option will be the first card in the list to prevent it from being buried by moderate to long lists of existing entities.

## Tests

Confirmed that the create new task option is the first card displayed on the existing entity check page.

## Screenshots

<img width="920" alt="reverse_existing_entity_check_card_order" src="https://user-images.githubusercontent.com/77648584/219443435-5330ad11-7612-4f2b-970a-ea926d03b936.PNG">
