### PR TITLE
Bindings Selector UX Tweaks 1

### DIFF
--- a/src/components/collection/BindingSearch.tsx
+++ b/src/components/collection/BindingSearch.tsx
@@ -19,9 +19,10 @@ import { CollectionData } from './Selector/types';
 
 interface Props {
     readOnly?: boolean;
+    shortenName?: boolean;
 }
 
-function BindingSearch({ readOnly = false }: Props) {
+function BindingSearch({ shortenName, readOnly = false }: Props) {
     const entityType = useEntityType();
     const workflow = useEntityWorkflow();
 
@@ -188,7 +189,9 @@ function BindingSearch({ readOnly = false }: Props) {
             onChange={(value) => {
                 handlers.updateCollections(value as any);
             }}
-            getValue={(option: CollectionData) => stripPathing(option.name)}
+            getValue={(option: CollectionData) =>
+                shortenName ? stripPathing(option.name) : option.name
+            }
             AutocompleteProps={{
                 getOptionLabel: (option: CollectionData) => option.name,
                 groupBy: (option: CollectionData) => option.classification,

--- a/src/components/collection/BindingSearch.tsx
+++ b/src/components/collection/BindingSearch.tsx
@@ -13,6 +13,7 @@ import {
     useResourceConfig_setRestrictedDiscoveredCollections,
 } from 'stores/ResourceConfig/hooks';
 import useConstant from 'use-constant';
+import { stripPathing } from 'utils/misc-utils';
 import CollectionSelectorSearch from './Selector/Search';
 import { CollectionData } from './Selector/types';
 
@@ -187,7 +188,7 @@ function BindingSearch({ readOnly = false }: Props) {
             onChange={(value) => {
                 handlers.updateCollections(value as any);
             }}
-            getValue={(option: CollectionData) => option.name}
+            getValue={(option: CollectionData) => stripPathing(option.name)}
             AutocompleteProps={{
                 getOptionLabel: (option: CollectionData) => option.name,
                 groupBy: (option: CollectionData) => option.classification,

--- a/src/components/collection/BindingSearch.tsx
+++ b/src/components/collection/BindingSearch.tsx
@@ -20,12 +20,14 @@ import CollectionSelectorSearch from './Selector/Search';
 import { CollectionData } from './Selector/types';
 
 interface Props {
+    itemType?: string;
     emptyListComponent?: ReactNode;
     readOnly?: boolean;
     shortenName?: boolean;
 }
 
 function BindingSearch({
+    itemType,
     emptyListComponent,
     shortenName,
     readOnly = false,
@@ -214,6 +216,7 @@ function BindingSearch({
     if (collectionOptions.length > 0 && !specError) {
         return (
             <CollectionSelectorSearch
+                itemType={itemType}
                 options={collectionOptions}
                 readOnly={readOnly || formActive}
                 selectedCollections={collectionValues}

--- a/src/components/collection/BindingSearch.tsx
+++ b/src/components/collection/BindingSearch.tsx
@@ -1,6 +1,5 @@
 import { useEditorStore_persistedDraftId } from 'components/editor/Store/hooks';
 import { useEntityType } from 'context/EntityContext';
-import { useEntityWorkflow } from 'context/Workflow';
 import useDraftSpecs from 'hooks/useDraftSpecs';
 import useLiveSpecs from 'hooks/useLiveSpecs';
 import { useEffect, useMemo, useState } from 'react';
@@ -24,7 +23,7 @@ interface Props {
 
 function BindingSearch({ shortenName, readOnly = false }: Props) {
     const entityType = useEntityType();
-    const workflow = useEntityWorkflow();
+    const isCapture = entityType === 'capture';
 
     const intl = useIntl();
     const discoveredCollectionsLabel = useConstant(() =>
@@ -87,23 +86,21 @@ function BindingSearch({ shortenName, readOnly = false }: Props) {
 
     useEffect(() => {
         if (populateCollectionOptions) {
-            const liveSpecCollectionOptions: CollectionData[] =
-                workflow === 'capture_create'
-                    ? []
-                    : liveSpecs.map(({ catalog_name }) => ({
-                          name: catalog_name,
-                          classification: existingCollectionsLabel,
-                      }));
+            const liveSpecCollectionOptions: CollectionData[] = isCapture
+                ? []
+                : liveSpecs.map(({ catalog_name }) => ({
+                      name: catalog_name,
+                      classification: existingCollectionsLabel,
+                  }));
 
-            const draftSpecCollectionOptions: CollectionData[] =
-                entityType === 'capture'
-                    ? draftSpecs
-                          .filter(({ spec_type }) => spec_type === 'collection')
-                          .map(({ catalog_name }) => ({
-                              name: catalog_name,
-                              classification: discoveredCollectionsLabel,
-                          }))
-                    : [];
+            const draftSpecCollectionOptions: CollectionData[] = isCapture
+                ? draftSpecs
+                      .filter(({ spec_type }) => spec_type === 'collection')
+                      .map(({ catalog_name }) => ({
+                          name: catalog_name,
+                          classification: discoveredCollectionsLabel,
+                      }))
+                : [];
 
             const draftSpecCollections: string[] =
                 draftSpecCollectionOptions.map((collection) => collection.name);
@@ -118,14 +115,12 @@ function BindingSearch({ shortenName, readOnly = false }: Props) {
             setCollectionOptions(collectionsOnServer);
         }
     }, [
-        setCollectionOptions,
         discoveredCollectionsLabel,
         draftSpecs,
-        entityType,
         existingCollectionsLabel,
+        isCapture,
         liveSpecs,
         populateCollectionOptions,
-        workflow,
     ]);
 
     const populateCollectionValues = useMemo(() => {

--- a/src/components/collection/Selector/List.tsx
+++ b/src/components/collection/Selector/List.tsx
@@ -17,6 +17,7 @@ import CollectionSelectorRow from './Row';
 
 interface Props {
     collections: Set<string>;
+    header?: string;
     removeCollection?: (collectionName: string) => void;
     currentCollection?: any;
     setCurrentCollection?: (collection: any) => void;
@@ -36,6 +37,7 @@ const initialState = {
 function CollectionSelectorList({
     readOnly,
     collections,
+    header,
     removeCollection,
     currentCollection,
     setCurrentCollection,
@@ -44,10 +46,12 @@ function CollectionSelectorList({
 }: Props) {
     const onSelectTimeOut = useRef<number | null>(null);
     const intl = useIntl();
-    const collectionsLabel = useConstant(() =>
-        intl.formatMessage({
-            id: 'workflows.collectionSelector.label.listHeader',
-        })
+    const collectionsLabel = useConstant(
+        () =>
+            header ??
+            intl.formatMessage({
+                id: 'workflows.collectionSelector.label.listHeader',
+            })
     );
 
     const selectionEnabled = currentCollection && setCurrentCollection;

--- a/src/components/collection/Selector/Search.tsx
+++ b/src/components/collection/Selector/Search.tsx
@@ -19,8 +19,9 @@ interface Props {
     options: any[];
     onChange: (collections: string[], reason: AutocompleteChangeReason) => void;
     selectedCollections: string[] | CollectionData[];
-    readOnly?: boolean;
+    itemType?: string;
     getValue?: (option: any) => string;
+    readOnly?: boolean;
     AutocompleteProps?: any; // TODO (typing) - need to typ as props
 }
 
@@ -29,13 +30,19 @@ function CollectionSelectorSearch({
     onChange,
     selectedCollections,
     readOnly = false,
+    itemType,
     getValue,
     AutocompleteProps,
 }: Props) {
     const intl = useIntl();
-    const collectionsLabel = intl.formatMessage({
-        id: 'entityCreate.bindingsConfig.collectionsLabel',
-    });
+    const collectionsLabel = intl.formatMessage(
+        {
+            id: 'entityCreate.bindingsConfig.collectionsLabel',
+        },
+        {
+            items: itemType ?? intl.formatMessage({ id: 'terms.collections' }),
+        }
+    );
 
     const [missingInput, setMissingInput] = useState(false);
     const [inputValue, setInputValue] = useState('');

--- a/src/components/collection/schema/Editor/Skeleton.tsx
+++ b/src/components/collection/schema/Editor/Skeleton.tsx
@@ -4,6 +4,13 @@ import { FormattedMessage } from 'react-intl';
 function CollectionSchemaEditorSkeleton() {
     return (
         <>
+            <Stack>
+                <Typography variant="subtitle1" component="div">
+                    <FormattedMessage id="entityName.label" />
+                </Typography>
+                <Skeleton width={150} height={50} sx={{ mb: 1, mt: 0 }} />
+            </Stack>
+
             <Typography variant="subtitle1" component="div">
                 <FormattedMessage id="schemaEditor.key.label" />
             </Typography>

--- a/src/components/collection/schema/Editor/index.tsx
+++ b/src/components/collection/schema/Editor/index.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@mui/material';
+import { Grid, Stack, Typography } from '@mui/material';
 import {
     useBindingsEditorStore_editModeEnabled,
     useBindingsEditorStore_populateInferSchemaResponse,
@@ -11,6 +11,7 @@ import PropertiesViewer from 'components/schema/PropertiesViewer';
 import { useEntityType } from 'context/EntityContext';
 import useDraftSpecEditor from 'hooks/useDraftSpecEditor';
 import { useEffect, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { useUpdateEffect } from 'react-use';
 import { Schema } from 'types';
 import { getProperSchemaScope } from 'utils/schema-utils';
@@ -73,6 +74,19 @@ function CollectionSchemaEditor({ entityName }: Props) {
     if (draftSpec && entityName) {
         return (
             <Grid container>
+                <Stack
+                    sx={{
+                        alignItems: 'start',
+                        alignContent: 'start',
+                        mb: 3,
+                    }}
+                >
+                    <Typography variant="subtitle1" component="div">
+                        <FormattedMessage id="entityName.label" />
+                    </Typography>
+                    <Typography sx={{ ml: 1.5 }}>{entityName}</Typography>
+                </Stack>
+
                 <KeyAutoComplete
                     value={draftSpec.spec.key}
                     disabled={!editModeEnabled}

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -22,13 +22,14 @@ import {
     useResourceConfig_setRestrictedDiscoveredCollections,
 } from 'stores/ResourceConfig/hooks';
 import { EntityWorkflow } from 'types';
-import { hasLength } from 'utils/misc-utils';
+import { hasLength, stripPathing } from 'utils/misc-utils';
 
 interface BindingSelectorProps {
     loading: boolean;
     skeleton: ReactNode;
     readOnly?: boolean;
     RediscoverButton?: ReactNode;
+    shortenName?: boolean;
 }
 
 interface RowProps {
@@ -37,9 +38,17 @@ interface RowProps {
     workflow: EntityWorkflow | null;
     disabled: boolean;
     draftId: string | null;
+    shortenName?: boolean;
 }
 
-function Row({ collection, task, workflow, disabled, draftId }: RowProps) {
+function Row({
+    collection,
+    disabled,
+    draftId,
+    shortenName,
+    task,
+    workflow,
+}: RowProps) {
     // Resource Config Store
     const discoveredCollections = useResourceConfig_discoveredCollections();
     const removeCollection = useResourceConfig_removeCollection();
@@ -80,7 +89,7 @@ function Row({ collection, task, workflow, disabled, draftId }: RowProps) {
     return (
         <>
             <ListItemText
-                primary={collection}
+                primary={shortenName ? stripPathing(collection) : collection}
                 primaryTypographyProps={typographyTruncation}
             />
 
@@ -98,8 +107,9 @@ function Row({ collection, task, workflow, disabled, draftId }: RowProps) {
 
 function BindingSelector({
     loading,
-    skeleton,
     readOnly,
+    shortenName,
+    skeleton,
     RediscoverButton,
 }: BindingSelectorProps) {
     const theme = useTheme();
@@ -168,10 +178,11 @@ function BindingSelector({
 
                     <Row
                         collection={collection}
-                        task={task}
-                        workflow={workflow}
                         disabled={formActive}
                         draftId={draftId}
+                        shortenName={shortenName}
+                        task={task}
+                        workflow={workflow}
                     />
                 </>
             );
@@ -180,10 +191,11 @@ function BindingSelector({
         return (
             <Row
                 collection={collection}
-                task={task}
-                workflow={workflow}
                 disabled={formActive}
                 draftId={draftId}
+                shortenName={shortenName}
+                task={task}
+                workflow={workflow}
             />
         );
     };

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -211,7 +211,10 @@ function BindingSelector({
         <Box>{skeleton}</Box>
     ) : (
         <>
-            <BindingSearch readOnly={disableActions} />
+            <BindingSearch
+                readOnly={disableActions}
+                shortenName={shortenName}
+            />
 
             <CollectionSelectorActions
                 readOnly={disableActions ?? rows.size === 0}

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -27,6 +27,7 @@ import { hasLength, stripPathing } from 'utils/misc-utils';
 interface BindingSelectorProps {
     loading: boolean;
     skeleton: ReactNode;
+    itemType?: string;
     readOnly?: boolean;
     RediscoverButton?: ReactNode;
     shortenName?: boolean;
@@ -106,6 +107,7 @@ function Row({
 }
 
 function BindingSelector({
+    itemType,
     loading,
     readOnly,
     shortenName,
@@ -212,17 +214,19 @@ function BindingSelector({
     ) : (
         <>
             <BindingSearch
+                itemType={itemType}
                 readOnly={disableActions}
                 shortenName={shortenName}
             />
 
             <CollectionSelectorActions
-                readOnly={disableActions ?? rows.size === 0}
+                readOnly={rows.size === 0 || disableActions}
                 RediscoverButton={RediscoverButton}
                 removeAllCollections={handlers.removeAllCollections}
             />
 
             <CollectionSelectorList
+                header={itemType}
                 readOnly={disableActions}
                 collections={rows}
                 currentCollection={currentCollection}

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -19,7 +19,7 @@ import { DraftSpecQuery } from 'hooks/useDraftSpecs';
 import useLiveSpecs from 'hooks/useLiveSpecs';
 import { isEqual } from 'lodash';
 import { ReactNode, useEffect, useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import {
     useDetailsForm_connectorImage,
     useDetailsForm_details_entityName,
@@ -47,6 +47,7 @@ function BindingsMultiEditor({
     readOnly = false,
     RediscoverButton,
 }: Props) {
+    const intl = useIntl();
     const theme = useTheme();
 
     const localStore = useMemo(
@@ -150,6 +151,14 @@ function BindingsMultiEditor({
             ? liveSpecs.length === 0
             : draftSpecs.length === 0;
 
+    // For captures we want to show the bindings config as "Bindings"
+    //  Other entities we still call them "collections" so we set to undefined
+    //      as the default display is "collections"
+    const itemType =
+        entityType === 'capture'
+            ? intl.formatMessage({ id: 'terms.bindings' })
+            : undefined;
+
     return (
         <LocalZustandProvider createStore={localStore}>
             <Typography sx={{ mb: 2 }}>
@@ -161,6 +170,7 @@ function BindingsMultiEditor({
             <ListAndDetails
                 list={
                     <BindingSelector
+                        itemType={itemType}
                         shortenName={entityType === 'capture'}
                         loading={fetchingSpecs}
                         skeleton={<BindingsSelectorSkeleton />}

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -58,6 +58,7 @@ function BindingsMultiEditor({
 
     const entityType = useEntityType();
     const workflow = useEntityWorkflow();
+    const isCaptureCreate = workflow === 'capture_create';
 
     // Details Form Store
     const catalogName = useDetailsForm_details_entityName();
@@ -122,7 +123,7 @@ function BindingsMultiEditor({
 
     const removeDiscoveredCollectionOptions = useMemo(() => {
         if (
-            workflow === 'capture_create' &&
+            isCaptureCreate &&
             discoveredCollections &&
             discoveredCollections.length > 0 &&
             draftSpecs.length > 0
@@ -135,7 +136,7 @@ function BindingsMultiEditor({
         } else {
             return false;
         }
-    }, [catalogName, discoveredCollections, draftSpecs, workflow]);
+    }, [catalogName, discoveredCollections, draftSpecs, isCaptureCreate]);
 
     useEffect(() => {
         if (removeDiscoveredCollectionOptions) {
@@ -161,6 +162,7 @@ function BindingsMultiEditor({
             <ListAndDetails
                 list={
                     <BindingSelector
+                        shortenName={true}
                         loading={fetchingSpecs}
                         skeleton={<BindingsSelectorSkeleton />}
                         readOnly={readOnly}

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -58,7 +58,6 @@ function BindingsMultiEditor({
 
     const entityType = useEntityType();
     const workflow = useEntityWorkflow();
-    const isCaptureCreate = workflow === 'capture_create';
 
     // Details Form Store
     const catalogName = useDetailsForm_details_entityName();
@@ -123,7 +122,7 @@ function BindingsMultiEditor({
 
     const removeDiscoveredCollectionOptions = useMemo(() => {
         if (
-            isCaptureCreate &&
+            workflow === 'capture_create' &&
             discoveredCollections &&
             discoveredCollections.length > 0 &&
             draftSpecs.length > 0
@@ -136,7 +135,7 @@ function BindingsMultiEditor({
         } else {
             return false;
         }
-    }, [catalogName, discoveredCollections, draftSpecs, isCaptureCreate]);
+    }, [catalogName, discoveredCollections, draftSpecs, workflow]);
 
     useEffect(() => {
         if (removeDiscoveredCollectionOptions) {

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -162,7 +162,7 @@ function BindingsMultiEditor({
             <ListAndDetails
                 list={
                     <BindingSelector
-                        shortenName={true}
+                        shortenName={entityType === 'capture'}
                         loading={fetchingSpecs}
                         skeleton={<BindingsSelectorSkeleton />}
                         readOnly={readOnly}

--- a/src/components/schema/KeyAutoComplete/ReadOnly.tsx
+++ b/src/components/schema/KeyAutoComplete/ReadOnly.tsx
@@ -79,6 +79,7 @@ function ReadOnly({ value }: Props) {
                         flexFlow: 'wrap',
                         overflowY: 'wr',
                         pl: 0,
+                        mt: 0,
                     }}
                 >
                     {value.map((key: string) => {

--- a/src/components/tables/Collections/useCollectionColumns.tsx
+++ b/src/components/tables/Collections/useCollectionColumns.tsx
@@ -44,7 +44,7 @@ const useCollectionColumns = (): ColumnProps[] => {
     return useMemo(() => {
         if (hasDetails) {
             const response = [...defaultColumns];
-            response.splice(2, 1, statsHeader);
+            response.splice(2, 0, statsHeader);
             return response;
         } else {
             return defaultColumns;

--- a/src/hooks/useLiveSpecs.ts
+++ b/src/hooks/useLiveSpecs.ts
@@ -15,17 +15,29 @@ const queryColumns = ['catalog_name', 'spec_type'];
 
 const defaultResponse: LiveSpecsQuery[] = [];
 
-function useLiveSpecs(specType: Entity) {
+function useLiveSpecs(specType: Entity, matchName?: string) {
     const draftSpecQuery = useQuery<LiveSpecsQuery>(
         TABLES.LIVE_SPECS_EXT,
         {
             columns: queryColumns,
-            filter: (query) =>
-                query.eq('spec_type', specType).order('updated_at', {
-                    ascending: false,
-                }),
+            filter: (query) => {
+                let queryBuilder = query
+                    .eq('spec_type', specType)
+                    .order('updated_at', {
+                        ascending: false,
+                    });
+
+                if (matchName) {
+                    queryBuilder = queryBuilder.like(
+                        'catalog_name',
+                        `${matchName}%`
+                    );
+                }
+
+                return queryBuilder;
+            },
         },
-        [specType]
+        [specType, matchName]
     );
 
     const { data, error, isValidating } = useSelect(draftSpecQuery);

--- a/src/hooks/useLiveSpecs.ts
+++ b/src/hooks/useLiveSpecs.ts
@@ -15,7 +15,7 @@ const queryColumns = ['catalog_name', 'spec_type'];
 
 const defaultResponse: LiveSpecsQuery[] = [];
 
-function useLiveSpecs(specType: Entity, matchName?: string) {
+function useLiveSpecs(specType?: Entity, matchName?: string) {
     const draftSpecQuery = useQuery<LiveSpecsQuery>(
         TABLES.LIVE_SPECS_EXT,
         {
@@ -40,7 +40,9 @@ function useLiveSpecs(specType: Entity, matchName?: string) {
         [specType, matchName]
     );
 
-    const { data, error, isValidating } = useSelect(draftSpecQuery);
+    const { data, error, isValidating } = useSelect(
+        specType ? draftSpecQuery : null
+    );
 
     return {
         liveSpecs: data ? data.data : defaultResponse,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -46,6 +46,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     // Terms
     'terms.connectors': `Connectors`,
     'terms.collections': `Collections`,
+    'terms.bindings': `Bindings`,
     'terms.permissions': `Access Grants`,
     'terms.materialization': `Materialization`,
     'terms.capture': `Capture`,
@@ -614,8 +615,8 @@ const EntityCreate: ResolvedIntlConfig['messages'] = {
 
     'entityCreate.endpointConfig.configCanBeBlank.message': `This {entityType} requires no configuration.`,
 
-    'entityCreate.bindingsConfig.collectionsLabel': `Available ${CommonMessages['terms.collections']}`,
-    'entityCreate.bindingsConfig.noRows': `Please select from the ${CommonMessages['terms.collections']} above to begin.`,
+    'entityCreate.bindingsConfig.collectionsLabel': `Available {items}`,
+    'entityCreate.bindingsConfig.noRows': `Please select from the list above to begin.`,
     'entityCreate.bindingsConfig.noRowsTitle': `No selection made`,
 
     'entityCreate.connector.label': `${CommonMessages['connector.label']} Search`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -651,7 +651,7 @@ const CaptureCreate: ResolvedIntlConfig['messages'] = {
 
     'captureCreate.collections.heading': `Output Collections`,
     'captureCreate.collectionSelector.heading': `Collection Selector`,
-    'captureCreate.collectionSelector.instructions': `The collections bound to your capture. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Specification tab.`,
+    'captureCreate.collectionSelector.instructions': `The collections bound to your capture. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Collection tab.`,
 
     'captureCreate.test.failedErrorTitle': `Configuration Test Failed`,
     'captureCreate.test.serverUnreachable': `Unable to reach server while testing configuration.`,
@@ -687,7 +687,7 @@ const CaptureEdit: ResolvedIntlConfig['messages'] = {
 
     'captureEdit.collections.heading': `Output Collections`,
     'captureEdit.collectionSelector.heading': `Collection Selector`,
-    'captureEdit.collectionSelector.instructions': `The collections bound to your existing capture. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Specification tab.`,
+    'captureEdit.collectionSelector.instructions': `The collections bound to your existing capture. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Collection tab.`,
 
     'captureEdit.test.failedErrorTitle': `Configuration Test Failed`,
     'captureEdit.test.serverUnreachable': `Unable to reach server while testing configuration.`,
@@ -782,7 +782,7 @@ const MaterializationEdit: ResolvedIntlConfig['messages'] = {
     'materializationEdit.test.inProgress': `Please wait while we try to connect to the destination.`,
 
     'materializationEdit.collectionSelector.heading': `Collection Selector`,
-    'materializationEdit.collectionSelector.instructions': `The collections bound to your existing materialization. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Specification tab.`,
+    'materializationEdit.collectionSelector.instructions': `The collections bound to your existing materialization. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Collection tab.`,
 
     'materializationEdit.resourceConfig.heading': `Resource Configuration`,
     'materializationEdit.save.failedErrorTitle': `Materialization Save Failed`,
@@ -838,7 +838,7 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.collectionSelector.label.discoveredCollections': `Discovered Collections`,
     'workflows.collectionSelector.label.existingCollections': `Existing Collections`,
     'workflows.collectionSelector.label.listHeader': `Collections`,
-    'workflows.collectionSelector.tab.collectionSchema': `Schema`,
+    'workflows.collectionSelector.tab.collectionSchema': `Collection`,
     'workflows.collectionSelector.tab.resourceConfig': `Config`,
 
     'workflows.collectionSelector.schemaEdit.cta.syncSchema': `Synchronize Schema`,

--- a/src/stores/Tables/Store.ts
+++ b/src/stores/Tables/Store.ts
@@ -132,6 +132,10 @@ export const getInitialState = (
         setRows: (val) => {
             set(
                 produce(({ rows }) => {
+                    // Reset rows so we start with an empty map
+                    rows.clear();
+
+                    // Go through all the rows and add to the map
                     val.forEach((el) => {
                         rows.set(el.id, el);
                     });

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -12,6 +12,12 @@ export const stripPathing = (stringVal: string) => {
     );
 };
 
+export const stripName = (stringVal: string) => {
+    if (!stringVal) return stringVal;
+
+    return stringVal.substring(0, stringVal.lastIndexOf('/') + 1);
+};
+
 export const hasLength = (val: string | any[] | null | undefined): boolean => {
     return Boolean(val && val.length > 0);
 };


### PR DESCRIPTION
## Changes

1. Show only the final part of the name in the output collections list
2. Update the `schema` tab to `collections` tab
3. Added the full name to the collection tab

## Tests

Manual

## Issues

Part of https://github.com/estuary/ui/issues/611

## Content

Schema -> Collection tab is all

## Screenshots

Default view
![image](https://github.com/estuary/ui/assets/270078/85e66873-6bd1-408f-b7b0-c6297930d19d)

Collection tab
![image](https://github.com/estuary/ui/assets/270078/aeb66e46-8c29-4f3f-888b-17fed8fc8fd3)

