### PR TITLE
Entity name UX Tweaks 1

### DIFF
--- a/src/forms/renderers/CatalogName/AutoComplete.tsx
+++ b/src/forms/renderers/CatalogName/AutoComplete.tsx
@@ -105,6 +105,7 @@ export const CatalogNameAutoComplete = (
             disabled={!enabled}
             freeSolo
             fullWidth
+            selectOnFocus={false}
             getOptionLabel={getStringValue}
             id={id}
             inputValue={inputValue}

--- a/src/forms/renderers/CatalogName/AutoComplete.tsx
+++ b/src/forms/renderers/CatalogName/AutoComplete.tsx
@@ -117,7 +117,7 @@ export const CatalogNameAutoComplete = (
                 getStringValue(option) === value
             }
             onChange={(_event: any, newValue: any) => {
-                handleChange(path, newValue?.const);
+                handleChange(path, getStringValue(newValue));
             }}
             onInputChange={(_event, newInputValue) => {
                 setInputValue(newInputValue);

--- a/src/forms/renderers/CatalogName/AutoComplete.tsx
+++ b/src/forms/renderers/CatalogName/AutoComplete.tsx
@@ -34,7 +34,6 @@ import {
     FilterOptionsState,
     Input,
 } from '@mui/material';
-import { throttle } from 'lodash';
 import merge from 'lodash/merge';
 import React, { ReactNode } from 'react';
 
@@ -73,6 +72,7 @@ export const CatalogNameAutoComplete = (
         data,
         className,
         id,
+        isValid,
         enabled,
         path,
         handleChange,
@@ -84,35 +84,44 @@ export const CatalogNameAutoComplete = (
 
     const options = generateOptionsArray(rootSchema as JsonSchema7, path);
     const appliedUiSchemaOptions = merge({}, config, options);
-    const [inputValue, setInputValue] = React.useState(data ?? '');
+    const singleOption = options.length === 1;
+    const singleOptionString = getStringValue(options[0]);
 
-    const debounceUpdate = throttle((newInputValue: any) => {
-        handleChange(path, newInputValue);
-    }, 250);
+    // Attempt to set the input value to:
+    //  The data provided
+    //  The only option
+    //  Default to blank
+    const [inputValue, setInputValue] = React.useState(
+        data ? data : singleOption ? singleOptionString : ''
+    );
+    const inputEmpty = inputValue.length === 0;
 
     return (
         <Autocomplete
+            autoComplete
+            autoHighlight
             className={className}
-            id={id}
+            disableClearable
             disabled={!enabled}
-            value={inputValue}
+            freeSolo
+            fullWidth
+            getOptionLabel={getStringValue}
+            id={id}
             inputValue={inputValue}
+            openOnFocus={!isValid || inputEmpty}
+            options={options}
+            style={{ marginTop: 16 }}
+            value={inputValue}
+            isOptionEqualToValue={(option, value) =>
+                getStringValue(option) === value
+            }
             onChange={(_event: any, newValue: any) => {
-                handleChange(path, newValue?.value);
+                handleChange(path, newValue?.const);
             }}
             onInputChange={(_event, newInputValue) => {
                 setInputValue(newInputValue);
-                debounceUpdate(newInputValue);
+                handleChange(path, newInputValue);
             }}
-            autoHighlight
-            autoComplete
-            disableClearable
-            openOnFocus={inputValue.length === 0}
-            fullWidth
-            freeSolo
-            options={options}
-            getOptionLabel={getStringValue}
-            style={{ marginTop: 16 }}
             renderInput={(params) => (
                 <Input
                     style={{ width: '100%' }}


### PR DESCRIPTION
## Changes

1. Default the input to the only prefix is there is only one

## Tests

Manually tested create and edit

## Issues

https://github.com/estuary/ui/issues/616

## Content

n/a

## Screenshots

Only allowed prefix will be prefilled
![image](https://github.com/estuary/ui/assets/270078/4f04c121-d745-4145-8cf0-d7cce172c443)

Has multiple prefix so not prefilled
![image](https://github.com/estuary/ui/assets/270078/c435c9ea-3b06-41bb-98e4-5c5f7a73dd68)
