### PR TITLE
WIP: discover draft errors and better error scoping

### DIFF
--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -263,6 +263,7 @@ function useDiscoverCapture(
                     if (payload.error === JOB_STATUS_POLLER_ERROR) {
                         jobFailed(payload.error);
                     } else {
+                        setDraftId(discoverDraftId);
                         jobFailed(`${messagePrefix}.test.failedErrorTitle`);
                     }
                 }

--- a/src/components/shared/Entity/Error/DraftErrors.tsx
+++ b/src/components/shared/Entity/Error/DraftErrors.tsx
@@ -10,10 +10,29 @@ function DraftErrors({ draftId, enablePolling }: DraftErrorProps) {
     const { draftSpecErrors } = useDraftSpecErrors(draftId, enablePolling);
 
     if (draftSpecErrors.length > 0) {
-        const errors: KeyValue[] = draftSpecErrors.map((draftError) => ({
-            title: draftError.detail,
-            val: draftError.scope,
-        }));
+        const errors: KeyValue[] = draftSpecErrors.map((draftError) => {
+            // TODO(johnny): Could we use a breadcrumb presentation here?
+            // 1) Remove file:///flow.json# prefix if present.
+            // 2) Split on '/'. Each component is a breadcrumb.
+            // 3) Replace ~1 => '/' for each item.
+            // 4) Replace ~0 => '~' for each item.
+            const scope = draftError.scope
+                // Strip the canonical source file used by control-plane builds.
+                // It's not user-defined and thus not useful to the user.
+                .replace('file:///flow.json#', '')
+                // Remove JSON pointer escapes. The result is not technically a JSON pointer,
+                // but it's far more legible.
+                .replaceAll('~1', '/')
+                .replaceAll('~0', '~');
+
+            // TODO(johnny): Can we turn newlines into proper breaks?
+            const detail = draftError.detail;
+
+            return {
+                title: detail,
+                val: scope,
+            };
+        });
         return <KeyValueList data={errors} />;
     } else {
         return null;


### PR DESCRIPTION
## Changes

This is a draft.

* Discover operations produce `draft_errors` on failure, but they're not shown in the UI. Attempt to fix this by setting the draft ID. There are some outstanding / known issues around being able to retry the discover.

* Parse the `scope` URLs of the `draft_errors` table to make them more useable. They are always URLs with JSON-Pointer fragments, and they almost-always have a well-known resource, so the fragment is the interesting bit (Note this isn't guaranteed, and it _is_ possible there might be a different resource). Attempt to make `scope` more ergonomic for the user by removing escapes. A breadcrumb or similar component, to show the pointer path structure, would help a lot here!

## Tests

Tested manually. See screenshots in #control-plane slack.

## Issues

_Please list out any related issues (Here so issue is not auto closed by PR)_

## Content

_Were there any changes to [content](https://github.com/estuary/ui/tree/main/src/lang) that you need to get reviewed?_

## Screenshots

_If applicable - please include some screenshots of the new UI_
