### PR TITLE
prod: prune unbound discovered collections at end of workflows only

### DIFF
--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -91,7 +91,7 @@ function Row({ collection, task, workflow, disabled, draftId }: RowProps) {
                 setRestrictedDiscoveredCollections(collection);
             }
 
-            if (draftId) {
+            if (draftId && !discoveredCollections?.includes(collection)) {
                 void deleteDraftSpecsByCatalogName(
                     draftId,
                     'collection',
@@ -162,6 +162,7 @@ function BindingSelector({
     const setCurrentCollection = useResourceConfig_setCurrentCollection();
 
     const collections = useResourceConfig_collections();
+    const discoveredCollections = useResourceConfig_discoveredCollections();
 
     const resourceConfig = useResourceConfig_resourceConfig();
 
@@ -177,11 +178,19 @@ function BindingSelector({
 
             removeAllCollections(workflow, task);
 
-            if (draftId && collections && collections.length > 0) {
+            const publishedCollections =
+                discoveredCollections && collections
+                    ? collections.filter(
+                          (collection) =>
+                              !discoveredCollections.includes(collection)
+                      )
+                    : [];
+
+            if (draftId && publishedCollections.length > 0) {
                 void deleteDraftSpecsByCatalogName(
                     draftId,
                     'collection',
-                    collections,
+                    publishedCollections,
                     'remove'
                 );
             }


### PR DESCRIPTION
## Changes

Prevent a discovered binding removed via the binding selector in the UI from being deleted from the draft. This prevents the collection from being bound to the collection a subsequent time in a given workflow. Unbound, discovered collections should only be pruned at the end of a workflow, prompted by a click of the _Save and Publish_ CTA.

## Tests

_Describe the approach to testing._
