### PR TITLE
Adjust when the organization name on the onboarding page is validated

### DIFF
--- a/src/directives/Onboard/OrganizationName.tsx
+++ b/src/directives/Onboard/OrganizationName.tsx
@@ -25,14 +25,13 @@ function OrganizationNameField() {
 
     const handlers = {
         update: (updatedValue: string) => {
+            const pattern = new RegExp(`^${PREFIX_NAME_PATTERN}$`);
+
+            setNameInvalid(!pattern.test(updatedValue));
+
             setRequestedTenant(updatedValue);
 
             if (nameMissing) setNameMissing(!hasLength(updatedValue));
-        },
-        validateOrganizationName: () => {
-            const pattern = new RegExp(`^${PREFIX_NAME_PATTERN}$`);
-
-            setNameInvalid(!pattern.test(requestedTenant));
         },
     };
 
@@ -58,7 +57,6 @@ function OrganizationNameField() {
                 label={<FormattedMessage id="common.tenant.creationForm" />}
                 value={requestedTenant}
                 onChange={(event) => handlers.update(event.target.value)}
-                onBlur={() => handlers.validateOrganizationName()}
                 required
                 inputProps={{
                     pattern: PREFIX_NAME_PATTERN,


### PR DESCRIPTION
## Changes

Validate the contents of the organization name field on the _Onboarding_ page whenever the value changes.

## Tests

Approaches to testing are as follows:

1. Enter an invalid character in organization name field and observe that the field assumes an error state. Attempt to submit the form (via the enter key or clicking the CTA) and observe that the form cannot be submitted.

1. Enter a valid string in the organization name field, do not complete the survey, and observe that the form can be submitted.

1. Enter a valid string in the organization name field, complete the survey, and observe that the form can be submitted.
