### PR TITLE
prod: remove message from tenant invitation dialog

### DIFF
--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
@@ -92,7 +92,7 @@ function GenerateInvitation({
     };
 
     return (
-        <Grid container spacing={2} sx={{ mb: 5 }}>
+        <Grid container spacing={2} sx={{ mb: 5, pt: 1 }}>
             <Grid item xs={12} md={5}>
                 <AutocompletedField
                     label={intl.formatMessage({

--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/index.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/index.tsx
@@ -66,9 +66,9 @@ function SharePrefixDialog({ objectRoles, open, setOpen }: Props) {
             </DialogTitle>
 
             <DialogContent>
-                <Typography sx={{ mb: 3 }}>
+                {/* <Typography sx={{ mb: 3 }}>
                     <FormattedMessage id="admin.users.sharePrefix.message" />
-                </Typography>
+                </Typography> */}
 
                 {serverError ? (
                     <Box sx={{ mb: 3 }}>


### PR DESCRIPTION
## Changes

Remove the tenant invitation dialog description.

## Screenshots

<img width="1149" alt="content-removal" src="https://github.com/estuary/ui/assets/77648584/9d9cb653-0e92-4538-8eb6-5d8f72cc94d6">
