### PR TITLE
Fix week stats queries

### DIFF
--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -75,13 +75,13 @@ const getStatsByName = (names: string[], filter?: StatsFilter) => {
         case 'thisWeek':
             queryBuilder = queryBuilder
                 .gte('ts', formatToGMT(startOfWeek(today)))
-                .lte('ts', formatToGMT(endOfWeek(today)))
+                .lt('ts', formatToGMT(endOfWeek(today)))
                 .eq('grain', 'daily');
             break;
         case 'lastWeek':
             queryBuilder = queryBuilder
                 .gte('ts', formatToGMT(startOfWeek(lastWeek)))
-                .lte('ts', formatToGMT(endOfWeek(lastWeek)))
+                .lt('ts', formatToGMT(endOfWeek(lastWeek)))
                 .eq('grain', 'daily');
             break;
 


### PR DESCRIPTION
## Changes

Switch from `lte` and `lt` in the query. The "end of week" is considered 

## Tests

Manually tested

## Issues

Fixes https://github.com/estuary/ui/issues/539

## Content

N/A 

## Screenshots

This week
![image](https://user-images.githubusercontent.com/270078/229846902-72f1ebda-28fb-452c-a348-d150e6d143c0.png)

Last week
![image](https://user-images.githubusercontent.com/270078/229846958-b64fc783-4226-47f1-8cbb-b03ec630710c.png)

