### PR TITLE
moves location of security headers

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -31,14 +31,9 @@ http {
 
     # X-Frame-Options is to prevent from clickJacking attack
     add_header X-Frame-Options SAMEORIGIN;
-    
+
     # disable content-type sniffing on some browsers.
     add_header X-Content-Type-Options nosniff;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options: SAMEORIGIN always;
-    add_header X-Content-Type-Options: nosniff always;
-    add_header Referrer-Policy: no-referrer-when-downgrade always;
-    add_header Permissions-Policy "geolocation=(), microphone=(), camera=() always";
 
 
     #gzip  on;
@@ -58,6 +53,11 @@ http {
             index  index.html index.htm;
             try_files $uri $uri/ /index.html;
             add_header Cache-Control 'no-cache, no-store, must-revalidate';
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header X-Frame-Options: SAMEORIGIN always;
+            add_header X-Content-Type-Options: nosniff always;
+            add_header Referrer-Policy: no-referrer-when-downgrade always;
+            add_header Permissions-Policy "geolocation=(), microphone=(), camera=() always";
         }
 
         location /static {
@@ -79,7 +79,7 @@ http {
             return 503;
         }
         error_page 503 @maintenance;
-        
+
         location @maintenance {
             root /usr/share/nginx/html;
             rewrite ^(.*)$ /503.html break;


### PR DESCRIPTION
## Changes

This fixes the location of the security headers to the location block. I've verified the headers work locally. 

## Tests

```
curl -I localhost:8080
HTTP/1.1 200 OK
Server: nginx/1.23.4
Date: Wed, 05 Apr 2023 20:04:49 GMT
Content-Type: text/html
Content-Length: 2368
Last-Modified: Wed, 05 Apr 2023 13:47:42 GMT
Connection: keep-alive
ETag: "642d7bfe-940"
Cache-Control: no-cache, no-store, must-revalidate
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Frame-Options:: SAMEORIGIN
X-Content-Type-Options:: nosniff
Referrer-Policy:: no-referrer-when-downgrade
Permissions-Policy: geolocation=(), microphone=(), camera=() always
Accept-Ranges: bytes
```

## Issues

Related: https://github.com/estuary/ops/issues/310

## Content

No content changes. 

## Screenshots

No changed UI