### PR TITLE
UX Tweaks: Binding selecting, stats, and date time picker

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
 
         // Design decision we made for how we like code
         'react/destructuring-assignment': 'error',
+        'no-tabs': 'error',
 
         // We're using a new React so I think this is safe
         'react/react-in-jsx-scope': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "ansicolor": "^1.1.100",
                 "data-plane-gateway": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
                 "date-fns": "^2.29.3",
+                "date-fns-tz": "^2.0.0",
                 "filter-obj": "^5.1.0",
                 "iconoir-react": "^6.2.0",
                 "immer": "^9.0.17",
@@ -9128,6 +9129,14 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/date-fns"
+            }
+        },
+        "node_modules/date-fns-tz": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+            "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+            "peerDependencies": {
+                "date-fns": ">=2.0.0"
             }
         },
         "node_modules/dayjs": {
@@ -33581,6 +33590,12 @@
             "version": "2.29.3",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
             "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+        },
+        "date-fns-tz": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+            "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+            "requires": {}
         },
         "dayjs": {
             "version": "1.11.7",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "ansicolor": "^1.1.100",
         "data-plane-gateway": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
         "date-fns": "^2.29.3",
+        "date-fns-tz": "^2.0.0",
         "filter-obj": "^5.1.0",
         "iconoir-react": "^6.2.0",
         "immer": "^9.0.17",

--- a/src/components/collection/Picker.tsx
+++ b/src/components/collection/Picker.tsx
@@ -3,12 +3,15 @@ import {
     AutocompleteChangeReason,
     Box,
     TextField,
+    Typography,
 } from '@mui/material';
 import { useEditorStore_persistedDraftId } from 'components/editor/Store/hooks';
 import { useEntityType } from 'context/EntityContext';
+import { truncateTextSx } from 'context/Theme';
 import { useEntityWorkflow } from 'context/Workflow';
 import useDraftSpecs from 'hooks/useDraftSpecs';
 import useLiveSpecs from 'hooks/useLiveSpecs';
+import { Check } from 'iconoir-react';
 import { isEqual } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -232,7 +235,6 @@ function CollectionPicker({ readOnly = false }: Props) {
                 value={collectionValues}
                 inputValue={inputValue}
                 size="small"
-                filterSelectedOptions
                 fullWidth
                 onChange={handlers.updateCollections}
                 onInputChange={(_event, newInputValue, reason) => {
@@ -257,6 +259,34 @@ function CollectionPicker({ readOnly = false }: Props) {
                         onBlur={handlers.validateSelection}
                     />
                 )}
+                renderOption={(props, option, { selected }) => {
+                    return (
+                        <li {...props}>
+                            <Box
+                                sx={{
+                                    ml: -2,
+                                    mr: 0.5,
+                                }}
+                            >
+                                <Check
+                                    aria-checked={selected}
+                                    style={{
+                                        visibility: selected
+                                            ? 'visible'
+                                            : 'hidden',
+                                    }}
+                                />
+                            </Box>
+                            <Typography
+                                sx={{
+                                    ...truncateTextSx,
+                                }}
+                            >
+                                {option.name}
+                            </Typography>
+                        </li>
+                    );
+                }}
             />
         </Box>
     ) : null;

--- a/src/components/collection/Picker.tsx
+++ b/src/components/collection/Picker.tsx
@@ -236,7 +236,6 @@ function CollectionPicker({ readOnly = false }: Props) {
                 inputValue={inputValue}
                 size="small"
                 fullWidth
-                open={true}
                 onChange={handlers.updateCollections}
                 onInputChange={(_event, newInputValue, reason) => {
                     const inputBeingReset =

--- a/src/components/collection/Picker.tsx
+++ b/src/components/collection/Picker.tsx
@@ -236,6 +236,7 @@ function CollectionPicker({ readOnly = false }: Props) {
                 inputValue={inputValue}
                 size="small"
                 fullWidth
+                open={true}
                 onChange={handlers.updateCollections}
                 onInputChange={(_event, newInputValue, reason) => {
                     const inputBeingReset =
@@ -261,7 +262,10 @@ function CollectionPicker({ readOnly = false }: Props) {
                 )}
                 renderOption={(props, option, { selected }) => {
                     return (
-                        <li {...props}>
+                        // TODO (styling) weirdly the paddingLeft was getting overwritten
+                        //  for dark mode and caused the icon to be too close to the edge
+                        //  so hardcoding the padding here for now
+                        <li {...props} style={{ paddingLeft: 24 }}>
                             <Box
                                 sx={{
                                     ml: -2,

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -176,13 +176,15 @@ function BindingSelector({
                 if (currentConfig.errors.length > 0) {
                     return (
                         <>
-                            <WarningCircle
-                                style={{
-                                    marginRight: 4,
-                                    fontSize: 12,
-                                    color: theme.palette.error.main,
-                                }}
-                            />
+                            <Box>
+                                <WarningCircle
+                                    style={{
+                                        marginRight: 4,
+                                        fontSize: 12,
+                                        color: theme.palette.error.main,
+                                    }}
+                                />
+                            </Box>
 
                             <Row
                                 collection={params.row}

--- a/src/components/login/MagicLinkInputs.tsx
+++ b/src/components/login/MagicLinkInputs.tsx
@@ -77,16 +77,16 @@ const MagicLinkInputs = ({ onSubmit, schema, uiSchema }: Props) => {
             setShowErrors(false);
             setLoading(true);
 
-            const { error } = await onSubmit(formData).finally(() => {
-                setLoading(false);
-            });
+            const { error } = await onSubmit(formData);
 
             if (error) {
+                setLoading(false);
                 setSubmitError(error);
                 return;
             }
 
             if (!hasToken) {
+                setLoading(false);
                 displayNotification('login.magicLink', 'success');
             }
         },

--- a/src/components/shared/AlertBox.tsx
+++ b/src/components/shared/AlertBox.tsx
@@ -109,7 +109,7 @@ const AlertBox = forwardRef<any, Props>(function NavLinkRef(
                           ...SHARED_STYLING,
                           borderLeftColor:
                               theme.palette[severity][theme.palette.mode],
-                          color: theme.palette[severity][theme.palette.mode],
+                          color: alertTextPrimary[theme.palette.mode],
                           mr: 0,
                           px: 1,
                           borderLeftStyle: 'solid',

--- a/src/components/shared/Entity/Create/index.tsx
+++ b/src/components/shared/Entity/Create/index.tsx
@@ -143,71 +143,65 @@ function EntityCreate({
               !entityNameChanged &&
               persistedDraftId;
 
-    return (
+    return connectorTagsError ? (
+        <Error error={connectorTagsError} />
+    ) : (
         <>
-            <Box sx={{ maxHeight: 200, overflowY: 'auto', mb: 2 }}>
-                {errorSummary}
-            </Box>
+            {toolbar}
 
-            {connectorTagsError ? (
-                <Error error={connectorTagsError} />
-            ) : (
-                <>
-                    {toolbar}
+            <Box sx={{ mb: 4 }}>{errorSummary}</Box>
 
-                    <Collapse in={formSubmitError !== null} unmountOnExit>
-                        {formSubmitError ? (
-                            <EntityError
-                                title={formSubmitError.title}
-                                error={formSubmitError.error}
-                                logToken={logToken}
-                                draftId={draftId}
-                            />
-                        ) : null}
-                    </Collapse>
+            <Collapse in={formSubmitError !== null} unmountOnExit>
+                {formSubmitError ? (
+                    <EntityError
+                        title={formSubmitError.title}
+                        error={formSubmitError.error}
+                        logToken={logToken}
+                        draftId={draftId}
+                    />
+                ) : null}
+            </Collapse>
 
-                    {!isValidating && connectorTags.length === 0 ? (
-                        <AlertBox severity="warning">
-                            <FormattedMessage
-                                id={`${messagePrefix}.missingConnectors`}
-                            />
-                        </AlertBox>
-                    ) : connectorTags.length > 0 ? (
-                        <ErrorBoundryWrapper>
-                            <DetailsForm
-                                connectorTags={connectorTags}
-                                accessGrants={combinedGrants}
-                                entityType={entityType}
-                            />
-                        </ErrorBoundryWrapper>
-                    ) : null}
+            {!isValidating && connectorTags.length === 0 ? (
+                <AlertBox severity="warning">
+                    <FormattedMessage
+                        id={`${messagePrefix}.missingConnectors`}
+                    />
+                </AlertBox>
+            ) : connectorTags.length > 0 ? (
+                <ErrorBoundryWrapper>
+                    <DetailsForm
+                        connectorTags={connectorTags}
+                        accessGrants={combinedGrants}
+                        entityType={entityType}
+                    />
+                </ErrorBoundryWrapper>
+            ) : null}
 
-                    {imageTag.connectorId ? (
-                        <ErrorBoundryWrapper>
-                            <EndpointConfig
-                                connectorImage={imageTag.id}
-                                hideBorder={!displayResourceConfig}
-                            />
-                        </ErrorBoundryWrapper>
-                    ) : null}
+            {imageTag.connectorId ? (
+                <ErrorBoundryWrapper>
+                    <EndpointConfig
+                        connectorImage={imageTag.id}
+                        hideBorder={!displayResourceConfig}
+                    />
+                </ErrorBoundryWrapper>
+            ) : null}
 
-                    {displayResourceConfig ? (
-                        <ErrorBoundryWrapper>
-                            <CollectionConfig
-                                draftSpecs={taskDraftSpec}
-                                RediscoverButton={RediscoverButton}
-                                hideBorder={!draftId}
-                            />
-                        </ErrorBoundryWrapper>
-                    ) : null}
+            {displayResourceConfig ? (
+                <ErrorBoundryWrapper>
+                    <CollectionConfig
+                        draftSpecs={taskDraftSpec}
+                        RediscoverButton={RediscoverButton}
+                        hideBorder={!draftId}
+                    />
+                </ErrorBoundryWrapper>
+            ) : null}
 
-                    <ErrorBoundryWrapper>
-                        <CatalogEditor
-                            messageId={`${messagePrefix}.finalReview.instructions`}
-                        />
-                    </ErrorBoundryWrapper>
-                </>
-            )}
+            <ErrorBoundryWrapper>
+                <CatalogEditor
+                    messageId={`${messagePrefix}.finalReview.instructions`}
+                />
+            </ErrorBoundryWrapper>
         </>
     );
 }

--- a/src/components/shared/Entity/Edit.tsx
+++ b/src/components/shared/Entity/Edit.tsx
@@ -1,4 +1,4 @@
-import { Collapse } from '@mui/material';
+import { Box, Collapse } from '@mui/material';
 import { RealtimeSubscription } from '@supabase/supabase-js';
 import { createEntityDraft } from 'api/drafts';
 import { createDraftSpec, updateDraftSpec } from 'api/draftSpecs';
@@ -391,7 +391,7 @@ function EntityEdit({
         <>
             {toolbar}
 
-            {errorSummary}
+            <Box sx={{ mb: 4 }}>{errorSummary}</Box>
 
             {connectorTagsError ? (
                 <Error error={connectorTagsError} />

--- a/src/components/tables/Details/ShardErrors.tsx
+++ b/src/components/tables/Details/ShardErrors.tsx
@@ -51,7 +51,7 @@ function ShardErrors({ shards }: Props) {
                     (shardDetails: ShardDetails) =>
                         shardDetails.id &&
                         shardDetails.errors && (
-                            <Accordion key={shardDetails.id}>
+                            <Accordion key={shardDetails.id} defaultExpanded>
                                 <AccordionSummary
                                     expandIcon={
                                         <NavArrowDown

--- a/src/context/fetcher/index.tsx
+++ b/src/context/fetcher/index.tsx
@@ -3,7 +3,7 @@ import { GrantDetailsContextProvider } from './GrantDetails';
 import { TenantContextProvider } from './Tenant';
 
 // This context is to house any "preloading" of stuff we need to do
-//	when the app is being rendered for an Authenticated user.
+//  when the app is being rendered for an Authenticated user.
 //  Anything in here should NOT CHANGE often... if ever.
 function PreFetchDataProvider({ children }: BaseComponentProps) {
     return (

--- a/src/forms/renderers/Overrides/material/controls/MaterialDateControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialDateControl.tsx
@@ -29,23 +29,18 @@ import {
     RankedTester,
     rankWith,
 } from '@jsonforms/core';
-import {
-    MaterialInputControl,
-    MuiInputText,
-} from '@jsonforms/material-renderers';
+import { MuiInputText } from '@jsonforms/material-renderers';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { Box, Hidden, IconButton, Popover, Stack } from '@mui/material';
 import { LocalizationProvider, StaticDatePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { format } from 'date-fns';
 import { Calendar } from 'iconoir-react';
-import {
-    bindPopover,
-    bindTrigger,
-    usePopupState,
-} from 'material-ui-popup-state/hooks';
+import { bindFocus, bindPopover } from 'material-ui-popup-state/hooks';
 import { useIntl } from 'react-intl';
 import { Patterns } from 'types/jsonforms';
+import { CustomMaterialInputControl } from './MaterialInputControl';
+import useDatePickerState from './useDatePickerState';
 
 const INVALID_DATE = 'Invalid Date';
 
@@ -56,10 +51,9 @@ export const Custom_MaterialDateControl = (props: ControlProps) => {
     const { data, id, visible, enabled, path, handleChange, label } = props;
 
     const intl = useIntl();
-    const popupState = usePopupState({
-        variant: 'popover',
-        popupId: `date-picker-${id}`,
-    });
+    const { state, buttonRef, events } = useDatePickerState(
+        `date-picker-${id}`
+    );
 
     const formatDate = (value: Date) => {
         try {
@@ -91,7 +85,11 @@ export const Custom_MaterialDateControl = (props: ControlProps) => {
                 }}
                 direction="row"
             >
-                <MaterialInputControl input={MuiInputText} {...props} />
+                <CustomMaterialInputControl
+                    inputEvents={events}
+                    input={MuiInputText}
+                    {...props}
+                />
                 <Box sx={{ paddingTop: 2 }}>
                     <IconButton
                         aria-label={intl.formatMessage(
@@ -103,14 +101,15 @@ export const Custom_MaterialDateControl = (props: ControlProps) => {
                             }
                         )}
                         disabled={!enabled}
-                        {...bindTrigger(popupState)}
+                        ref={buttonRef}
+                        {...bindFocus(state)}
                     >
                         <Calendar />
                     </IconButton>
                 </Box>
 
                 <Popover
-                    {...bindPopover(popupState)}
+                    {...bindPopover(state)}
                     anchorOrigin={{
                         vertical: 'center',
                         horizontal: 'left',
@@ -129,7 +128,7 @@ export const Custom_MaterialDateControl = (props: ControlProps) => {
                             disabled={!enabled}
                             value={data}
                             onChange={onChange}
-                            onAccept={popupState.close}
+                            onAccept={state.close}
                             closeOnSelect={true}
                             // We don't need an input
                             // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/forms/renderers/Overrides/material/controls/MaterialDateTimeControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialDateTimeControl.tsx
@@ -29,10 +29,7 @@ import {
     RankedTester,
     rankWith,
 } from '@jsonforms/core';
-import {
-    MaterialInputControl,
-    MuiInputText,
-} from '@jsonforms/material-renderers';
+import { MuiInputText } from '@jsonforms/material-renderers';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { Box, Hidden, IconButton, Popover, Stack } from '@mui/material';
 import {
@@ -42,12 +39,10 @@ import {
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { formatRFC3339 } from 'date-fns';
 import { Calendar } from 'iconoir-react';
-import {
-    bindPopover,
-    bindTrigger,
-    usePopupState,
-} from 'material-ui-popup-state/hooks';
+import { bindFocus, bindPopover } from 'material-ui-popup-state/hooks';
 import { useIntl } from 'react-intl';
+import { CustomMaterialInputControl } from './MaterialInputControl';
+import useDatePickerState from './useDatePickerState';
 
 const INVALID_DATE = 'Invalid Date';
 const TIMEZONE_OFFSET = new RegExp('([+-][0-9]{2}:[0-9]{2})$');
@@ -78,10 +73,9 @@ export const Custom_MaterialDateTimeControl = (props: ControlProps) => {
     const { data, id, visible, enabled, path, handleChange, label } = props;
 
     const intl = useIntl();
-    const popupState = usePopupState({
-        variant: 'popover',
-        popupId: `date-time-picker-${id}`,
-    });
+    const { state, buttonRef, events } = useDatePickerState(
+        `date-time-picker-${id}`
+    );
 
     // We have a special handler that formats the date so that
     //  it can handle if there was an error formatting, always
@@ -127,7 +121,11 @@ export const Custom_MaterialDateTimeControl = (props: ControlProps) => {
                 }}
                 direction="row"
             >
-                <MaterialInputControl input={MuiInputText} {...props} />
+                <CustomMaterialInputControl
+                    inputEvents={events}
+                    input={MuiInputText}
+                    {...props}
+                />
                 <Box sx={{ paddingTop: 2 }}>
                     <IconButton
                         aria-label={intl.formatMessage(
@@ -139,14 +137,15 @@ export const Custom_MaterialDateTimeControl = (props: ControlProps) => {
                             }
                         )}
                         disabled={!enabled}
-                        {...bindTrigger(popupState)}
+                        ref={buttonRef}
+                        {...bindFocus(state)}
                     >
                         <Calendar />
                     </IconButton>
                 </Box>
 
                 <Popover
-                    {...bindPopover(popupState)}
+                    {...bindPopover(state)}
                     anchorOrigin={{
                         vertical: 'center',
                         horizontal: 'left',
@@ -166,7 +165,7 @@ export const Custom_MaterialDateTimeControl = (props: ControlProps) => {
                             disabled={!enabled}
                             value={dateTimePickerValue}
                             onChange={onChange}
-                            onAccept={popupState.close}
+                            onAccept={state.close}
                             closeOnSelect={true}
                             // We don't need an input
                             // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/forms/renderers/Overrides/material/controls/MaterialInputControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialInputControl.tsx
@@ -1,0 +1,130 @@
+/* eslint-disable react/jsx-no-leaked-render */
+/*
+  The MIT License
+
+  Copyright (c) 2017-2021 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import {
+    ControlProps,
+    isDescriptionHidden,
+    showAsRequired,
+} from '@jsonforms/core';
+import { useFocus } from '@jsonforms/material-renderers';
+
+import { FormControl, FormHelperText, Hidden, InputLabel } from '@mui/material';
+import merge from 'lodash/merge';
+
+export interface WithInput {
+    input: any;
+}
+
+interface Props {
+    inputEvents: {
+        keyDown: (event?: any) => any;
+        focus: (event?: any) => any;
+    };
+}
+
+// ONLY USE THIS WHEN YOU NEED TO CONTROL FOCUS.
+// Customizations:
+//  1. inputEvents
+//    Allows you to pass in a focus function that fires when the input is focused
+//
+export const CustomMaterialInputControl = (
+    props: Props & ControlProps & WithInput
+) => {
+    const [focused, onFocus, onBlur] = useFocus();
+    const {
+        id,
+        description,
+        errors,
+        label,
+        uischema,
+        visible,
+        required,
+        config,
+        input,
+        inputEvents,
+    } = props;
+    const isValid = errors.length === 0;
+    const appliedUiSchemaOptions = merge({}, config, uischema.options);
+
+    const showDescription = !isDescriptionHidden(
+        visible,
+        description,
+        focused,
+        appliedUiSchemaOptions.showUnfocusedDescription
+    );
+
+    const firstFormHelperText = showDescription
+        ? description
+        : !isValid
+        ? errors
+        : null;
+    const secondFormHelperText = showDescription && !isValid ? errors : null;
+    const InnerComponent = input;
+
+    const onFocusHandler = () => {
+        inputEvents.focus();
+        onFocus();
+    };
+
+    const onKeydown = () => {
+        inputEvents.keyDown();
+    };
+
+    return (
+        <Hidden xsUp={!visible}>
+            <FormControl
+                fullWidth={!appliedUiSchemaOptions.trim}
+                onFocus={onFocusHandler}
+                onBlur={onBlur}
+                id={id}
+                variant="standard"
+                onKeyDown={onKeydown}
+            >
+                <InputLabel
+                    htmlFor={`${id}-input`}
+                    error={!isValid}
+                    required={showAsRequired(
+                        required ?? false,
+                        appliedUiSchemaOptions.hideRequiredAsterisk
+                    )}
+                >
+                    {label}
+                </InputLabel>
+                <InnerComponent
+                    {...props}
+                    id={`${id}-input`}
+                    isValid={isValid}
+                    visible={visible}
+                />
+                <FormHelperText error={!isValid && !showDescription}>
+                    {firstFormHelperText}
+                </FormHelperText>
+                <FormHelperText error={!isValid}>
+                    {secondFormHelperText}
+                </FormHelperText>
+            </FormControl>
+        </Hidden>
+    );
+};

--- a/src/forms/renderers/Overrides/material/controls/MaterialTimeControl.tsx
+++ b/src/forms/renderers/Overrides/material/controls/MaterialTimeControl.tsx
@@ -29,25 +29,20 @@ import {
     RankedTester,
     rankWith,
 } from '@jsonforms/core';
-import {
-    MaterialInputControl,
-    MuiInputText,
-} from '@jsonforms/material-renderers';
+import { MuiInputText } from '@jsonforms/material-renderers';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { Box, Hidden, IconButton, Popover, Stack } from '@mui/material';
 import { LocalizationProvider, StaticTimePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { format } from 'date-fns';
 import { Clock } from 'iconoir-react';
-import {
-    bindPopover,
-    bindTrigger,
-    usePopupState,
-} from 'material-ui-popup-state/hooks';
+import { bindFocus, bindPopover } from 'material-ui-popup-state/hooks';
 import { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { Patterns } from 'types/jsonforms';
 import { hasLength } from 'utils/misc-utils';
+import { CustomMaterialInputControl } from './MaterialInputControl';
+import useDatePickerState from './useDatePickerState';
 
 const INVALID_TIME = 'Invalid Time';
 
@@ -58,10 +53,9 @@ export const Custom_MaterialTimeControl = (props: ControlProps) => {
     const { data, id, visible, enabled, path, handleChange, label } = props;
 
     const intl = useIntl();
-    const popupState = usePopupState({
-        variant: 'popover',
-        popupId: `time-picker-${id}`,
-    });
+    const { state, buttonRef, events } = useDatePickerState(
+        `time-picker-${id}`
+    );
 
     // Need to set the default time for both create and edit
     //  This attempts to parse the current value and use it
@@ -120,7 +114,11 @@ export const Custom_MaterialTimeControl = (props: ControlProps) => {
                 }}
                 direction="row"
             >
-                <MaterialInputControl input={MuiInputText} {...props} />
+                <CustomMaterialInputControl
+                    inputEvents={events}
+                    input={MuiInputText}
+                    {...props}
+                />
                 <Box sx={{ paddingTop: 2 }}>
                     <IconButton
                         aria-label={intl.formatMessage(
@@ -132,14 +130,15 @@ export const Custom_MaterialTimeControl = (props: ControlProps) => {
                             }
                         )}
                         disabled={!enabled}
-                        {...bindTrigger(popupState)}
+                        ref={buttonRef}
+                        {...bindFocus(state)}
                     >
                         <Clock />
                     </IconButton>
                 </Box>
 
                 <Popover
-                    {...bindPopover(popupState)}
+                    {...bindPopover(state)}
                     anchorOrigin={{
                         vertical: 'center',
                         horizontal: 'left',
@@ -156,7 +155,7 @@ export const Custom_MaterialTimeControl = (props: ControlProps) => {
                             disabled={!enabled}
                             value={timePickerValue}
                             onChange={onChange}
-                            onAccept={popupState.close}
+                            onAccept={state.close}
                             closeOnSelect={true}
                             // We don't need an input
                             // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/forms/renderers/Overrides/material/controls/useDatePickerState.ts
+++ b/src/forms/renderers/Overrides/material/controls/useDatePickerState.ts
@@ -1,0 +1,36 @@
+import { usePopupState } from 'material-ui-popup-state/hooks';
+import { useMemo, useRef } from 'react';
+
+// TODO (accessibility) Setting the `disableAutoFocus` means this pop up is not
+//   accessible at all. We do this because it makes the showing/hiding when clicking
+//   make a lot more sense. When auto focus is on if you click away from the picker
+//   it does not close.
+function useDatePickerState(key: string) {
+    const state = usePopupState({
+        variant: 'popover',
+        popupId: key,
+        disableAutoFocus: true,
+    });
+    const buttonRef = useRef(null);
+
+    const events = useMemo(() => {
+        return {
+            focus: () => {
+                state.open(buttonRef.current);
+            },
+            keyDown: () => {
+                if (state.isOpen) {
+                    state.close();
+                }
+            },
+        };
+    }, [state]);
+
+    return {
+        state,
+        buttonRef,
+        events,
+    };
+}
+
+export default useDatePickerState;


### PR DESCRIPTION
## Changes

These changes were pulled from the old branch that handle details page

485: Adding a renderer that shows a check box next to items selected
475: Open the date/time/date-time picker open calendar by default
474: Changed how we fetch the stats to use the proper GMT timezone
Tweak: Update the icon color in alert box as Icon Noir's much thinner lines made them hard to see when colored 

## Tests

Manually tested

## Issues

Fixes https://github.com/estuary/ui/issues/485
Fixes https://github.com/estuary/ui/issues/475
Fixes https://github.com/estuary/ui/issues/474

## Content

N/A

## Screenshots

See https://github.com/estuary/ui/pull/464 for details

![image](https://user-images.githubusercontent.com/270078/220727703-72d83071-d448-4514-86c9-2ffb7bb88b6d.png)
