### PR TITLE
fix: Loading spinner bug, and use `FormattedMessage` instead of `MessageWithLink`

### DIFF
--- a/src/components/admin/Billing/PaymentMethods.tsx
+++ b/src/components/admin/Billing/PaymentMethods.tsx
@@ -29,9 +29,8 @@ import {
 } from 'api/billing';
 import { PaymentForm } from 'components/admin/Billing/CapturePaymentMethod';
 import { PaymentMethod } from 'components/admin/Billing/PaymentMethodRow';
-import MessageWithLink from 'components/content/MessageWithLink';
+import { useTenantDetails } from 'context/fetcher/Tenant';
 import useCombinedGrantsExt from 'hooks/useCombinedGrantsExt';
-import useTenants from 'hooks/useTenants';
 
 import { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -41,7 +40,7 @@ const PaymentMethods = () => {
         () => loadStripe(process.env.REACT_APP_STRIPE_PUBLISHABLE_KEY ?? ''),
         []
     );
-    const tenants = useTenants();
+    const tenants = useTenantDetails();
     const grants = useCombinedGrantsExt({ adminOnly: true });
 
     const [refreshCounter, setRefreshCounter] = useState(0);
@@ -58,10 +57,10 @@ const PaymentMethods = () => {
     const [defaultSource, setDefaultSource] = useState<string | null>(null);
 
     useEffect(() => {
-        if (tenants.tenants.length > 0 && selectedTenant === null) {
-            setSelectedTenant(tenants.tenants[0].tenant);
+        if (tenants && tenants.length > 0 && selectedTenant === null) {
+            setSelectedTenant(tenants[0].tenant);
         }
-    }, [selectedTenant, tenants.tenants]);
+    }, [selectedTenant, tenants]);
 
     useEffect(() => {
         void (async () => {
@@ -107,11 +106,11 @@ const PaymentMethods = () => {
                 </Button>
             </Box>
 
-            <MessageWithLink messageID="billing.payment_methods.description" />
+            <FormattedMessage id="billing.payment_methods.description" />
 
             <Divider />
 
-            {tenants.tenants.length > 1 ? (
+            {tenants && tenants.length > 1 ? (
                 <FormControl fullWidth>
                     <InputLabel>Tenant</InputLabel>
                     <Select
@@ -119,7 +118,7 @@ const PaymentMethods = () => {
                         value={selectedTenant ?? ''}
                         onChange={(evt) => setSelectedTenant(evt.target.value)}
                     >
-                        {tenants.tenants
+                        {tenants
                             .filter((t) =>
                                 grants.combinedGrants.find(
                                     (g) => g.object_role === t.tenant
@@ -182,7 +181,7 @@ const PaymentMethods = () => {
                                                 fontSize: 15,
                                             }}
                                         >
-                                            <MessageWithLink messageID="billing.payment_methods.none_available" />
+                                            <FormattedMessage id="billing.payment_methods.none_available" />
                                         </Typography>
                                     </TableCell>
                                 </TableRow>

--- a/src/components/admin/Billing/index.tsx
+++ b/src/components/admin/Billing/index.tsx
@@ -14,7 +14,6 @@ import TasksByMonth from 'components/admin/Billing/graphs/TasksByMonthGraph';
 import PaymentMethods from 'components/admin/Billing/PaymentMethods';
 import PricingTierDetails from 'components/admin/Billing/PricingTierDetails';
 import AdminTabs from 'components/admin/Tabs';
-import MessageWithLink from 'components/content/MessageWithLink';
 import AlertBox from 'components/shared/AlertBox';
 import BillingHistoryTable from 'components/tables/Billing';
 import { semiTransparentBackground } from 'context/Theme';
@@ -214,7 +213,7 @@ function AdminBilling() {
                         fallback={
                             <AlertBox short severity="error">
                                 <Typography component="div">
-                                    <MessageWithLink messageID="admin.billing.error.paymentMethodsError" />
+                                    <FormattedMessage id="admin.billing.error.paymentMethodsError" />
                                 </Typography>
                             </AlertBox>
                         }


### PR DESCRIPTION
## Changes

* Fix intermittent bug where full-page loading spinner shows up on Billing because of subtile misunderstanding of SWR hook
* Replace `MessageWithLink` with `FormattedMessage`, which was causing a bunch of errors about missing doc links, which makes sense since we don't have a docs pager for billing yet