### PR TITLE
prod: align task spec bindings with binding selector

### DIFF
--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -7,6 +7,7 @@ import { isEmpty } from 'lodash';
 import { CallSupabaseResponse } from 'services/supabase';
 import { ResourceConfigDictionary } from 'stores/ResourceConfig/types';
 import { EntityWithCreateWorkflow, Schema } from 'types';
+import { hasLength } from 'utils/misc-utils';
 import { ConnectorConfig } from '../../flow_deps/flow';
 
 // TODO (typing): Narrow the return type for this function.
@@ -29,7 +30,9 @@ export const generateTaskSpec = (
         const collectionNameProp =
             entityType === 'capture' ? 'target' : 'source';
 
-        Object.keys(resourceConfigs).forEach((collectionName) => {
+        const boundCollectionNames = Object.keys(resourceConfigs);
+
+        boundCollectionNames.forEach((collectionName) => {
             const resourceConfig = resourceConfigs[collectionName].data;
 
             const existingBindingIndex = draftSpec.bindings.findIndex(
@@ -49,6 +52,16 @@ export const generateTaskSpec = (
                 });
             }
         });
+
+        if (hasLength(draftSpec.bindings)) {
+            const filteredBindings = draftSpec.bindings.filter((binding: any) =>
+                boundCollectionNames.includes(binding[collectionNameProp])
+            );
+
+            draftSpec.bindings = filteredBindings;
+        }
+    } else {
+        draftSpec.bindings = [];
     }
 
     return draftSpec;


### PR DESCRIPTION
## Changes

Ensure a binding removed via the binding selector in the UI is removed from the task specification.

## Tests

Create a capture without manipulating form data after discovery.

Create a capture and remove a single binding after discovery.

Create a capture and remove multiple bindings after discovery.

Create a capture and remove all bindings after discovery.

Create a capture, remove a single binding, and manipulate data in the resource config form at least once after discovery.

Create a capture, remove multiple bindings, and manipulate data in the resource config form at least once after discovery.

**NOTE:** The tests described above were performed for all workflows, replacing _discovery_ with _initial form submission_ for materialization workflows.

## Issues

The issues directly below are advanced by this PR:
#510 
