### PR TITLE
Omit tasks under demo prefix from the existing task check

### DIFF
--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -152,7 +152,8 @@ const getLiveSpecs_existingTasks = (
             count: 'exact',
         })
         .eq('connector_id', connectorId)
-        .not('catalog_name', 'ilike', 'ops/%');
+        .not('catalog_name', 'ilike', 'ops/%')
+        .not('catalog_name', 'ilike', 'demo/%');
 
     queryBuilder = distributedTableFilter<
         CaptureQueryWithSpec | MaterializationQueryWithSpec

--- a/src/components/connectors/card/Logo.tsx
+++ b/src/components/connectors/card/Logo.tsx
@@ -4,9 +4,18 @@ interface Props {
     imageSrc: string | null | undefined;
     maxHeight?: number;
     padding?: string | number;
+    unknownConnectorIconConfig?: {
+        width: string | number;
+        fontSize: string | number;
+    };
 }
 
-function ConnectorLogo({ imageSrc, maxHeight, padding }: Props) {
+function ConnectorLogo({
+    imageSrc,
+    maxHeight,
+    padding,
+    unknownConnectorIconConfig,
+}: Props) {
     if (imageSrc) {
         return (
             <img
@@ -21,7 +30,14 @@ function ConnectorLogo({ imageSrc, maxHeight, padding }: Props) {
             />
         );
     } else {
-        return <NetworkLeft style={{ fontSize: '3rem' }} />;
+        return (
+            <NetworkLeft
+                style={{
+                    width: unknownConnectorIconConfig?.width,
+                    fontSize: unknownConnectorIconConfig?.fontSize ?? '3rem',
+                }}
+            />
+        );
     }
 }
 

--- a/src/components/shared/Entity/ExistingEntityCards/Cards/Existing.tsx
+++ b/src/components/shared/Entity/ExistingEntityCards/Cards/Existing.tsx
@@ -73,6 +73,7 @@ function ExistingEntityCard({ queryData }: Props) {
                         imageSrc={queryData.image}
                         maxHeight={35}
                         padding="0 0.5rem"
+                        unknownConnectorIconConfig={{ width: 51, fontSize: 24 }}
                     />
                 </Box>
 


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Omit tasks under the `demo/` prefix from the existing task check. Currently, this check is only performed in the materialization creation workflow.

1. Reduce the size of the icon displayed on an existing entity card when the logo associated with a connector is unspecified.

## Tests

1. View the "existing entity check" page for a connector with an unspecified logo URL in the database and confirm that the unknown connector icon is styled in the same fashion as the create new entity card icon.

1. Create a materialization under a new prefix (e.g., `melk/demo_test/`), adjust the `live_specs` query that computes the list of existing entities to exclude the new prefix, visit the "existing entity check" page and confirm that the new materialization does not appear in the list of existing entities.

## Issues

The issues directly below are completely resolved by this PR:
#519 

## Screenshots

**Reduced Unknown Connector Icon | Light**

<img width="956" alt="pr_screenshot-521-omit_demo_tasks_and_reduce_icon-unknown_connector-light" src="https://user-images.githubusercontent.com/77648584/225681589-69cfa2a2-fa61-4890-b053-834c910bf69f.PNG">

<br />

**Reduced Unknown Connector Icon | Light**

<img width="957" alt="pr_screenshot-521-omit_demo_tasks_and_reduce_icon-unknown_connector-dark" src="https://user-images.githubusercontent.com/77648584/225681682-7b612f46-a0a3-450b-a615-ea2e38d91232.PNG">