### PR TITLE
Add paid advertising option to onboarding survey

### DIFF
--- a/src/directives/Onboard/Survey.tsx
+++ b/src/directives/Onboard/Survey.tsx
@@ -36,6 +36,7 @@ function OnboardingSurvey() {
         intl.formatMessage({ id: 'tenant.origin.radio.youTube.label' }),
         intl.formatMessage({ id: 'tenant.origin.radio.email.label' }),
         intl.formatMessage({ id: 'tenant.origin.radio.gitHub.label' }),
+        intl.formatMessage({ id: 'tenant.origin.radio.paidAdvertising.label' }),
         surveyOptionOther,
     ]);
 

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -897,6 +897,7 @@ const Tenant: ResolvedIntlConfig['messages'] = {
     'tenant.origin.radio.youTube.label': `YouTube`,
     'tenant.origin.radio.email.label': `Email`,
     'tenant.origin.radio.gitHub.label': `GitHub`,
+    'tenant.origin.radio.paidAdvertising.label': `Paid Advertising`,
     'tenant.origin.radio.other.label': `Other`,
 };
 


### PR DESCRIPTION
## Changes

Add a _paid advertising_ option to the survey presented on the _Onboarding_ page.

## Issues

The issues directly below are completely resolved by this PR:
#596

## Screenshots

<img width="1102" alt="pr_screenshot-599-extend_survey-paid_advertising_option_added" src="https://user-images.githubusercontent.com/77648584/236547921-04da38d8-b9c6-4d7f-b402-08a177a3cb2d.PNG">
