### PR TITLE
refactor: Suffix new captures with the name of the connector being used

### DIFF
--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -13,6 +13,7 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import { useClient } from 'hooks/supabase-swr';
+import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import LogRocket from 'logrocket';
 import { useCallback, useMemo } from 'react';
 import { CustomEvents } from 'services/logrocket';
@@ -101,12 +102,22 @@ function useDiscoverCapture(
     const messagePrefix = useFormStateStore_messagePrefix();
 
     // Details Form Store
-    const entityName = useDetailsForm_details_entityName();
+    const formEntityName = useDetailsForm_details_entityName();
     const detailsFormsHasErrors = useDetailsForm_errorsExist();
     const imageConnectorId = useDetailsForm_connectorImage_connectorId();
     const imageConnectorTagId = useDetailsForm_connectorImage_id();
     const imagePath = useDetailsForm_connectorImage_imagePath();
     const setDraftedEntityName = useDetailsForm_setDraftedEntityName();
+
+    const connectorDetails = useConnectorWithTagDetail(null, imageConnectorId);
+    const tagDetails = connectorDetails.connectorTags.find(
+        (tag) => tag.id === imageConnectorTagId
+    );
+
+    const entityName =
+        workflow === 'capture_create' && tagDetails
+            ? `${formEntityName}/${tagDetails.image_name.split('/').at(-1)}`
+            : formEntityName;
 
     // Endpoint Config Store
     const setEncryptedEndpointConfig =


### PR DESCRIPTION
## Changes

Ever since we stopped having the backend suffix new capture names with the connector name, we've been running into an issue where people will not realize that a capture name of `acmeCo/pizza` will create a capture called `acmeCo/pizza`, and a bunch of collections called `acmeCo/meatlovers`, `acmeCo/pepperoni`. 

Instead what you would expect is `acmeCo/pizza/hawaiian`, etc. This change introduces that expected behavior by suffixing new capture names with the name of the connector, so a capture of `acmeCo/pizza` will actually create a capture of `acmeCo/pizza/source-pizza` and collections of `acmeCo/pizza/peppers-and-onions`, as expected. 

**NOTE:** Currently I'm unable to test this locally because there is some unknown issue with later versions of the supabase CLI, and earlier versions no longer work due to missing docker images at the registry. So this is as yet untested