### PR TITLE
Show discover errors and better formatting

### DIFF
--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -9,6 +9,7 @@ import {
     useEditorStore_isSaving,
     useEditorStore_persistedDraftId,
     useEditorStore_resetState,
+    useEditorStore_setDiscoveredDraftId,
     useEditorStore_setId,
     useEditorStore_setPersistedDraftId,
 } from 'components/editor/Store/hooks';
@@ -94,6 +95,7 @@ function useDiscoverCapture(
     const persistedDraftId = useEditorStore_persistedDraftId();
     const setPersistedDraftId = useEditorStore_setPersistedDraftId();
     const setDraftId = useEditorStore_setId();
+    const setDiscoveredDraftId = useEditorStore_setDiscoveredDraftId();
 
     const isSaving = useEditorStore_isSaving();
     const resetEditorState = useEditorStore_resetState();
@@ -228,6 +230,7 @@ function useDiscoverCapture(
             existingEndpointConfig: any // JsonFormsData,
         ) => {
             setDraftId(null);
+            setDiscoveredDraftId(discoverDraftId);
 
             jobStatusPoller(
                 supabaseClient
@@ -270,13 +273,14 @@ function useDiscoverCapture(
         },
         [
             jobFailed,
+            messagePrefix,
+            postGenerateMutate,
+            setDiscoveredDraftId,
             setDraftId,
             setDraftedEntityName,
             setFormState,
             setPreviousEndpointConfig,
             storeDiscoveredCollections,
-            messagePrefix,
-            postGenerateMutate,
             supabaseClient,
         ]
     );

--- a/src/components/editor/Store/create.ts
+++ b/src/components/editor/Store/create.ts
@@ -12,6 +12,7 @@ const getInitialStateData = () => {
     return {
         currentCatalog: null,
         id: null,
+        discoveredDraftId: null,
         persistedDraftId: null,
         pubId: null,
         specs: null,
@@ -45,6 +46,16 @@ const getInitialState = <T>(
                 }),
                 false,
                 'Set persisted draft id'
+            );
+        },
+
+        setDiscoveredDraftId: (newVal) => {
+            set(
+                produce((state) => {
+                    state.discoveredDraftId = newVal;
+                }),
+                false,
+                'Set discovered draft id'
             );
         },
 

--- a/src/components/editor/Store/hooks.ts
+++ b/src/components/editor/Store/hooks.ts
@@ -86,6 +86,40 @@ export const useEditorStore_setPersistedDraftId = (
     >(storeName(entityType, localScope), (state) => state.setPersistedDraftId);
 };
 
+export const useEditorStore_discoveredDraftId = (
+    params?: SelectorParams | undefined
+) => {
+    const localScope = params?.localScope;
+
+    const useZustandStore = localScope
+        ? useLocalZustandStore
+        : useGlobalZustandStore;
+
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        EditorStoreState<DraftSpecQuery>,
+        EditorStoreState<DraftSpecQuery>['discoveredDraftId']
+    >(storeName(entityType, localScope), (state) => state.discoveredDraftId);
+};
+
+export const useEditorStore_setDiscoveredDraftId = (
+    params?: SelectorParams | undefined
+) => {
+    const localScope = params?.localScope;
+
+    const useZustandStore = localScope
+        ? useLocalZustandStore
+        : useGlobalZustandStore;
+
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        EditorStoreState<DraftSpecQuery>,
+        EditorStoreState<DraftSpecQuery>['setDiscoveredDraftId']
+    >(storeName(entityType, localScope), (state) => state.setDiscoveredDraftId);
+};
+
 export const useEditorStore_pubId = (params?: SelectorParams | undefined) => {
     const localScope = params?.localScope;
 

--- a/src/components/editor/Store/types.ts
+++ b/src/components/editor/Store/types.ts
@@ -20,6 +20,11 @@ export interface EditorStoreState<T> {
         newVal: EditorStoreState<T>['persistedDraftId']
     ) => void;
 
+    discoveredDraftId: string | null;
+    setDiscoveredDraftId: (
+        newVal: EditorStoreState<T>['discoveredDraftId']
+    ) => void;
+
     pubId: string | null;
     setPubId: (newVal: EditorStoreState<T>['pubId']) => void;
 

--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -7,6 +7,7 @@ import { createPublication } from 'api/publications';
 import {
     useEditorStore_id,
     useEditorStore_isSaving,
+    useEditorStore_setDiscoveredDraftId,
     useEditorStore_setPubId,
 } from 'components/editor/Store/hooks';
 import { buttonSx } from 'components/shared/Entity/Header';
@@ -61,6 +62,8 @@ function EntityCreateSave({ disabled, dryRun, onFailure, logEvent }: Props) {
     const setPubId = useEditorStore_setPubId();
 
     const isSaving = useEditorStore_isSaving();
+
+    const setDiscoveredDraftId = useEditorStore_setDiscoveredDraftId();
 
     // Details Form Store
     const entityDescription = useDetailsForm_details_description();
@@ -166,6 +169,10 @@ function EntityCreateSave({ disabled, dryRun, onFailure, logEvent }: Props) {
                     draftSpecResponse.data &&
                     draftSpecResponse.data.length > 0
                 ) {
+                    // Now that we are making a call we can delete the
+                    //  draftId used for showing discovery errors
+                    setDiscoveredDraftId(null);
+
                     const unboundCollections = draftSpecResponse.data
                         .map((query) => query.catalog_name)
                         .filter(

--- a/src/components/shared/Entity/Error/DraftErrors.tsx
+++ b/src/components/shared/Entity/Error/DraftErrors.tsx
@@ -15,7 +15,7 @@ function parseScopeCrumbs(scope: string): string[] {
 
     // Match either a resource with a JSON fragment pointer, or a simple resource.
     const pivot = scope.indexOf('#/');
-    if (pivot != -1) {
+    if (pivot !== -1) {
         // Decode the fragment into a JSON pointer.
         const ptr = decodeURIComponent(scope.slice(pivot + 2));
 
@@ -32,7 +32,7 @@ function parseScopeCrumbs(scope: string): string[] {
 
     // Strip the canonical source file used by control-plane builds.
     // It's not user-defined and thus not useful to the user.
-    if (parts[0] == 'file:///flow.json') {
+    if (parts[0] === 'file:///flow.json') {
         parts.shift();
     }
     return parts;

--- a/src/components/shared/Entity/Error/DraftErrors.tsx
+++ b/src/components/shared/Entity/Error/DraftErrors.tsx
@@ -1,4 +1,4 @@
-import { Paper } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import KeyValueList, { KeyValue } from 'components/shared/KeyValueList';
 import useDraftSpecErrors from 'hooks/useDraftSpecErrors';
 
@@ -31,11 +31,32 @@ function DraftErrors({ draftId, enablePolling }: DraftErrorProps) {
 
             return {
                 val: (
-                    <Paper variant="outlined" sx={{ overflow: 'auto', p: 1 }}>
+                    <Box
+                        sx={{
+                            overflow: 'auto',
+                            pl: 2,
+                            whiteSpace: 'pre',
+                        }}
+                    >
                         {detail}
-                    </Paper>
+                    </Box>
                 ),
-                title: filteredScope,
+                title: (
+                    <Typography
+                        variant="h6"
+                        component="span"
+                        sx={{
+                            borderWidth: 1,
+                            borderStyle: 'solid',
+                            borderLeft: 0,
+                            borderRight: 0,
+                            borderTop: 0,
+                            maxWidth: 'min-content',
+                        }}
+                    >
+                        {filteredScope}
+                    </Typography>
+                ),
             };
         });
         return <KeyValueList data={errors} disableTypography />;

--- a/src/components/shared/Entity/Error/DraftErrors.tsx
+++ b/src/components/shared/Entity/Error/DraftErrors.tsx
@@ -1,3 +1,4 @@
+import { Paper } from '@mui/material';
 import KeyValueList, { KeyValue } from 'components/shared/KeyValueList';
 import useDraftSpecErrors from 'hooks/useDraftSpecErrors';
 
@@ -10,11 +11,34 @@ function DraftErrors({ draftId, enablePolling }: DraftErrorProps) {
     const { draftSpecErrors } = useDraftSpecErrors(draftId, enablePolling);
 
     if (draftSpecErrors.length > 0) {
-        const errors: KeyValue[] = draftSpecErrors.map((draftError) => ({
-            title: draftError.detail,
-            val: draftError.scope,
-        }));
-        return <KeyValueList data={errors} />;
+        const errors: KeyValue[] = draftSpecErrors.map((draftError) => {
+            const filteredScope = draftError.scope
+                // Strip the canonical source file used by control-plane builds.
+                // It's not user-defined and thus not useful to the user.
+                .replace('file:///flow.json#', '')
+                // Remove JSON pointer escapes. The result is not technically a JSON pointer,
+                // but it's far more legible.
+                .replaceAll('~1', '/')
+                .replaceAll('~0', '~');
+
+            // // Split by seperator so we can make a breadcrumb
+            // const scopes = filteredScope
+            //     .split('/')
+            //     // Ensure the splits have values (mainly strips the first item)
+            //     .filter((value) => hasLength(value));
+
+            const detail = draftError.detail;
+
+            return {
+                val: (
+                    <Paper variant="outlined" sx={{ overflow: 'auto', p: 1 }}>
+                        {detail}
+                    </Paper>
+                ),
+                title: filteredScope,
+            };
+        });
+        return <KeyValueList data={errors} disableTypography />;
     } else {
         return null;
     }

--- a/src/components/shared/Entity/Error/index.tsx
+++ b/src/components/shared/Entity/Error/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack } from '@mui/material';
+import { useEditorStore_discoveredDraftId } from 'components/editor/Store/hooks';
 import DraftErrors, {
     DraftErrorProps,
 } from 'components/shared/Entity/Error/DraftErrors';
@@ -14,13 +15,26 @@ interface Props {
 }
 
 function EntityError({ logToken, error, title, draftId }: Props) {
+    const discoveredDraftId = useEditorStore_discoveredDraftId();
+
+    // When a user is discovering we need to make sure we show those errors
+    //  but we would not want to show then at the same time we show test/pub
+    //  draft errors.
+    const idForDraftErrors = discoveredDraftId
+        ? discoveredDraftId
+        : draftId
+        ? draftId
+        : null;
+
     return (
         <HeaderSummary severity="error" title={title}>
             <Stack direction="column" spacing={2}>
                 <Box>
                     <Error error={error} hideTitle={true} />
 
-                    {draftId ? <DraftErrors draftId={draftId} /> : null}
+                    {idForDraftErrors ? (
+                        <DraftErrors draftId={idForDraftErrors} />
+                    ) : null}
                 </Box>
 
                 <ErrorLogs

--- a/src/components/shared/KeyValueList/index.tsx
+++ b/src/components/shared/KeyValueList/index.tsx
@@ -19,10 +19,7 @@ function KeyValueList({ data, disableTypography, sectionTitle }: Props) {
                 {sectionTitle ? (
                     <Typography variant="subtitle1">{sectionTitle}</Typography>
                 ) : null}
-                <List
-                    dense
-                    sx={{ ml: 2, pt: 0, overflow: 'auto', maxHeight: 300 }}
-                >
+                <List dense sx={{ ml: 1, pt: 0, overflowY: 'auto' }}>
                     {data.map(({ title, val }, index) => (
                         <ListItem key={`${title}-keyValueList-${index}`}>
                             <ListItemText

--- a/src/components/shared/KeyValueList/index.tsx
+++ b/src/components/shared/KeyValueList/index.tsx
@@ -23,6 +23,9 @@ function KeyValueList({ data, sectionTitle }: Props) {
                             key={`${title}-keyValueList-${index}`}
                             primary={title}
                             secondary={val}
+                            sx={{
+                                whiteSpace: 'pre',
+                            }}
                         />
                     ))}
                 </List>

--- a/src/components/shared/KeyValueList/index.tsx
+++ b/src/components/shared/KeyValueList/index.tsx
@@ -19,16 +19,16 @@ function KeyValueList({ data, disableTypography, sectionTitle }: Props) {
                 {sectionTitle ? (
                     <Typography variant="subtitle1">{sectionTitle}</Typography>
                 ) : null}
-                <List dense sx={{ ml: 2, pt: 0 }}>
+                <List
+                    dense
+                    sx={{ ml: 2, pt: 0, overflow: 'auto', maxHeight: 300 }}
+                >
                     {data.map(({ title, val }, index) => (
                         <ListItem key={`${title}-keyValueList-${index}`}>
                             <ListItemText
                                 disableTypography={disableTypography}
                                 primary={title}
                                 secondary={val}
-                                sx={{
-                                    whiteSpace: 'pre',
-                                }}
                             />
                         </ListItem>
                     ))}

--- a/src/components/shared/KeyValueList/index.tsx
+++ b/src/components/shared/KeyValueList/index.tsx
@@ -1,16 +1,18 @@
-import { List, ListItemText, Typography } from '@mui/material';
+import { List, ListItem, ListItemText, Typography } from '@mui/material';
+import { ReactNode } from 'react';
 
 export type KeyValue = {
-    title: string;
-    val?: string;
+    title: string | ReactNode;
+    val?: string | ReactNode;
 };
 
 interface Props {
     data: KeyValue[];
+    disableTypography?: boolean;
     sectionTitle?: string;
 }
 
-function KeyValueList({ data, sectionTitle }: Props) {
+function KeyValueList({ data, disableTypography, sectionTitle }: Props) {
     if (data.length > 0) {
         return (
             <>
@@ -19,14 +21,16 @@ function KeyValueList({ data, sectionTitle }: Props) {
                 ) : null}
                 <List dense sx={{ ml: 2, pt: 0 }}>
                     {data.map(({ title, val }, index) => (
-                        <ListItemText
-                            key={`${title}-keyValueList-${index}`}
-                            primary={title}
-                            secondary={val}
-                            sx={{
-                                whiteSpace: 'pre',
-                            }}
-                        />
+                        <ListItem key={`${title}-keyValueList-${index}`}>
+                            <ListItemText
+                                disableTypography={disableTypography}
+                                primary={title}
+                                secondary={val}
+                                sx={{
+                                    whiteSpace: 'pre',
+                                }}
+                            />
+                        </ListItem>
                     ))}
                 </List>
             </>

--- a/src/hooks/useDraftSpecErrors.ts
+++ b/src/hooks/useDraftSpecErrors.ts
@@ -9,6 +9,7 @@ interface DraftErrorsQuery {
     draft_id: string;
 }
 
+const MAX_ERRORS_DISPLAYED = 10;
 const DRAFT_SPEC_COLS = ['scope', 'detail', 'draft_id'];
 const defaultResponse: DraftErrorsQuery[] = [];
 
@@ -17,7 +18,11 @@ function useDraftSpecErrors(draftId?: string | null, enablePolling?: boolean) {
         TABLES.DRAFT_ERRORS,
         {
             columns: DRAFT_SPEC_COLS,
-            filter: (query) => query.eq('draft_id', draftId as string),
+            count: 'exact',
+            filter: (query) =>
+                query
+                    .eq('draft_id', draftId as string)
+                    .limit(MAX_ERRORS_DISPLAYED),
         },
         [draftId]
     );
@@ -33,6 +38,7 @@ function useDraftSpecErrors(draftId?: string | null, enablePolling?: boolean) {
 
     return {
         draftSpecErrors: data ? data.data : defaultResponse,
+        count: data ? data.count : null,
         error,
         mutate,
         isValidating,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -968,6 +968,10 @@ const DataPlaneAuthReq: ResolvedIntlConfig['messages'] = {
     'dataPlaneAuthReq.waiting.message': `Please wait while we authorize access to {catalogPrefix}. You will be redirected shortly.`,
 };
 
+const DraftErrors: ResolvedIntlConfig['messages'] = {
+    'draftErrors.totalCount': `Displaying {displaying} of {total, plural, one {# error} other {# errors}} `,
+};
+
 const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...CommonMessages,
     ...CTAs,
@@ -1018,6 +1022,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...NewTransform,
     ...TaskEndpoints,
     ...DataPlaneAuthReq,
+    ...DraftErrors,
 };
 
 export default enUSMessages;


### PR DESCRIPTION
## Changes

1. Allow key value list to take in components as title and val
2. Have draft errors wrap on newlines for errors
3. Have the overflow get handled with scrolling
4. Flipping the DraftErrors title and val so the layout makes a bit more sense
5. 

## Tests

Manually

## Issues

From Google docs backlog

## Content

N/A

## Screenshots

New error format for draft errors
![image](https://user-images.githubusercontent.com/270078/236276271-f4bae42a-380b-4b60-bf65-56ca5bcc3aca.png)

