### PR TITLE
fix: Gracefully degrade if stripe is catastrophically down, and fix a couple of other nits

### DIFF
--- a/src/components/admin/Billing/CapturePaymentMethod.tsx
+++ b/src/components/admin/Billing/CapturePaymentMethod.tsx
@@ -92,6 +92,7 @@ export const PaymentForm = ({ onSuccess, onError }: PaymentFormProps) => {
                                 email: 'never',
                             },
                         },
+                        readOnly: loading,
                         defaultValues: {
                             billingDetails: {
                                 name: user?.user_metadata.full_name,

--- a/src/components/admin/Billing/PaymentMethods.tsx
+++ b/src/components/admin/Billing/PaymentMethods.tsx
@@ -33,14 +33,14 @@ import MessageWithLink from 'components/content/MessageWithLink';
 import useCombinedGrantsExt from 'hooks/useCombinedGrantsExt';
 import useTenants from 'hooks/useTenants';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-const stripePromise = loadStripe(
-    process.env.REACT_APP_STRIPE_PUBLISHABLE_KEY ?? ''
-);
-
 const PaymentMethods = () => {
+    const stripePromise = useMemo(
+        () => loadStripe(process.env.REACT_APP_STRIPE_PUBLISHABLE_KEY ?? ''),
+        []
+    );
     const tenants = useTenants();
     const grants = useCombinedGrantsExt({ adminOnly: true });
 
@@ -86,7 +86,7 @@ const PaymentMethods = () => {
     }, [selectedTenant, refreshCounter]);
 
     return (
-        <Stack direction="column" spacing={2} sx={{ m: 2, width: '100%' }}>
+        <Stack direction="column" spacing={2} sx={{ width: '100%' }}>
             <Box sx={{ display: 'flex' }}>
                 <Typography
                     component="span"

--- a/src/components/admin/Billing/PaymentMethods.tsx
+++ b/src/components/admin/Billing/PaymentMethods.tsx
@@ -134,7 +134,7 @@ const PaymentMethods = () => {
                 </FormControl>
             ) : null}
 
-            {selectedTenant && methods.length > 0 && !methodsLoading ? (
+            {selectedTenant && !methodsLoading ? (
                 <TableContainer>
                     <Table
                         sx={{ minWidth: 650 }}
@@ -173,6 +173,20 @@ const PaymentMethods = () => {
                                     primary={method.id === defaultSource}
                                 />
                             ))}
+                            {methods.length < 1 ? (
+                                <TableRow>
+                                    <TableCell colSpan={6}>
+                                        <Typography
+                                            sx={{
+                                                textAlign: 'center',
+                                                fontSize: 15,
+                                            }}
+                                        >
+                                            <MessageWithLink messageID="billing.payment_methods.none_available" />
+                                        </Typography>
+                                    </TableCell>
+                                </TableRow>
+                            ) : null}
                         </TableBody>
                     </Table>
                 </TableContainer>

--- a/src/components/admin/Billing/index.tsx
+++ b/src/components/admin/Billing/index.tsx
@@ -14,6 +14,8 @@ import TasksByMonth from 'components/admin/Billing/graphs/TasksByMonthGraph';
 import PaymentMethods from 'components/admin/Billing/PaymentMethods';
 import PricingTierDetails from 'components/admin/Billing/PricingTierDetails';
 import AdminTabs from 'components/admin/Tabs';
+import MessageWithLink from 'components/content/MessageWithLink';
+import AlertBox from 'components/shared/AlertBox';
 import BillingHistoryTable from 'components/tables/Billing';
 import { semiTransparentBackground } from 'context/Theme';
 import useBillingCatalogStats from 'hooks/billing/useBillingCatalogStats';
@@ -21,6 +23,7 @@ import useCombinedGrantsExt from 'hooks/useCombinedGrantsExt';
 import usePageTitle from 'hooks/usePageTitle';
 import { HelpCircle } from 'iconoir-react';
 import { useEffect } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useUnmount } from 'react-use';
 import {
@@ -206,8 +209,19 @@ function AdminBilling() {
                         <DataByTaskGraph />
                     </Box>
                 </Grid>
-
-                <PaymentMethods />
+                <Box sx={{ paddingLeft: 2, paddingTop: 3, width: '100%' }}>
+                    <ErrorBoundary
+                        fallback={
+                            <AlertBox short severity="error">
+                                <Typography component="div">
+                                    <MessageWithLink messageID="admin.billing.error.paymentMethodsError" />
+                                </Typography>
+                            </AlertBox>
+                        }
+                    >
+                        <PaymentMethods />
+                    </ErrorBoundary>
+                </Box>
             </Grid>
         </>
     );

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -412,6 +412,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
 
     'admin.billing.header': `Billing`,
     'admin.billing.message.paidTier': `The {pricingTier} tier includes two tasks and {gbFree}GB are free every month. Thereafter you pay $0.75/GB with a \${taskRate} minimum per task.`,
+    'admin.billing.error.paymentMethodsError': `Sorry, something went wrong talking to our payment provider. We have been notified, please check back later.`,
     'admin.billing.error.undefinedPricingTier': `An issue was encountered gathering information about the pricing tier associated with this tenant. Please {docLink}.`,
     'admin.billing.error.undefinedPricingTier.docLink': `contact support`,
     'admin.billing.error.undefinedPricingTier.docPath': `mailto:support@estuary.dev`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -93,6 +93,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'billing.payment_methods.header': 'Payment Information',
     'billing.payment_methods.description':
         'Enter your payment information.  You won’t be charged until your account usage exceeds free tier limits.',
+    'billing.payment_methods.none_available': 'No payment methods available',
 };
 
 const CTAs: ResolvedIntlConfig['messages'] = {
@@ -412,7 +413,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
 
     'admin.billing.header': `Billing`,
     'admin.billing.message.paidTier': `The {pricingTier} tier includes two tasks and {gbFree}GB are free every month. Thereafter you pay $0.75/GB with a \${taskRate} minimum per task.`,
-    'admin.billing.error.paymentMethodsError': `Sorry, something went wrong talking to our payment provider. We have been notified, please check back later.`,
+    'admin.billing.error.paymentMethodsError': `There was an error connecting with our payment provider.  Please try again later.`,
     'admin.billing.error.undefinedPricingTier': `An issue was encountered gathering information about the pricing tier associated with this tenant. Please {docLink}.`,
     'admin.billing.error.undefinedPricingTier.docLink': `contact support`,
     'admin.billing.error.undefinedPricingTier.docPath': `mailto:support@estuary.dev`,


### PR DESCRIPTION
![Screen Shot 2023-04-21 at 15 58 41](https://user-images.githubusercontent.com/4368270/233724631-fe4edbf0-fef7-4adb-9f6f-68a7401f3679.png)

Also make the input form readonly while submitting, and move stripe initialization to inside the `<PaymentMethods>` component so that any errors it causes propagate correctly to the `<ErrorBoundary>`