### PR TITLE
Endpoint config and Resource config rehydration changes

### DIFF
--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -16,6 +16,7 @@ import {
     useEndpointConfigStore_endpointConfig_data,
     useEndpointConfigStore_endpointSchema,
     useEndpointConfigStore_previousEndpointConfig_data,
+    useEndpointConfigStore_setEncryptedEndpointConfig,
     useEndpointConfigStore_setEndpointConfig,
     useEndpointConfigStore_setEndpointSchema,
     useEndpointConfigStore_setPreviousEndpointConfig,
@@ -62,6 +63,8 @@ function EndpointConfig({
     const setEndpointSchema = useEndpointConfigStore_setEndpointSchema();
     const setServerUpdateRequired = useEndpointConfig_setServerUpdateRequired();
     const setEndpointCanBeEmpty = useEndpointConfig_setEndpointCanBeEmpty();
+    const setEncryptedEndpointConfig =
+        useEndpointConfigStore_setEncryptedEndpointConfig();
 
     // Workflow related props
     const workflow = useEntityWorkflow();
@@ -100,15 +103,21 @@ function EndpointConfig({
 
             const defaultConfig = createJSONFormDefaults(schema);
 
+            setServerUpdateRequired(true);
+            setEncryptedEndpointConfig({
+                data: {},
+            });
             setEndpointConfig(defaultConfig);
             setPreviousEndpointConfig(defaultConfig);
         }
     }, [
+        setServerUpdateRequired,
         setEndpointConfig,
         setEndpointSchema,
         setPreviousEndpointConfig,
         connectorTag?.endpoint_spec_schema,
         endpointSchemaChanged,
+        setEncryptedEndpointConfig,
     ]);
 
     // Controlling if we need to show the generate button again

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -545,9 +545,12 @@ const getInitialState = (
         const liveSpecIds = searchParams.getAll(
             GlobalSearchParams.LIVE_SPEC_ID
         );
+        const materializationHydrating = entityType === 'materialization';
+        const materializationReydrating =
+            materializationHydrating && rehydrating;
 
         const { resetState, setHydrationErrorsExist } = get();
-        resetState(rehydrating);
+        resetState(materializationReydrating);
 
         if (connectorId) {
             const { data, error } = await getSchema_Resource(connectorId);
@@ -573,8 +576,9 @@ const getInitialState = (
             } else if (data && data.length > 0) {
                 const { setResourceConfig, preFillCollections } = get();
 
-                const collectionNameProp =
-                    entityType === 'materialization' ? 'source' : 'target';
+                const collectionNameProp = materializationHydrating
+                    ? 'source'
+                    : 'target';
 
                 const sortedBindings = sortBy(data[0].spec.bindings, [
                     collectionNameProp,
@@ -606,9 +610,11 @@ const getInitialState = (
 
                 preFillEmptyCollections(data, rehydrating);
             }
-        } else if (rehydrating) {
+        } else if (materializationReydrating) {
             // If there is nothign to prefill but we are rehydrating we want to make sure
-            //  we prefill any collections the user already selected
+            //  we prefill any collections the user already selected but only for materializations
+            //  because for a Capture the collections are discovered and if the hydration is kicked
+            //  off then they will need to rediscover everything again
             const { preFillEmptyCollections } = get();
             preFillEmptyCollections([], rehydrating);
         }


### PR DESCRIPTION
## Changes

1. Make resource config only carry forward collections if the materialization is rehydrating. Otherwise - the collections (outside of preselected with URL params) are cleared out.
2. Have Endpoint config reset the "needs server" and encrypted config when connector changes

## Tests

Manually

## Issues

Caught from a slack convo and LogRocket

## Content

N/A

## Screenshots

N/A
