### PR TITLE
Billing UX tweaks

### DIFF
--- a/src/components/admin/Billing/PaymentMethods.tsx
+++ b/src/components/admin/Billing/PaymentMethods.tsx
@@ -4,7 +4,6 @@ import {
     Dialog,
     DialogContent,
     DialogTitle,
-    Divider,
     FormControl,
     InputLabel,
     MenuItem,
@@ -85,43 +84,43 @@ const PaymentMethods = () => {
     }, [selectedTenant, refreshCounter]);
 
     return (
-        <Stack direction="column" spacing={2} sx={{ width: '100%' }}>
-            <Box sx={{ display: 'flex' }}>
-                <Typography
-                    component="span"
-                    align="center"
-                    sx={{
-                        mb: 1,
-                        fontSize: 18,
-                        fontWeight: '400',
-                    }}
-                >
-                    <FormattedMessage id="admin.billing.payment_methods.header" />
-                </Typography>
+        <Stack spacing={3}>
+            <Stack
+                direction="row"
+                sx={{ mb: 1, justifyContent: 'space-between' }}
+            >
+                <Box>
+                    <Typography
+                        sx={{
+                            mb: 1,
+                            fontSize: 18,
+                            fontWeight: '400',
+                        }}
+                    >
+                        <FormattedMessage id="admin.billing.payment_methods.header" />
+                    </Typography>
 
-                <Box sx={{ flexGrow: 1 }} />
+                    <Typography>
+                        <FormattedMessage id="admin.billing.payment_methods.description" />
+                    </Typography>
+                </Box>
 
-                <Button
-                    sx={{ marginTop: 1 }}
-                    onClick={() => setNewMethodOpen(true)}
-                >
-                    Add Payment Method
-                </Button>
-            </Box>
-
-            <Typography>
-                <FormattedMessage id="admin.billing.payment_methods.description" />
-            </Typography>
-
-            <Divider />
+                <Box>
+                    <Button onClick={() => setNewMethodOpen(true)}>
+                        Add Payment Method
+                    </Button>
+                </Box>
+            </Stack>
 
             {tenants && tenants.length > 1 ? (
-                <FormControl fullWidth>
+                <FormControl size="small" sx={{ width: 350 }}>
                     <InputLabel>Tenant</InputLabel>
+
                     <Select
                         label="Tenant"
                         value={selectedTenant ?? ''}
                         onChange={(evt) => setSelectedTenant(evt.target.value)}
+                        sx={{ borderRadius: 3 }}
                     >
                         {tenants
                             .filter((t) =>
@@ -146,7 +145,12 @@ const PaymentMethods = () => {
                         size="small"
                     >
                         <TableHead>
-                            <TableRow>
+                            <TableRow
+                                sx={{
+                                    background: (theme) =>
+                                        theme.palette.background.default,
+                                }}
+                            >
                                 <TableCell width={200}>Type</TableCell>
                                 <TableCell>Name</TableCell>
                                 <TableCell>Last 4 digits</TableCell>

--- a/src/components/admin/Billing/PaymentMethods.tsx
+++ b/src/components/admin/Billing/PaymentMethods.tsx
@@ -29,7 +29,6 @@ import {
 } from 'api/billing';
 import { PaymentForm } from 'components/admin/Billing/CapturePaymentMethod';
 import { PaymentMethod } from 'components/admin/Billing/PaymentMethodRow';
-import MessageWithLink from 'components/content/MessageWithLink';
 import useCombinedGrantsExt from 'hooks/useCombinedGrantsExt';
 import useTenants from 'hooks/useTenants';
 
@@ -90,13 +89,16 @@ const PaymentMethods = () => {
             <Box sx={{ display: 'flex' }}>
                 <Typography
                     component="span"
-                    variant="h6"
+                    align="center"
                     sx={{
-                        alignItems: 'center',
+                        mb: 1,
+                        fontSize: 18,
+                        fontWeight: '400',
                     }}
                 >
-                    <FormattedMessage id="billing.payment_methods.header" />
+                    <FormattedMessage id="admin.billing.payment_methods.header" />
                 </Typography>
+
                 <Box sx={{ flexGrow: 1 }} />
 
                 <Button
@@ -107,7 +109,9 @@ const PaymentMethods = () => {
                 </Button>
             </Box>
 
-            <MessageWithLink messageID="billing.payment_methods.description" />
+            <Typography>
+                <FormattedMessage id="admin.billing.payment_methods.description" />
+            </Typography>
 
             <Divider />
 
@@ -182,7 +186,7 @@ const PaymentMethods = () => {
                                                 fontSize: 15,
                                             }}
                                         >
-                                            <MessageWithLink messageID="billing.payment_methods.none_available" />
+                                            <FormattedMessage id="admin.billing.payment_methods.none_available" />
                                         </Typography>
                                     </TableCell>
                                 </TableRow>

--- a/src/components/admin/Billing/PricingTierDetails.tsx
+++ b/src/components/admin/Billing/PricingTierDetails.tsx
@@ -1,6 +1,4 @@
-import { Box, Skeleton, Typography } from '@mui/material';
-import MessageWithLink from 'components/content/MessageWithLink';
-import AlertBox from 'components/shared/AlertBox';
+import { Skeleton, Typography } from '@mui/material';
 import { isSameMonth } from 'date-fns';
 import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -10,6 +8,7 @@ import {
 } from 'stores/Billing/hooks';
 import { BillingRecord } from 'stores/Billing/types';
 import useConstant from 'use-constant';
+import { FREE_GB_BY_TIER } from 'utils/billing-utils';
 
 function PricingTierDetails() {
     const intl = useIntl();
@@ -64,14 +63,30 @@ function PricingTierDetails() {
             </Skeleton>
         );
     } else {
+        // TODO (billing): Replace the hardcoded message with the commented out alert once
+        //   the new RPC is integrated. That integration coincides with logic that handles
+        //   this fallthrough scenario more effectively.
         return (
-            <Box sx={{ mt: 2 }}>
-                <AlertBox short severity="warning">
-                    <Typography component="div">
-                        <MessageWithLink messageID="admin.billing.error.undefinedPricingTier" />
-                    </Typography>
-                </AlertBox>
-            </Box>
+            <Typography>
+                <FormattedMessage
+                    id="admin.billing.message.paidTier"
+                    values={{
+                        pricingTier: intl.formatMessage({
+                            id: 'admin.billing.tier.personal',
+                        }),
+                        gbFree: FREE_GB_BY_TIER.PERSONAL,
+                        taskRate: 20,
+                    }}
+                />
+            </Typography>
+
+            // <Box sx={{ mt: 2 }}>
+            //     <AlertBox short severity="warning">
+            //         <Typography component="div">
+            //             <MessageWithLink messageID="admin.billing.error.undefinedPricingTier" />
+            //         </Typography>
+            //     </AlertBox>
+            // </Box>
         );
     }
 }

--- a/src/components/admin/Billing/index.tsx
+++ b/src/components/admin/Billing/index.tsx
@@ -211,7 +211,7 @@ function AdminBilling() {
                 </Grid>
 
                 <Grid item xs={12}>
-                    <Divider sx={{ mt: 3, mb: 2 }} />
+                    <Divider sx={{ mt: 3 }} />
                 </Grid>
 
                 <Grid item xs={12}>

--- a/src/components/admin/Billing/index.tsx
+++ b/src/components/admin/Billing/index.tsx
@@ -1,5 +1,6 @@
 import {
     Box,
+    Divider,
     Grid,
     Stack,
     Tooltip,
@@ -14,7 +15,6 @@ import TasksByMonth from 'components/admin/Billing/graphs/TasksByMonthGraph';
 import PaymentMethods from 'components/admin/Billing/PaymentMethods';
 import PricingTierDetails from 'components/admin/Billing/PricingTierDetails';
 import AdminTabs from 'components/admin/Tabs';
-import MessageWithLink from 'components/content/MessageWithLink';
 import AlertBox from 'components/shared/AlertBox';
 import BillingHistoryTable from 'components/tables/Billing';
 import { semiTransparentBackground } from 'context/Theme';
@@ -209,19 +209,24 @@ function AdminBilling() {
                         <DataByTaskGraph />
                     </Box>
                 </Grid>
-                <Box sx={{ paddingLeft: 2, paddingTop: 3, width: '100%' }}>
+
+                <Grid item xs={12}>
+                    <Divider sx={{ mt: 3, mb: 2 }} />
+                </Grid>
+
+                <Grid item xs={12}>
                     <ErrorBoundary
                         fallback={
                             <AlertBox short severity="error">
                                 <Typography component="div">
-                                    <MessageWithLink messageID="admin.billing.error.paymentMethodsError" />
+                                    <FormattedMessage id="admin.billing.error.paymentMethodsError" />
                                 </Typography>
                             </AlertBox>
                         }
                     >
                         <PaymentMethods />
                     </ErrorBoundary>
-                </Box>
+                </Grid>
             </Grid>
         </>
     );

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -88,12 +88,6 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'filter.time.thisWeek': `This Week`,
     'filter.time.lastMonth': `Last Month`,
     'filter.time.thisMonth': `This Month`,
-
-    // Billing Page
-    'billing.payment_methods.header': 'Payment Information',
-    'billing.payment_methods.description':
-        'Enter your payment information.  You won’t be charged until your account usage exceeds free tier limits.',
-    'billing.payment_methods.none_available': 'No payment methods available',
 };
 
 const CTAs: ResolvedIntlConfig['messages'] = {
@@ -434,10 +428,10 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.billing.table.history.tooltip.dataVolume': `bytes of data processed by tasks`,
     'admin.billing.table.history.emptyTableDefault.header': `No information found.`,
     'admin.billing.table.history.emptyTableDefault.message': `We couldn't find any billing information on file. Only administrators of a tenant are able to review billing information.`,
-    'admin.billing.payment.header': `Payment Information`,
-    'admin.billing.payment.message': `We are working on integrating a payment service provider to enable in-app transactions. To make a payment or inquire about our pricing tiers, please {docLink}.`,
-    'admin.billing.payment.message.docLink': `contact us`,
-    'admin.billing.payment.message.docPath': `mailto:support@estuary.dev`,
+
+    'admin.billing.payment_methods.header': `Payment Information`,
+    'admin.billing.payment_methods.description': `Enter your payment information.  You won’t be charged until your account usage exceeds free tier limits.`,
+    'admin.billing.payment_methods.none_available': `No payment methods available`,
 
     'admin.cookies': `Cookie Preference Management`,
     'admin.cookies.message': `Click below to manage your preferences.`,


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Hardcode the pricing tier constraints into the _Billing_ page description. This temporarily replaces the alert that was originally shown there when the pricing tier could not be determined by the UI.

1. Update the styling of the _Payment Information_ section so that it is more congruent with the overall application styling.

1. Co-locate all billing-related content strings.

## Tests

_Describe the approach to testing._

## Screenshots

**Billing Page | New User**

<img width="998" alt="pr_screenshot-576-payment_styling-no_stats" src="https://user-images.githubusercontent.com/77648584/233741657-fe6e9592-d3df-4d21-ad88-dd1493ed3e9f.PNG">

<br />

**Billing Page | Single Tenant**

<img width="997" alt="pr_screenshot-576-payment_styling-single_tenant" src="https://user-images.githubusercontent.com/77648584/233741394-d836218d-94af-456c-a2ca-f18e244062ce.PNG">

<br />

**Billing Page | Multiple Tenants**

<img width="998" alt="pr_screenshot-576-payment_styling-multi_tenant" src="https://user-images.githubusercontent.com/77648584/233741423-6f9ae9c0-899f-49cf-b128-d3121413f3f1.PNG">

<br />