### PR TITLE
Fixing the issue with backgrounds and reopening iframe when mode changes

### DIFF
--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -137,7 +137,11 @@ function EndpointConfig({
                 `${connectorTag.documentation_url}${concatSymbol}${DOCUSAURUS_THEME}=${theme.palette.mode}`
             );
         }
-    }, [connectorTag, setDocsURL, theme.palette.mode]);
+
+        // We do not want to trigger this if the theme changes so we just use the theme at load
+        //  because we fire a message to the docs when the theme changes
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [connectorTag, setDocsURL]);
 
     if (error) {
         return <Error error={error} />;

--- a/src/components/sidePanelDocs/Iframe.tsx
+++ b/src/components/sidePanelDocs/Iframe.tsx
@@ -107,6 +107,11 @@ function SidePanelIframe() {
             <iframe
                 ref={iframeRef}
                 style={{
+                    // This is here for safety on the rare chance that
+                    //  someone is using darkmode in the app but their docs
+                    //  load in as light mode. When in light mode Docusaurus
+                    //  does not set a background and makes the text unreadable
+                    backgroundColor: '#ffffff',
                     border: 'none',
                     height: '100%',
                     visibility: loading ? 'hidden' : 'visible',


### PR DESCRIPTION
## Changes

1. Hard code a white background to be safe
2. No longer reopen iframe when mode changes

## Tests

Manually tested by changing the docs light/dark mode separate from the dashboard

## Issues

Fixes https://github.com/estuary/ui/issues/562

## Content

N/A

## Screenshots

![image](https://user-images.githubusercontent.com/270078/231792462-0e1b9919-200a-4c30-89c2-17bcc191e752.png)

