### PR TITLE
formatting for security headers

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -54,9 +54,9 @@ http {
             try_files $uri $uri/ /index.html;
             add_header Cache-Control 'no-cache, no-store, must-revalidate';
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-            add_header X-Frame-Options: SAMEORIGIN always;
-            add_header X-Content-Type-Options: nosniff always;
-            add_header Referrer-Policy: no-referrer-when-downgrade always;
+            add_header X-Frame-Options SAMEORIGIN always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy no-referrer-when-downgrade always;
             add_header Permissions-Policy "geolocation=(), microphone=(), camera=() always";
         }
 


### PR DESCRIPTION
## Changes

This removes some superfluous colons that were causing the headers to not be used properly. This does not include CSP protections which we'll have to do once we identify all the asset locations. 

## Tests
Against a container running on localhost...

```
HTTP/1.1 200 OK
Server: nginx/1.23.4
Date: Thu, 06 Apr 2023 14:56:55 GMT
Content-Type: text/html
Content-Length: 2368
Last-Modified: Wed, 05 Apr 2023 13:47:42 GMT
Connection: keep-alive
ETag: "642d7bfe-940"
Cache-Control: no-cache, no-store, must-revalidate
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Referrer-Policy: no-referrer-when-downgrade
Permissions-Policy: geolocation=(), microphone=(), camera=() always
Accept-Ranges: bytes
```
## Issues

https://github.com/estuary/ops/issues/310

## Content

No content changes

## Screenshots

N/A
