### PR TITLE
prod: adjust end of workflow collection pruning approach

### DIFF
--- a/src/api/draftSpecs.ts
+++ b/src/api/draftSpecs.ts
@@ -184,8 +184,8 @@ export const deleteDraftSpecsByCatalogName = async (
 
         // TODO (unbound collections) This is hacky but it works
         //  We call this in 3 places (as of March 2023) and only one checks
-        //  the response. It only cares if this failed to make it pass
-        //  back the error directly. This way the typing is consistent.
+        //  the response. It only checks for `error` so making this always return
+        //  back an object with error. This way the typing is consistent.
         return {
             error: errors[0] ? errors[0].error : res[0].error,
         };

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -92,12 +92,9 @@ function Row({ collection, task, workflow, disabled, draftId }: RowProps) {
             }
 
             if (draftId) {
-                void deleteDraftSpecsByCatalogName(
-                    draftId,
-                    'collection',
-                    [collection],
-                    'remove'
-                );
+                void deleteDraftSpecsByCatalogName(draftId, 'collection', [
+                    collection,
+                ]);
             }
         },
     };
@@ -181,8 +178,7 @@ function BindingSelector({
                 void deleteDraftSpecsByCatalogName(
                     draftId,
                     'collection',
-                    collections,
-                    'remove'
+                    collections
                 );
             }
         },

--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mui/material';
 import {
     deleteDraftSpecsByCatalogName,
-    getDraftSpecsBySpecType,
+    getDraftSpecsBySpecTypeReduced,
 } from 'api/draftSpecs';
 import { createPublication } from 'api/publications';
 import {
@@ -151,7 +151,7 @@ function EntityCreateSave({ disabled, dryRun, onFailure, logEvent }: Props) {
 
         if (draftId) {
             if (collections && collections.length > 0) {
-                const draftSpecResponse = await getDraftSpecsBySpecType(
+                const draftSpecResponse = await getDraftSpecsBySpecTypeReduced(
                     draftId,
                     'collection'
                 );
@@ -177,8 +177,7 @@ function EntityCreateSave({ disabled, dryRun, onFailure, logEvent }: Props) {
                         await deleteDraftSpecsByCatalogName(
                             draftId,
                             'collection',
-                            unboundCollections,
-                            'remove'
+                            unboundCollections
                         );
                     if (deleteDraftSpecsResponse.error) {
                         return onFailure({

--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -1,5 +1,8 @@
 import { Button } from '@mui/material';
-import { deleteDraftSpecsByCatalogName } from 'api/draftSpecs';
+import {
+    deleteDraftSpecsByCatalogName,
+    getDraftSpecsBySpecType,
+} from 'api/draftSpecs';
 import { createPublication } from 'api/publications';
 import {
     useEditorStore_id,
@@ -148,20 +151,45 @@ function EntityCreateSave({ disabled, dryRun, onFailure, logEvent }: Props) {
 
         if (draftId) {
             if (collections && collections.length > 0) {
-                const deleteDraftSpecsResponse =
-                    await deleteDraftSpecsByCatalogName(
-                        draftId,
-                        'collection',
-                        collections,
-                        'preserve'
-                    );
-                if (deleteDraftSpecsResponse.error) {
+                const draftSpecResponse = await getDraftSpecsBySpecType(
+                    draftId,
+                    'collection'
+                );
+
+                if (draftSpecResponse.error) {
                     return onFailure({
                         error: {
                             title: 'captureEdit.generate.failedErrorTitle',
-                            error: deleteDraftSpecsResponse.error,
+                            error: draftSpecResponse.error,
                         },
                     });
+                } else if (
+                    draftSpecResponse.data &&
+                    draftSpecResponse.data.length > 0
+                ) {
+                    const unboundCollections = draftSpecResponse.data
+                        .map((query) => query.catalog_name)
+                        .filter(
+                            (collection) => !collections.includes(collection)
+                        );
+
+                    if (unboundCollections.length > 0) {
+                        const deleteDraftSpecsResponse =
+                            await deleteDraftSpecsByCatalogName(
+                                draftId,
+                                'collection',
+                                unboundCollections,
+                                'remove'
+                            );
+                        if (deleteDraftSpecsResponse.error) {
+                            return onFailure({
+                                error: {
+                                    title: 'captureEdit.generate.failedErrorTitle',
+                                    error: deleteDraftSpecsResponse.error,
+                                },
+                            });
+                        }
+                    }
                 }
             }
 

--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -173,22 +173,20 @@ function EntityCreateSave({ disabled, dryRun, onFailure, logEvent }: Props) {
                             (collection) => !collections.includes(collection)
                         );
 
-                    if (unboundCollections.length > 0) {
-                        const deleteDraftSpecsResponse =
-                            await deleteDraftSpecsByCatalogName(
-                                draftId,
-                                'collection',
-                                unboundCollections,
-                                'remove'
-                            );
-                        if (deleteDraftSpecsResponse.error) {
-                            return onFailure({
-                                error: {
-                                    title: 'captureEdit.generate.failedErrorTitle',
-                                    error: deleteDraftSpecsResponse.error,
-                                },
-                            });
-                        }
+                    const deleteDraftSpecsResponse =
+                        await deleteDraftSpecsByCatalogName(
+                            draftId,
+                            'collection',
+                            unboundCollections,
+                            'remove'
+                        );
+                    if (deleteDraftSpecsResponse.error) {
+                        return onFailure({
+                            error: {
+                                title: 'captureEdit.generate.failedErrorTitle',
+                                error: deleteDraftSpecsResponse.error,
+                            },
+                        });
                     }
                 }
             }


### PR DESCRIPTION
## Changes

Adjust the collection pruning approach used by the _Save and Publish_ CTA as follows: obtain a list of all collections that belong to the draft, filter out the collections that are bound to the given task, and explicitly delete the collections that are determined to **not** be bound to the task.

## Tests

_Describe the approach to testing._
