### PR TITLE
prod: use unique identifier for entity table row key

### DIFF
--- a/src/components/tables/Captures/Rows.tsx
+++ b/src/components/tables/Captures/Rows.tsx
@@ -68,7 +68,7 @@ function Row({ isSelected, setRow, row, stats, showEntityStatus }: RowProps) {
         <>
             <TableRow
                 hover
-                onClick={() => handlers.clickRow(row.last_pub_id)}
+                onClick={() => handlers.clickRow(row.id)}
                 selected={isSelected}
                 sx={getEntityTableRowSx(theme, detailsExpanded)}
             >
@@ -178,8 +178,8 @@ function Rows({ data, showEntityStatus }: RowsProps) {
                 <Row
                     stats={stats}
                     row={row}
-                    key={row.last_pub_id}
-                    isSelected={selected.has(row.last_pub_id)}
+                    key={row.id}
+                    isSelected={selected.has(row.id)}
                     setRow={setRow}
                     showEntityStatus={showEntityStatus}
                 />

--- a/src/components/tables/Materializations/Rows.tsx
+++ b/src/components/tables/Materializations/Rows.tsx
@@ -71,7 +71,7 @@ function Row({ isSelected, setRow, row, stats, showEntityStatus }: RowProps) {
         <>
             <TableRow
                 hover
-                onClick={() => handlers.clickRow(row.last_pub_id)}
+                onClick={() => handlers.clickRow(row.id)}
                 selected={isSelected}
                 sx={getEntityTableRowSx(theme, detailsExpanded)}
             >
@@ -181,8 +181,8 @@ function Rows({ data, showEntityStatus }: RowsProps) {
                 <Row
                     stats={stats}
                     row={row}
-                    key={row.last_pub_id}
-                    isSelected={selected.has(row.last_pub_id)}
+                    key={row.id}
+                    isSelected={selected.has(row.id)}
                     setRow={setRow}
                     showEntityStatus={showEntityStatus}
                 />


### PR DESCRIPTION
## Changes

Use the live spec ID as the key for entity table rows.

## Issues

The issues directly below are completely resolved by this PR:
#533 
