### PR TITLE
Gitpod dialog UX Tweaks 1

### DIFF
--- a/src/components/derivation/Create/index.tsx
+++ b/src/components/derivation/Create/index.tsx
@@ -16,18 +16,18 @@ function DerivationCreate() {
     // it's closed, so you don't reopen it and have your previous
     // selections still selected, which would be unexpected.
     const [newCollectionKey, setNewCollectionKey] = useState(0);
-    const [showBackdrop, setShowBackdrop] = useState(false);
+    const [showConfirmation, setShowConfirmation] = useState(false);
 
     const closeDialog = () => {
         navigate(authenticatedRoutes.collections.fullPath);
-        setShowBackdrop(false);
+        setShowConfirmation(false);
         setNewCollectionKey((k) => k + 1);
     };
 
     return (
         <Dialog
             open
-            fullWidth={!showBackdrop}
+            fullWidth={!showConfirmation}
             maxWidth="lg"
             onClose={closeDialog}
             aria-labelledby={ARIA_LABEL_ID}
@@ -36,7 +36,7 @@ function DerivationCreate() {
                 <FormattedMessage id="newTransform.modal.title" />
             </DialogTitleWithClose>
             <DialogContent>
-                <Collapse in={showBackdrop}>
+                <Collapse in={showConfirmation}>
                     <AlertBox
                         short
                         severity="info"
@@ -49,12 +49,12 @@ function DerivationCreate() {
                         <FormattedMessage id="newTransform.info.gitPodWindowMessage" />
                     </AlertBox>
                 </Collapse>
-                <Collapse in={!showBackdrop}>
+                <Collapse in={!showConfirmation}>
                     <TransformationCreate
                         key={newCollectionKey}
                         postWindowOpen={(gitPodWindow) => {
                             if (gitPodWindow) {
-                                setShowBackdrop(true);
+                                setShowConfirmation(true);
                             }
                         }}
                     />

--- a/src/components/derivation/Create/index.tsx
+++ b/src/components/derivation/Create/index.tsx
@@ -1,5 +1,6 @@
-import { Dialog, DialogContent } from '@mui/material';
+import { Collapse, Dialog, DialogContent, Typography } from '@mui/material';
 import { authenticatedRoutes } from 'app/routes';
+import AlertBox from 'components/shared/AlertBox';
 import DialogTitleWithClose from 'components/shared/Dialog/TitleWithClose';
 import TransformationCreate from 'components/transformation/create';
 import { useState } from 'react';
@@ -15,16 +16,18 @@ function DerivationCreate() {
     // it's closed, so you don't reopen it and have your previous
     // selections still selected, which would be unexpected.
     const [newCollectionKey, setNewCollectionKey] = useState(0);
+    const [showBackdrop, setShowBackdrop] = useState(false);
 
     const closeDialog = () => {
         navigate(authenticatedRoutes.collections.fullPath);
+        setShowBackdrop(false);
         setNewCollectionKey((k) => k + 1);
     };
 
     return (
         <Dialog
             open
-            fullWidth
+            fullWidth={!showBackdrop}
             maxWidth="lg"
             onClose={closeDialog}
             aria-labelledby={ARIA_LABEL_ID}
@@ -33,7 +36,29 @@ function DerivationCreate() {
                 <FormattedMessage id="newTransform.modal.title" />
             </DialogTitleWithClose>
             <DialogContent>
-                <TransformationCreate key={newCollectionKey} />
+                <Collapse in={showBackdrop}>
+                    <AlertBox
+                        short
+                        severity="info"
+                        title={
+                            <Typography>
+                                <FormattedMessage id="newTransform.info.gitPodWindowTitle" />
+                            </Typography>
+                        }
+                    >
+                        <FormattedMessage id="newTransform.info.gitPodWindowMessage" />
+                    </AlertBox>
+                </Collapse>
+                <Collapse in={!showBackdrop}>
+                    <TransformationCreate
+                        key={newCollectionKey}
+                        postWindowOpen={(gitPodWindow) => {
+                            if (gitPodWindow) {
+                                setShowBackdrop(true);
+                            }
+                        }}
+                    />
+                </Collapse>
             </DialogContent>
         </Dialog>
     );

--- a/src/components/derivation/Create/index.tsx
+++ b/src/components/derivation/Create/index.tsx
@@ -53,6 +53,8 @@ function DerivationCreate() {
                     <TransformationCreate
                         key={newCollectionKey}
                         postWindowOpen={(gitPodWindow) => {
+                            // If there is a window object we know the browser at least let us open it up.
+                            //  This does not 100% prove that GitPod loaded correctly
                             if (gitPodWindow) {
                                 setShowConfirmation(true);
                             }

--- a/src/components/derivation/Create/index.tsx
+++ b/src/components/derivation/Create/index.tsx
@@ -1,10 +1,12 @@
-import { Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { Dialog, DialogContent } from '@mui/material';
 import { authenticatedRoutes } from 'app/routes';
+import DialogTitleWithClose from 'components/shared/Dialog/TitleWithClose';
 import TransformationCreate from 'components/transformation/create';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
+const ARIA_LABEL_ID = 'derivation-create-dialog';
 function DerivationCreate() {
     const navigate = useNavigate();
 
@@ -14,19 +16,22 @@ function DerivationCreate() {
     // selections still selected, which would be unexpected.
     const [newCollectionKey, setNewCollectionKey] = useState(0);
 
+    const closeDialog = () => {
+        navigate(authenticatedRoutes.collections.fullPath);
+        setNewCollectionKey((k) => k + 1);
+    };
+
     return (
         <Dialog
             open
             fullWidth
             maxWidth="lg"
-            onClose={() => {
-                navigate(authenticatedRoutes.collections.fullPath);
-                setNewCollectionKey((k) => k + 1);
-            }}
+            onClose={closeDialog}
+            aria-labelledby={ARIA_LABEL_ID}
         >
-            <DialogTitle>
+            <DialogTitleWithClose id={ARIA_LABEL_ID} onClose={closeDialog}>
                 <FormattedMessage id="newTransform.modal.title" />
-            </DialogTitle>
+            </DialogTitleWithClose>
             <DialogContent>
                 <TransformationCreate key={newCollectionKey} />
             </DialogContent>

--- a/src/components/shared/Dialog/TitleWithClose.tsx
+++ b/src/components/shared/Dialog/TitleWithClose.tsx
@@ -1,0 +1,37 @@
+import { DialogTitle, IconButton } from '@mui/material';
+import { Cancel } from 'iconoir-react';
+import { useIntl } from 'react-intl';
+import { BaseComponentProps } from 'types';
+
+export interface DialogTitleProps extends BaseComponentProps {
+    id: string;
+    onClose: () => void;
+}
+
+function DialogTitleWithClose({
+    children,
+    onClose,
+    ...other
+}: DialogTitleProps) {
+    const intl = useIntl();
+
+    return (
+        <DialogTitle {...other}>
+            {children}
+            <IconButton
+                aria-label={intl.formatMessage({ id: 'cta.close' })}
+                onClick={onClose}
+                sx={{
+                    color: (theme) => theme.palette.text.primary,
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                }}
+            >
+                <Cancel />
+            </IconButton>
+        </DialogTitle>
+    );
+}
+
+export default DialogTitleWithClose;

--- a/src/components/transformation/create/generateTemplate.ts
+++ b/src/components/transformation/create/generateTemplate.ts
@@ -16,6 +16,8 @@ const makeNameSafe = (source: string) => {
     //  Do we remove only the tenant portion of the name?
     //      or
     //  Do we remove everything up to the last part of the path
+    //      or
+    //  Do we make it some combo of those and add something to ensure it is unique for a user
     const base = stripPathing(source);
 
     return { name, base };

--- a/src/components/transformation/create/generateTemplate.ts
+++ b/src/components/transformation/create/generateTemplate.ts
@@ -2,6 +2,7 @@ import { stripPathing } from 'utils/misc-utils';
 
 export type DerivationLanguage = 'sql' | 'typescript';
 
+// Constants for part of the templates down below
 const key = ['/your_key'];
 const schema = {
     type: 'object',
@@ -9,7 +10,8 @@ const schema = {
     required: ['your_key'],
 };
 
-const makeNameSafe = (source: string) => {
+// Need to make sure whatever name we pass in can be used in a file name
+const makeNameSafeForFiles = (source: string) => {
     return source.replaceAll(/\//g, '_');
 };
 
@@ -18,7 +20,7 @@ const generateSqlTemplate = (
     selectedCollectionSet: Set<string>
 ) => {
     const transforms = Array.from(selectedCollectionSet).map((source) => {
-        const name = makeNameSafe(source);
+        const name = makeNameSafeForFiles(source);
         return {
             name: `${name}`,
             source,
@@ -45,7 +47,7 @@ const generateTsTemplate = (
     selectedCollectionSet: Set<string>
 ) => {
     const transforms = Array.from(selectedCollectionSet).map((source) => {
-        const name = makeNameSafe(source);
+        const name = makeNameSafeForFiles(source);
 
         return {
             name: `${name}`,

--- a/src/components/transformation/create/generateTemplate.ts
+++ b/src/components/transformation/create/generateTemplate.ts
@@ -1,0 +1,80 @@
+import { stripPathing } from 'utils/misc-utils';
+
+export type DerivationLanguage = 'sql' | 'typescript';
+
+const key = ['/your_key'];
+const schema = {
+    type: 'object',
+    properties: { your_key: { type: 'string' } },
+    required: ['your_key'],
+};
+
+const makeNameSafe = (source: string) => {
+    const name = source.replace(/[^a-z]/g, '_');
+
+    // TODO (GitPod) what do we make this base here?
+    //  Do we remove only the tenant portion of the name?
+    //      or
+    //  Do we remove everything up to the last part of the path
+    const base = stripPathing(source);
+
+    return { name, base };
+};
+
+const generateSqlTemplate = (selectedCollectionSet: Set<string>) => {
+    const transforms = Array.from(selectedCollectionSet).map((source) => {
+        const { base, name } = makeNameSafe(source);
+        return {
+            name: `${name}`,
+            source,
+            lambda: `${base}.lambda.${name}.sql`,
+        };
+    });
+
+    return {
+        schema,
+        key,
+        derive: {
+            // TODO (GitPod) what do we make this base here?
+            //  there could be multiple bases
+            using: { sqlite: { migrations: ['BASE.migration.0.sql'] } },
+            transforms,
+        },
+    };
+};
+
+const generateTsTemplate = (selectedCollectionSet: Set<string>) => {
+    const transforms = Array.from(selectedCollectionSet).map((source) => {
+        const { name } = makeNameSafe(source);
+
+        return {
+            name: `${name}`,
+            source,
+        };
+    });
+
+    return {
+        schema,
+        key,
+        derive: {
+            // TODO (GitPod) what do we make this base here?
+            //  there could be multiple bases
+            using: { typescript: { module: 'BASE.ts' } },
+            transforms,
+        },
+    };
+};
+
+const generateTemplate = (
+    language: DerivationLanguage,
+    selectedCollectionSet: Set<string>
+) => {
+    switch (language) {
+        case 'typescript':
+            return generateTsTemplate(selectedCollectionSet);
+        default:
+            return generateSqlTemplate(selectedCollectionSet);
+    }
+};
+
+export default generateTemplate;

--- a/src/components/transformation/create/generateTransformSpec.ts
+++ b/src/components/transformation/create/generateTransformSpec.ts
@@ -65,7 +65,7 @@ const generateTsTemplate = (
     };
 };
 
-const generateTemplate = (
+const generateTransformSpec = (
     language: DerivationLanguage,
     entityName: string,
     selectedCollectionSet: Set<string>
@@ -86,4 +86,4 @@ const generateTemplate = (
     }
 };
 
-export default generateTemplate;
+export default generateTransformSpec;

--- a/src/components/transformation/create/generateTransformSpec.ts
+++ b/src/components/transformation/create/generateTransformSpec.ts
@@ -10,21 +10,17 @@ const schema = {
     required: ['your_key'],
 };
 
-// Need to make sure whatever name we pass in can be used in a file name
-const makeNameSafeForFiles = (source: string) => {
-    return source.replaceAll(/\//g, '_');
-};
-
 const generateSqlTemplate = (
     entityName: string,
     selectedCollectionSet: Set<string>
 ) => {
     const transforms = Array.from(selectedCollectionSet).map((source) => {
-        const name = makeNameSafeForFiles(source);
+        const baseName = stripPathing(source);
+
         return {
-            name: `${name}`,
+            name: `${baseName}`,
             source,
-            lambda: `${entityName}.lambda.${name}.sql`,
+            lambda: `${entityName}.lambda.${baseName}.sql`,
         };
     });
 
@@ -47,10 +43,10 @@ const generateTsTemplate = (
     selectedCollectionSet: Set<string>
 ) => {
     const transforms = Array.from(selectedCollectionSet).map((source) => {
-        const name = makeNameSafeForFiles(source);
+        const baseName = stripPathing(source);
 
         return {
-            name: `${name}`,
+            name: `${baseName}`,
             source,
         };
     });

--- a/src/components/transformation/create/index.tsx
+++ b/src/components/transformation/create/index.tsx
@@ -157,8 +157,6 @@ function TransformationCreate({ postWindowOpen }: Props) {
                 selectedCollectionSet
             );
 
-            console.log('spec', spec);
-
             await createDraftSpec(
                 draftId,
                 computedEntityName,

--- a/src/components/transformation/create/index.tsx
+++ b/src/components/transformation/create/index.tsx
@@ -23,16 +23,13 @@ import {
 import { createEntityDraft } from 'api/drafts';
 import { createDraftSpec } from 'api/draftSpecs';
 import { createRefreshToken } from 'api/tokens';
+import { BindingsSelectorSkeleton } from 'components/collection/CollectionSkeletons';
+import CollectionSelector from 'components/collection/Selector';
+import SingleLineCode from 'components/content/SingleLineCode';
 import useCombinedGrantsExt from 'hooks/useCombinedGrantsExt';
 import useLiveSpecs from 'hooks/useLiveSpecs';
 import { useSnackbar } from 'notistack';
 import { useCallback, useMemo, useState } from 'react';
-
-// Something seems to be conflicting with the import re-ordering of this
-// eslint-disable-next-line import/order
-import { BindingsSelectorSkeleton } from 'components/collection/CollectionSkeletons';
-import CollectionSelector from 'components/collection/Selector';
-import SingleLineCode from 'components/content/SingleLineCode';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSet } from 'react-use';
 import { generateGitPodURL } from 'services/gitpod';

--- a/src/components/transformation/create/index.tsx
+++ b/src/components/transformation/create/index.tsx
@@ -52,7 +52,11 @@ const StyledStepConnector = styled(StepConnector)(() => ({
 type DerivationLanguage = 'sql' | 'typescript';
 const NAME_RE = new RegExp(`^(${PREFIX_NAME_PATTERN}/?)*$`);
 
-function TransformationCreate() {
+interface Props {
+    postWindowOpen: (window: Window | null) => void;
+}
+
+function TransformationCreate({ postWindowOpen }: Props) {
     const intl = useIntl();
 
     const collections = useLiveSpecs('collection');
@@ -204,7 +208,7 @@ function TransformationCreate() {
             } catch (e: unknown) {
                 displayError(
                     intl.formatMessage({
-                        id: 'newTransform.errors.gitPod',
+                        id: 'newTransform.errors.urlNotGenerated',
                     })
                 );
                 console.error(e);
@@ -373,16 +377,33 @@ function TransformationCreate() {
                             }}
                         />
                         <LoadingButton
-                            disabled={!!entityNameError || !!submitButtonError}
                             fullWidth
                             variant="contained"
                             loading={urlLoading}
+                            disabled={
+                                !!entityNameError ||
+                                !!submitButtonError ||
+                                urlLoading
+                            }
                             sx={{ marginBottom: 3 }}
                             loadingPosition="end"
                             onClick={async () => {
                                 const gitpodUrl = await generateUrl();
                                 if (gitpodUrl) {
-                                    window.open(gitpodUrl, '_blank');
+                                    const gitPodWindow = window.open(
+                                        gitpodUrl,
+                                        '_blank'
+                                    );
+
+                                    if (!gitPodWindow || gitPodWindow.closed) {
+                                        displayError(
+                                            intl.formatMessage({
+                                                id: 'newTransform.errors.gitPodWindow',
+                                            })
+                                        );
+                                    }
+
+                                    postWindowOpen(gitPodWindow);
                                 }
                             }}
                         >
@@ -391,12 +412,14 @@ function TransformationCreate() {
                                     id: 'newTransform.button.cta',
                                 })}
                         </LoadingButton>
-                        <Stack>
-                            <Typography
-                                variant="body2"
-                                sx={{ color: 'rgb(150,150,150)' }}
-                            >
-                                <FormattedMessage id="newTransform.instructions" />
+                        <Stack spacing={1}>
+                            <Typography variant="caption">
+                                <Box>
+                                    <FormattedMessage id="newTransform.instructions1" />
+                                </Box>
+                                <Box>
+                                    <FormattedMessage id="newTransform.instructions2" />
+                                </Box>
                             </Typography>
 
                             <SingleLineCode value="flowctl --help" />

--- a/src/components/transformation/create/index.tsx
+++ b/src/components/transformation/create/index.tsx
@@ -378,7 +378,6 @@ function TransformationCreate({ postWindowOpen }: Props) {
                                 urlLoading
                             }
                             sx={{ marginBottom: 3 }}
-                            loadingPosition="end"
                             onClick={async () => {
                                 const gitpodUrl = await generateUrl();
                                 if (gitpodUrl) {

--- a/src/components/transformation/create/index.tsx
+++ b/src/components/transformation/create/index.tsx
@@ -37,7 +37,9 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useSet } from 'react-use';
 import { generateGitPodURL } from 'services/gitpod';
 import { PREFIX_NAME_PATTERN } from 'utils/misc-utils';
-import generateTemplate, { DerivationLanguage } from './generateTemplate';
+import generateTransformSpec, {
+    DerivationLanguage,
+} from './generateTransformSpec';
 import SingleStep from './SingleStep';
 import { StepBox } from './StepBox';
 
@@ -152,7 +154,7 @@ function TransformationCreate({ postWindowOpen }: Props) {
             }
             const draftId: string = draft.data[0].id;
 
-            const spec = generateTemplate(
+            const spec = generateTransformSpec(
                 derivationLanguage,
                 computedEntityName,
                 selectedCollectionSet

--- a/src/components/transformation/create/index.tsx
+++ b/src/components/transformation/create/index.tsx
@@ -154,6 +154,7 @@ function TransformationCreate({ postWindowOpen }: Props) {
 
             const spec = generateTemplate(
                 derivationLanguage,
+                computedEntityName,
                 selectedCollectionSet
             );
 

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -900,12 +900,12 @@ const Docs: ResolvedIntlConfig['messages'] = {
 };
 
 const NewTransform: ResolvedIntlConfig['messages'] = {
-    'newTransform.modal.title': `Build a new transformation`,
+    'newTransform.modal.title': `Derive A New Collection`,
     'newTransform.language.title': `Language`,
     'newTransform.language.sql': `SQL`,
     'newTransform.language.ts': `Typescript`,
-    'newTransform.collection.label': `Transformation Name`,
-    'newTransform.errors.collection': `Select A Source Collection`,
+    'newTransform.collection.label': `Derived Collection Name`,
+    'newTransform.errors.collection': `Select source collections`,
     'newTransform.errors.name': `Name Your Transform`,
     'newTransform.errors.prefixMissing': `No prefix selected`,
     'newTransform.errors.namePattern': `Name does not match pattern`,
@@ -915,9 +915,9 @@ const NewTransform: ResolvedIntlConfig['messages'] = {
     'newTransform.errors.gitPodWindow': `Failed to open GitPod. Your browser may be blocking it from opening. Please ensure your browser allows pop-ups.`,
     'newTransform.info.gitPodWindowTitle': `GitPod should be opened in a new tab or window`,
     'newTransform.info.gitPodWindowMessage': `To develop your transformation please use GitPod.`,
-    'newTransform.stepper.step1.label': `Select your collections`,
+    'newTransform.stepper.step1.label': `Select source collections`,
     'newTransform.stepper.step2.label': `Transformation Language`,
-    'newTransform.stepper.step3.label': `Write Transformation`,
+    'newTransform.stepper.step3.label': `Write transformations`,
     'newTransform.instructions1': `You will be set up with an environment to create a
                             transformation.`,
     'newTransform.instructions2': `Create your query and use the CLI to

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -530,7 +530,7 @@ const Materializations: ResolvedIntlConfig['messages'] = {
 
 const Collections: ResolvedIntlConfig['messages'] = {
     'collectionsTable.title': `Collections`,
-    'collectionsTable.cta.new': `New Collection`,
+    'collectionsTable.cta.new': `New Transformation`,
     'collectionsTable.detailsCTA': `Details`,
     'collectionsTable.filterLabel': `Filter collections`,
     'collections.message1': `You currently have no collections. Click the Captures icon on the menu bar to get started.`,
@@ -900,11 +900,11 @@ const Docs: ResolvedIntlConfig['messages'] = {
 };
 
 const NewTransform: ResolvedIntlConfig['messages'] = {
-    'newTransform.modal.title': `Build a new collection`,
+    'newTransform.modal.title': `Build a new transformation`,
     'newTransform.language.title': `Language`,
     'newTransform.language.sql': `SQL`,
     'newTransform.language.ts': `Typescript`,
-    'newTransform.collection.label': `Collection Name`,
+    'newTransform.collection.label': `Transformation Name`,
     'newTransform.errors.collection': `Select A Source Collection`,
     'newTransform.errors.name': `Name Your Transform`,
     'newTransform.errors.prefixMissing': `No prefix selected`,
@@ -912,7 +912,7 @@ const NewTransform: ResolvedIntlConfig['messages'] = {
     'newTransform.errors.nameInvalid': `Invalid entity name`,
     'newTransform.errors.nameMissing': `Missing entity name`,
     'newTransform.errors.gitPod': `Failed to open GitPod`,
-    'newTransform.stepper.step1.label': `Select your collection`,
+    'newTransform.stepper.step1.label': `Select your collections`,
     'newTransform.stepper.step2.label': `Transformation Language`,
     'newTransform.stepper.step3.label': `Write Transformation`,
     'newTransform.instructions': `You will be set up with an environment to create a

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -911,12 +911,16 @@ const NewTransform: ResolvedIntlConfig['messages'] = {
     'newTransform.errors.namePattern': `Name does not match pattern`,
     'newTransform.errors.nameInvalid': `Invalid entity name`,
     'newTransform.errors.nameMissing': `Missing entity name`,
-    'newTransform.errors.gitPod': `Failed to open GitPod`,
+    'newTransform.errors.urlNotGenerated': `We failed to generate the proper URL to start GitPod. ${Error['error.tryAgain']}`,
+    'newTransform.errors.gitPodWindow': `Failed to open GitPod. Your browser may be blocking it from opening. Please ensure your browser allows pop-ups.`,
+    'newTransform.info.gitPodWindowTitle': `GitPod should be opened in a new tab or window`,
+    'newTransform.info.gitPodWindowMessage': `To build out your transformation please use GitPod.`,
     'newTransform.stepper.step1.label': `Select your collections`,
     'newTransform.stepper.step2.label': `Transformation Language`,
     'newTransform.stepper.step3.label': `Write Transformation`,
-    'newTransform.instructions': `You will be set up with an environment to create a
-                            transform. Create your query and use the CLI to
+    'newTransform.instructions1': `You will be set up with an environment to create a
+                            transformation.`,
+    'newTransform.instructions2': `Create your query and use the CLI to
                             continue, e.g`,
     'newTransform.button.cta': `Proceed to GitPod`,
 };

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -914,7 +914,7 @@ const NewTransform: ResolvedIntlConfig['messages'] = {
     'newTransform.errors.urlNotGenerated': `We failed to generate the proper URL to start GitPod. ${Error['error.tryAgain']}`,
     'newTransform.errors.gitPodWindow': `Failed to open GitPod. Your browser may be blocking it from opening. Please ensure your browser allows pop-ups.`,
     'newTransform.info.gitPodWindowTitle': `GitPod should be opened in a new tab or window`,
-    'newTransform.info.gitPodWindowMessage': `To build out your transformation please use GitPod.`,
+    'newTransform.info.gitPodWindowMessage': `To develop your transformation please use GitPod.`,
     'newTransform.stepper.step1.label': `Select your collections`,
     'newTransform.stepper.step2.label': `Transformation Language`,
     'newTransform.stepper.step3.label': `Write Transformation`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -906,7 +906,7 @@ const NewTransform: ResolvedIntlConfig['messages'] = {
     'newTransform.language.ts': `Typescript`,
     'newTransform.collection.label': `Derived Collection Name`,
     'newTransform.errors.collection': `Select source collections`,
-    'newTransform.errors.name': `Name Your Transform`,
+    'newTransform.errors.name': `Name your Derived Collection`,
     'newTransform.errors.prefixMissing': `No prefix selected`,
     'newTransform.errors.namePattern': `Name does not match pattern`,
     'newTransform.errors.nameInvalid': `Invalid entity name`,


### PR DESCRIPTION
## Changes

1. Update content from `collection` to `transformation` to reduce possible confusion
2. Add a dedicated close button to the dialog
3. Add more fine grained errors around URL missing vs Window not opening
4. Update the modal when GitPod is opened

## Tests

Manually tested

## Issues

Contributes to: https://github.com/estuary/ui/issues/552

## Content

Updating content that was discussed with Dave during 1on1

## Screenshots

Updated button to make it clear this is for a transformation
![image](https://user-images.githubusercontent.com/270078/230640205-bceb0bd5-79ff-4920-b207-685cf96bddec.png)

Updated content in the modal
![image](https://user-images.githubusercontent.com/270078/231281761-1109d88e-4f8f-4691-b626-ac6d1b5713a3.png)



Handle if the URL could not be generated
![image](https://user-images.githubusercontent.com/270078/230639024-18c684f0-d9a3-4064-87d0-fe586618116a.png)


Handle if the window was not able to be opened
![image](https://user-images.githubusercontent.com/270078/230639478-b9b76e56-98a1-448b-90a5-ef0077072408.png)


After GitPod window is opened
![image](https://user-images.githubusercontent.com/270078/230638660-ea02fc78-a0ef-4a81-bda1-190c1d1c0ec2.png)

Gitpod files for SQL transformation
![image](https://user-images.githubusercontent.com/270078/231239880-e2030e15-5925-4764-8ce7-0eec240a4374.png)

Gitpod files for TS transformation
![image](https://user-images.githubusercontent.com/270078/231240104-d9f5a7e6-1bae-4be0-9466-843bbb5ca65a.png)


