### PR TITLE
Omit demo tasks from existing entity check hydrator

### DIFF
--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -269,7 +269,7 @@ const getLiveSpecsByCatalogNames = async (
 const getLiveSpecsByConnectorId = async (
     specType: EntityWithCreateWorkflow,
     connectorId: string,
-    prefixFilter?: string
+    prefixFilters?: string[]
 ) => {
     const taskColumns: string =
         specType === 'capture'
@@ -284,12 +284,14 @@ const getLiveSpecsByConnectorId = async (
         .eq('connector_id', connectorId)
         .eq('spec_type', specType);
 
-    if (prefixFilter) {
-        queryBuilder = queryBuilder.not(
-            'catalog_name',
-            'ilike',
-            `${prefixFilter}/%`
-        );
+    if (prefixFilters && prefixFilters.length > 0) {
+        prefixFilters.forEach((prefix) => {
+            queryBuilder = queryBuilder.not(
+                'catalog_name',
+                'ilike',
+                `${prefix}/%`
+            );
+        });
     }
 
     const data = await queryBuilder.then(

--- a/src/components/shared/Entity/ExistingEntityCards/Store/create.ts
+++ b/src/components/shared/Entity/ExistingEntityCards/Store/create.ts
@@ -61,7 +61,7 @@ const getInitialState = (
                 const { data, error } = await getLiveSpecsByConnectorId(
                     entityType,
                     connectorId,
-                    'ops'
+                    ['ops', 'demo']
                 );
 
                 if (error) {


### PR DESCRIPTION
## Changes

Omit tasks under the `demo/` prefix from the existing task check performed by the store hydrator. Currently, this check is only performed in the materialization creation workflow.

## Tests

_Describe the approach to testing._

## Issues

The issues directly below are completely resolved by this PR:
#540 
