### PR TITLE
Default docs to proper mode

### DIFF
--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import { useEditorStore_id } from 'components/editor/Store/hooks';
 import AlertBox from 'components/shared/AlertBox';
 import EndpointConfigForm from 'components/shared/Entity/EndpointConfig/Form';
@@ -34,6 +34,8 @@ interface Props {
     hideBorder?: boolean;
 }
 
+const DOCUSAURUS_THEME = 'docusaurus-theme';
+
 function EndpointConfig({
     connectorImage,
     readOnly = false,
@@ -41,6 +43,7 @@ function EndpointConfig({
 }: Props) {
     // General hooks
     const intl = useIntl();
+    const theme = useTheme();
 
     // The useConnectorTag hook can accept a connector ID or a connector tag ID.
     const { connectorTag, error } = useConnectorTag(connectorImage);
@@ -126,9 +129,11 @@ function EndpointConfig({
     });
     useEffect(() => {
         if (connectorTag) {
-            setDocsURL(connectorTag.documentation_url);
+            setDocsURL(
+                `${connectorTag.documentation_url}?${DOCUSAURUS_THEME}=${theme.palette.mode}`
+            );
         }
-    }, [connectorTag, setDocsURL]);
+    }, [connectorTag, setDocsURL, theme.palette.mode]);
 
     if (error) {
         return <Error error={error} />;

--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -129,8 +129,12 @@ function EndpointConfig({
     });
     useEffect(() => {
         if (connectorTag) {
+            const concatSymbol = connectorTag.documentation_url.includes('?')
+                ? '&'
+                : '?';
+
             setDocsURL(
-                `${connectorTag.documentation_url}?${DOCUSAURUS_THEME}=${theme.palette.mode}`
+                `${connectorTag.documentation_url}${concatSymbol}${DOCUSAURUS_THEME}=${theme.palette.mode}`
             );
         }
     }, [connectorTag, setDocsURL, theme.palette.mode]);

--- a/src/components/sidePanelDocs/Iframe.tsx
+++ b/src/components/sidePanelDocs/Iframe.tsx
@@ -74,11 +74,13 @@ function SidePanelIframe() {
         };
     }, [iframeCurrent, setAnimateOpening]);
 
-    if (disabled) {
-        if (!hasLength(docsURL)) {
-            return null;
-        }
+    // Make sure we don't include an iframe unless we actually need it
+    if (!hasLength(docsURL)) {
+        return null;
+    }
 
+    // Handle when it is disabled so there is some messaging to the user to let them know how to view docs
+    if (disabled) {
         return (
             <Box
                 sx={{


### PR DESCRIPTION
## Changes

After https://github.com/estuary/flow/pull/1000 is merged we can default the docs to light/dark mode on load

## Tests

Manually

## Issues

N/A... just something annoying I see sometimes

## Content

N/A

## Screenshots

N/A
