### PR TITLE
Integrate the billing RPC

### DIFF
--- a/.env.development.local
+++ b/.env.development.local
@@ -2,13 +2,13 @@
 # These properties are used when running locally. They match the defaults that you get when running
 # `supabase start` in animated-carnival.
 
-#REACT_APP_SUPABASE_URL=http://localhost:5431
+REACT_APP_SUPABASE_URL=http://localhost:5431
 
 # Supabase CLI pre v1.40
 #REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs
 
 # Supabase CLI v1.40
-#REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
 
 REACT_APP_GATEWAY_AUTH_TOKEN_URL=http://localhost:5431/rest/v1/rpc/gateway_auth_token
 
@@ -26,7 +26,3 @@ REACT_APP_DOCS_ORIGIN=http://localhost:3001
 #REACT_APP_DOCS_IFRAME_STRING_INCLUDE=localhost
 
 REACT_APP_STRIPE_PUBLISHABLE_KEY=pk_test_51LC6y0L0ioq4FQU8AaJOK8SqjH4NCFuYh0hYPOLGvPUaSL3SPku0YECw0Fg7fYEXgBN87f37TNviHxjnMX7wlmwg00La2sdB2O
-
-# REMOVE
-REACT_APP_SUPABASE_URL=https://eyrcnmuzzyriypdajwdk.supabase.co
-REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco

--- a/.env.development.local
+++ b/.env.development.local
@@ -2,13 +2,13 @@
 # These properties are used when running locally. They match the defaults that you get when running
 # `supabase start` in animated-carnival.
 
-REACT_APP_SUPABASE_URL=http://localhost:5431
+#REACT_APP_SUPABASE_URL=http://localhost:5431
 
 # Supabase CLI pre v1.40
 #REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs
 
 # Supabase CLI v1.40
-REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+#REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
 
 REACT_APP_GATEWAY_AUTH_TOKEN_URL=http://localhost:5431/rest/v1/rpc/gateway_auth_token
 
@@ -26,3 +26,7 @@ REACT_APP_DOCS_ORIGIN=http://localhost:3001
 #REACT_APP_DOCS_IFRAME_STRING_INCLUDE=localhost
 
 REACT_APP_STRIPE_PUBLISHABLE_KEY=pk_test_51LC6y0L0ioq4FQU8AaJOK8SqjH4NCFuYh0hYPOLGvPUaSL3SPku0YECw0Fg7fYEXgBN87f37TNviHxjnMX7wlmwg00La2sdB2O
+
+# REMOVE
+REACT_APP_SUPABASE_URL=https://eyrcnmuzzyriypdajwdk.supabase.co
+REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco

--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -1,4 +1,5 @@
 import { PostgrestSingleResponse } from '@supabase/postgrest-js';
+import { format } from 'date-fns';
 import {
     FUNCTIONS,
     invokeSupabase,
@@ -62,12 +63,17 @@ export interface BillingRecord {
 
 export const getBillingRecord = (
     billed_prefix: string,
-    billed_month: string
+    month: string | Date
 ) => {
+    const formattedMonth: string =
+        typeof month === 'string'
+            ? month
+            : format(month, "yyyy-MM-dd' 00:00:00+00'");
+
     return supabaseClient
         .rpc<BillingRecord>(RPCS.BILLING_REPORT, {
             billed_prefix,
-            billed_month,
+            billed_month: formattedMonth,
         })
         .throwOnError()
         .single();

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -108,14 +108,12 @@ const getStatsByName = (names: string[], filter?: StatsFilter) => {
     return queryBuilder.then(handleSuccess<CatalogStats[]>, handleFailure);
 };
 
-const getStatsForBilling = (tenants: string[]) => {
+const getStatsForBilling = (tenants: string[], startDate: string) => {
     const subjectRoleFilters = tenants
         .map((tenant) => `catalog_name.ilike.${tenant}%`)
         .join(',');
 
     const today = new Date();
-    const currentMonth = startOfMonth(today);
-    const startMonth = subMonths(currentMonth, 5);
 
     return supabaseClient
         .from<CatalogStats_Billing>(TABLES.CATALOG_STATS)
@@ -130,13 +128,15 @@ const getStatsForBilling = (tenants: string[]) => {
         `
         )
         .eq('grain', 'monthly')
-        .gte('ts', formatToGMT(startMonth))
+        .gte('ts', formatToGMT(startDate))
         .lt('ts', formatToGMT(today))
         .or(subjectRoleFilters)
         .order('ts', { ascending: false });
 };
 
-// TODO (billing): Enable pagination when the new RPC is available.
+// TODO (billing): Enable pagination when a database table containing historic billing data is available.
+//   This function is temporarily unused since the billing history table component is using filtered data
+//   returned by the billing_report RPC to populate the contents of its rows.
 const getStatsForBillingHistoryTable = (
     tenants: string[],
     // pagination: any,

--- a/src/components/admin/Billing/PricingTierDetails.tsx
+++ b/src/components/admin/Billing/PricingTierDetails.tsx
@@ -6,7 +6,7 @@ import {
     useBilling_billingHistory,
     useBilling_hydrated,
 } from 'stores/Billing/hooks';
-import { BillingRecord } from 'stores/Billing/types';
+import { FormattedBillingRecord } from 'stores/Billing/types';
 import useConstant from 'use-constant';
 import { FREE_GB_BY_TIER } from 'utils/billing-utils';
 
@@ -19,19 +19,20 @@ function PricingTierDetails() {
     const billingStoreHydrated = useBilling_hydrated();
     const billingHistory = useBilling_billingHistory();
 
-    const latestBillingRecord: BillingRecord | undefined = useMemo(() => {
-        if (billingHistory.length > 0) {
-            const evaluatedBillingRecord = billingHistory.find((record) =>
-                isSameMonth(record.date, today)
-            );
+    const latestBillingRecord: FormattedBillingRecord | undefined =
+        useMemo(() => {
+            if (billingHistory.length > 0) {
+                const evaluatedBillingRecord = billingHistory.find((record) =>
+                    isSameMonth(record.date, today)
+                );
 
-            return evaluatedBillingRecord
-                ? evaluatedBillingRecord
-                : billingHistory[0];
-        } else {
-            return undefined;
-        }
-    }, [billingHistory, today]);
+                return evaluatedBillingRecord
+                    ? evaluatedBillingRecord
+                    : billingHistory[0];
+            } else {
+                return undefined;
+            }
+        }, [billingHistory, today]);
 
     if (
         latestBillingRecord?.pricingTier &&

--- a/src/components/admin/Billing/graphs/DataByMonthGraph.tsx
+++ b/src/components/admin/Billing/graphs/DataByMonthGraph.tsx
@@ -63,8 +63,6 @@ function DataByMonthGraph() {
             .filter(({ billed_month }) => {
                 const billedMonth = stripTimeFromDate(billed_month);
 
-                console.log(billedMonth);
-
                 return isWithinInterval(billedMonth, {
                     start: startDate,
                     end: today,

--- a/src/components/admin/Billing/graphs/DataByMonthGraph.tsx
+++ b/src/components/admin/Billing/graphs/DataByMonthGraph.tsx
@@ -181,12 +181,18 @@ function DataByMonthGraph() {
                             } else {
                                 const tooltipTitle =
                                     billingHistory
-                                        .map(({ billed_month }) =>
-                                            intl.formatDate(billed_month, {
-                                                month: 'short',
-                                                year: 'numeric',
-                                            })
-                                        )
+                                        .map(({ billed_month }) => {
+                                            const billedMonth =
+                                                stripTimeFromDate(billed_month);
+
+                                            return intl.formatDate(
+                                                billedMonth,
+                                                {
+                                                    month: 'short',
+                                                    year: 'numeric',
+                                                }
+                                            );
+                                        })
                                         .find((date) =>
                                             date.includes(config.axisValueLabel)
                                         ) ?? config.axisValueLabel;

--- a/src/components/admin/Billing/graphs/DataByMonthGraph.tsx
+++ b/src/components/admin/Billing/graphs/DataByMonthGraph.tsx
@@ -23,10 +23,8 @@ import {
 } from 'stores/Billing/hooks';
 import useConstant from 'use-constant';
 import {
-    BYTES_PER_GB,
     CARD_AREA_HEIGHT,
     formatDataVolumeForDisplay,
-    FREE_GB_BY_TIER,
     SeriesConfig,
     SeriesNames,
 } from 'utils/billing-utils';
@@ -58,56 +56,40 @@ function DataByMonthGraph() {
 
         const scopedDataSet: {
             month: string;
-            dataVolume: number;
-            gbFree: number | null;
+            includedDataVolume: number;
+            surplusDataVolume: number;
         }[] = billingHistory
-            .filter(({ date }) =>
-                isWithinInterval(date, {
+            .filter(({ billed_month }) => {
+                const billedMonth = new Date(billed_month);
+
+                return isWithinInterval(billedMonth, {
                     start: startDate,
                     end: today,
-                })
-            )
-            .map(({ date, dataVolume, gbFree }) => ({
-                month: intl.formatDate(date, { month: 'short' }),
-                dataVolume,
-                gbFree,
+                });
+            })
+            .map(({ billed_month, line_items }) => ({
+                month: intl.formatDate(billed_month, { month: 'short' }),
+                includedDataVolume: line_items[2].count,
+                surplusDataVolume: line_items[3].count,
             }));
 
         return scopedDataSet.flatMap(
-            ({ month, dataVolume, gbFree }): SeriesConfig | SeriesConfig[] => {
-                const freeBytes =
-                    (gbFree ?? FREE_GB_BY_TIER.PERSONAL) * BYTES_PER_GB;
-
-                if (dataVolume > freeBytes) {
-                    const byteSurplus = dataVolume - freeBytes;
-
-                    return [
-                        {
-                            seriesName: SeriesNames.INCLUDED,
-                            stack: stackId,
-                            data: [[month, freeBytes]],
-                        },
-                        {
-                            seriesName: SeriesNames.SURPLUS,
-                            stack: stackId,
-                            data: [[month, byteSurplus]],
-                        },
-                    ];
-                } else {
-                    return [
-                        {
-                            seriesName: SeriesNames.INCLUDED,
-                            stack: stackId,
-                            data: [[month, dataVolume]],
-                        },
-                        {
-                            seriesName: SeriesNames.SURPLUS,
-                            stack: stackId,
-                            data: [[month, 0]],
-                        },
-                    ];
-                }
-            }
+            ({
+                month,
+                includedDataVolume,
+                surplusDataVolume,
+            }): SeriesConfig | SeriesConfig[] => [
+                {
+                    seriesName: SeriesNames.INCLUDED,
+                    stack: stackId,
+                    data: [[month, includedDataVolume]],
+                },
+                {
+                    seriesName: SeriesNames.SURPLUS,
+                    stack: stackId,
+                    data: [[month, surplusDataVolume]],
+                },
+            ]
         );
     }, [billingHistory, intl, today]);
 
@@ -156,7 +138,7 @@ function DataByMonthGraph() {
                     barMinHeight: seriesName === SeriesNames.INCLUDED ? 3 : 0,
                     data: data.map(([month, dataVolume]) => [
                         month,
-                        (dataVolume / BYTES_PER_GB).toFixed(3),
+                        dataVolume.toFixed(3),
                     ]),
                 })),
                 textStyle: {
@@ -194,8 +176,8 @@ function DataByMonthGraph() {
                             } else {
                                 const tooltipTitle =
                                     billingHistory
-                                        .map(({ date }) =>
-                                            intl.formatDate(date, {
+                                        .map(({ billed_month }) =>
+                                            intl.formatDate(billed_month, {
                                                 month: 'short',
                                                 year: 'numeric',
                                             })

--- a/src/components/admin/Billing/graphs/DataByMonthGraph.tsx
+++ b/src/components/admin/Billing/graphs/DataByMonthGraph.tsx
@@ -27,6 +27,7 @@ import {
     formatDataVolumeForDisplay,
     SeriesConfig,
     SeriesNames,
+    stripTimeFromDate,
 } from 'utils/billing-utils';
 
 const stackId = 'Data Volume';
@@ -60,18 +61,24 @@ function DataByMonthGraph() {
             surplusDataVolume: number;
         }[] = billingHistory
             .filter(({ billed_month }) => {
-                const billedMonth = new Date(billed_month);
+                const billedMonth = stripTimeFromDate(billed_month);
+
+                console.log(billedMonth);
 
                 return isWithinInterval(billedMonth, {
                     start: startDate,
                     end: today,
                 });
             })
-            .map(({ billed_month, line_items }) => ({
-                month: intl.formatDate(billed_month, { month: 'short' }),
-                includedDataVolume: line_items[2].count,
-                surplusDataVolume: line_items[3].count,
-            }));
+            .map(({ billed_month, line_items }) => {
+                const billedMonth = stripTimeFromDate(billed_month);
+
+                return {
+                    month: intl.formatDate(billedMonth, { month: 'short' }),
+                    includedDataVolume: line_items[2].count,
+                    surplusDataVolume: line_items[3].count,
+                };
+            });
 
         return scopedDataSet.flatMap(
             ({

--- a/src/components/admin/Billing/graphs/DataByTaskGraph.tsx
+++ b/src/components/admin/Billing/graphs/DataByTaskGraph.tsx
@@ -212,7 +212,8 @@ function DataByTaskGraph() {
                         tooltipConfigs.forEach((config) => {
                             const dataVolume = formatDataVolumeForDisplay(
                                 seriesConfig,
-                                config
+                                config,
+                                true
                             );
 
                             if (content) {

--- a/src/components/admin/Billing/graphs/TasksByMonthGraph.tsx
+++ b/src/components/admin/Billing/graphs/TasksByMonthGraph.tsx
@@ -175,12 +175,18 @@ function DataByMonthGraph() {
                             } else {
                                 const tooltipTitle =
                                     billingHistory
-                                        .map(({ billed_month }) =>
-                                            intl.formatDate(billed_month, {
-                                                month: 'short',
-                                                year: 'numeric',
-                                            })
-                                        )
+                                        .map(({ billed_month }) => {
+                                            const billedMonth =
+                                                stripTimeFromDate(billed_month);
+
+                                            return intl.formatDate(
+                                                billedMonth,
+                                                {
+                                                    month: 'short',
+                                                    year: 'numeric',
+                                                }
+                                            );
+                                        })
                                         .find((date) =>
                                             date.includes(config.axisValueLabel)
                                         ) ?? config.axisValueLabel;

--- a/src/components/admin/Billing/graphs/TasksByMonthGraph.tsx
+++ b/src/components/admin/Billing/graphs/TasksByMonthGraph.tsx
@@ -67,12 +67,13 @@ function DataByMonthGraph() {
                     end: today,
                 });
             })
-            .map(({ billed_month, line_items }) => {
+            .map(({ billed_month, line_items, max_concurrent_tasks }) => {
                 const billedMonth = stripTimeFromDate(billed_month);
 
                 return {
                     month: intl.formatDate(billedMonth, { month: 'short' }),
-                    includedTasks: line_items[0].count,
+                    includedTasks:
+                        max_concurrent_tasks > 0 ? line_items[0].count : 0,
                     surplusTasks: line_items[1].count,
                 };
             });

--- a/src/components/admin/Billing/graphs/TasksByMonthGraph.tsx
+++ b/src/components/admin/Billing/graphs/TasksByMonthGraph.tsx
@@ -26,6 +26,7 @@ import {
     CARD_AREA_HEIGHT,
     SeriesConfig,
     SeriesNames,
+    stripTimeFromDate,
 } from 'utils/billing-utils';
 
 const stackId = 'Task Count';
@@ -59,18 +60,22 @@ function DataByMonthGraph() {
             surplusTasks: number;
         }[] = billingHistory
             .filter(({ billed_month }) => {
-                const billedMonth = new Date(billed_month);
+                const billedMonth = stripTimeFromDate(billed_month);
 
                 return isWithinInterval(billedMonth, {
                     start: startDate,
                     end: today,
                 });
             })
-            .map(({ billed_month, line_items }) => ({
-                month: intl.formatDate(billed_month, { month: 'short' }),
-                includedTasks: line_items[0].count,
-                surplusTasks: line_items[1].count,
-            }));
+            .map(({ billed_month, line_items }) => {
+                const billedMonth = stripTimeFromDate(billed_month);
+
+                return {
+                    month: intl.formatDate(billedMonth, { month: 'short' }),
+                    includedTasks: line_items[0].count,
+                    surplusTasks: line_items[1].count,
+                };
+            });
 
         return scopedDataSet.flatMap(
             ({

--- a/src/components/admin/Billing/index.tsx
+++ b/src/components/admin/Billing/index.tsx
@@ -14,7 +14,7 @@ import AlertBox from 'components/shared/AlertBox';
 import BillingHistoryTable from 'components/tables/Billing';
 import { eachMonthOfInterval, format, startOfMonth, subMonths } from 'date-fns';
 import useBillingCatalogStats from 'hooks/billing/useBillingCatalogStats';
-import useBillingHistory from 'hooks/billing/useBillingHistory';
+import useBillingRecord from 'hooks/billing/useBillingRecord';
 import usePageTitle from 'hooks/usePageTitle';
 import { useEffect, useMemo, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -73,8 +73,8 @@ function AdminBilling() {
         isValidating: isValidatingStats,
     } = useBillingCatalogStats();
 
-    const { billingHistory, isValidating: isValidatingHistory } =
-        useBillingHistory(currentMonth);
+    const { billingRecord, isValidating: isValidatingRecord } =
+        useBillingRecord(currentMonth);
 
     useEffect(() => {
         if (!isValidatingStats && billingStats) {
@@ -139,16 +139,16 @@ function AdminBilling() {
     useEffect(() => {
         if (
             historyInitialized &&
-            !isValidatingHistory &&
-            hasLength(billingHistory)
+            !isValidatingRecord &&
+            hasLength(billingRecord)
         ) {
-            updateBillingHistory(billingHistory);
+            updateBillingHistory(billingRecord);
         }
     }, [
         updateBillingHistory,
-        billingHistory,
+        billingRecord,
         historyInitialized,
-        isValidatingHistory,
+        isValidatingRecord,
     ]);
 
     useUnmount(() => resetBillingState());

--- a/src/components/admin/Billing/index.tsx
+++ b/src/components/admin/Billing/index.tsx
@@ -16,6 +16,7 @@ import { eachMonthOfInterval, format, startOfMonth, subMonths } from 'date-fns';
 import useBillingCatalogStats from 'hooks/billing/useBillingCatalogStats';
 import useBillingRecord from 'hooks/billing/useBillingRecord';
 import usePageTitle from 'hooks/usePageTitle';
+import { isArray, isEmpty } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { FormattedMessage } from 'react-intl';
@@ -32,7 +33,6 @@ import {
     useBilling_updateBillingHistory,
 } from 'stores/Billing/hooks';
 import useConstant from 'use-constant';
-import { hasLength } from 'utils/misc-utils';
 
 const routeTitle = authenticatedRoutes.admin.billing.title;
 
@@ -144,9 +144,11 @@ function AdminBilling() {
         if (
             historyInitialized &&
             !isValidatingRecord &&
-            hasLength(billingRecord)
+            !isEmpty(billingRecord)
         ) {
-            updateBillingHistory(billingRecord);
+            updateBillingHistory(
+                isArray(billingRecord) ? billingRecord : [billingRecord]
+            );
         }
     }, [
         updateBillingHistory,

--- a/src/components/admin/Tabs.tsx
+++ b/src/components/admin/Tabs.tsx
@@ -10,7 +10,6 @@ function AdminTabs() {
     const { pathname } = useLocation();
     const [selectedTab, setSelectedTab] = useState(0);
 
-    // TODO (billing): Enable the billing tab when the work needed on the control-plane is complete.
     const tabProps = useConstant(() => {
         const response = [
             {

--- a/src/components/tables/Billing/Rows.tsx
+++ b/src/components/tables/Billing/Rows.tsx
@@ -13,9 +13,9 @@ interface RowsProps {
     data: BillingRecord[];
 }
 
-// TODO: Determine if the details table column is necessary and, if so,
-//   what data should be displayed in that column. My proposition is that
-//   the tier evaluation for that month should be identified in that column.
+// TODO: Determine if it is intentional for max concurrent tasks to be zero when
+//   the billing_report RPC clearly reports a data volume surplus. Falling back on the
+//   tracked included task count in the interim.
 function Row({ row }: RowProps) {
     return (
         <TableRow hover>
@@ -24,7 +24,11 @@ function Row({ row }: RowProps) {
             <DataVolume volumeInGB={row.total_processed_data_gb} />
 
             <TableCell>
-                <Typography>{row.max_concurrent_tasks}</Typography>
+                <Typography>
+                    {row.max_concurrent_tasks > 0
+                        ? row.max_concurrent_tasks
+                        : row.line_items[0].count}
+                </Typography>
             </TableCell>
 
             <TableCell>
@@ -42,9 +46,12 @@ function Row({ row }: RowProps) {
 function Rows({ data }: RowsProps) {
     return (
         <>
-            {data.slice(0, 4).map((record, index) => (
-                <Row row={record} key={index} />
-            ))}
+            {data
+                .slice(data.length - 4, data.length)
+                .reverse()
+                .map((record, index) => (
+                    <Row row={record} key={index} />
+                ))}
         </>
     );
 }

--- a/src/components/tables/Billing/Rows.tsx
+++ b/src/components/tables/Billing/Rows.tsx
@@ -1,16 +1,16 @@
 import { TableCell, TableRow, Typography } from '@mui/material';
+import { BillingRecord } from 'api/billing';
+import DataVolume from 'components/tables/cells/billing/DataVolume';
 import TimeStamp from 'components/tables/cells/billing/TimeStamp';
 import MonetaryValue from 'components/tables/cells/MonetaryValue';
-import Bytes from 'components/tables/cells/stats/Bytes';
 import { FormattedMessage } from 'react-intl';
-import { FormattedBillingRecord } from 'stores/Billing/types';
 
 interface RowProps {
-    row: FormattedBillingRecord;
+    row: BillingRecord;
 }
 
 interface RowsProps {
-    data: FormattedBillingRecord[];
+    data: BillingRecord[];
 }
 
 // TODO: Determine if the details table column is necessary and, if so,
@@ -19,26 +19,21 @@ interface RowsProps {
 function Row({ row }: RowProps) {
     return (
         <TableRow hover>
-            <TimeStamp date={row.date} timestamp={row.timestamp} />
+            <TimeStamp date={row.billed_month} />
 
-            <Bytes
-                val={row.dataVolume}
-                messageId="admin.billing.table.history.tooltip.dataVolume"
-            />
+            <DataVolume volumeInGB={row.total_processed_data_gb} />
 
             <TableCell>
-                <Typography>{row.taskCount}</Typography>
+                <Typography>{row.max_concurrent_tasks}</Typography>
             </TableCell>
 
             <TableCell>
                 <Typography>
-                    <FormattedMessage
-                        id={`admin.billing.tier.${row.pricingTier}`}
-                    />
+                    <FormattedMessage id="admin.billing.tier.personal" />
                 </Typography>
             </TableCell>
 
-            <MonetaryValue amount={row.totalCost} />
+            <MonetaryValue amount={row.subtotal / 100} />
         </TableRow>
     );
 }

--- a/src/components/tables/Billing/Rows.tsx
+++ b/src/components/tables/Billing/Rows.tsx
@@ -3,14 +3,14 @@ import TimeStamp from 'components/tables/cells/billing/TimeStamp';
 import MonetaryValue from 'components/tables/cells/MonetaryValue';
 import Bytes from 'components/tables/cells/stats/Bytes';
 import { FormattedMessage } from 'react-intl';
-import { BillingRecord } from 'stores/Billing/types';
+import { FormattedBillingRecord } from 'stores/Billing/types';
 
 interface RowProps {
-    row: BillingRecord;
+    row: FormattedBillingRecord;
 }
 
 interface RowsProps {
-    data: BillingRecord[];
+    data: FormattedBillingRecord[];
 }
 
 // TODO: Determine if the details table column is necessary and, if so,

--- a/src/components/tables/Billing/Rows.tsx
+++ b/src/components/tables/Billing/Rows.tsx
@@ -13,9 +13,6 @@ interface RowsProps {
     data: BillingRecord[];
 }
 
-// TODO: Determine if it is intentional for max concurrent tasks to be zero when
-//   the billing_report RPC clearly reports a data volume surplus. Falling back on the
-//   tracked included task count in the interim.
 function Row({ row }: RowProps) {
     return (
         <TableRow hover>
@@ -24,11 +21,7 @@ function Row({ row }: RowProps) {
             <DataVolume volumeInGB={row.total_processed_data_gb} />
 
             <TableCell>
-                <Typography>
-                    {row.max_concurrent_tasks > 0
-                        ? row.max_concurrent_tasks
-                        : row.line_items[0].count}
-                </Typography>
+                <Typography>{row.max_concurrent_tasks}</Typography>
             </TableCell>
 
             <TableCell>

--- a/src/components/tables/Billing/index.tsx
+++ b/src/components/tables/Billing/index.tsx
@@ -33,7 +33,8 @@ export const columns: TableColumns[] = [
     },
 ];
 
-// TODO (billing): Enable pagination when a database table containing historic billing data is available.
+// TODO (billing): Use the getStatsForBillingHistoryTable query function as the primary source of data for this view
+//   when a database table containing historic billing data is available.
 function BillingHistoryTable() {
     const intl = useIntl();
 

--- a/src/components/tables/EntityTable/TableHeader.tsx
+++ b/src/components/tables/EntityTable/TableHeader.tsx
@@ -13,6 +13,7 @@ interface Props {
     selectData?: any;
     selectableTableStoreName?: SelectTableStoreNames;
     sortDirection?: SortDirection;
+    noBackgroundColor?: boolean;
 }
 
 function EntityTableHeader({
@@ -23,6 +24,7 @@ function EntityTableHeader({
     selectData,
     selectableTableStoreName,
     sortDirection,
+    noBackgroundColor,
 }: Props) {
     const enableSort = columnToSort && headerClick && sortDirection;
 
@@ -30,7 +32,9 @@ function EntityTableHeader({
         <TableHead>
             <TableRow
                 sx={{
-                    background: (theme) => theme.palette.background.default,
+                    background: noBackgroundColor
+                        ? undefined
+                        : (theme) => theme.palette.background.default,
                 }}
             >
                 {columns.map((column, index) => {

--- a/src/components/tables/cells/billing/DataVolume.tsx
+++ b/src/components/tables/cells/billing/DataVolume.tsx
@@ -1,0 +1,32 @@
+import { Box, TableCell, Tooltip, Typography } from '@mui/material';
+import { useIntl } from 'react-intl';
+
+interface Props {
+    volumeInGB: number;
+}
+
+// TODO (stats) we can combine this with the Docs component.
+const DataVolume = ({ volumeInGB }: Props) => {
+    const intl = useIntl();
+
+    return (
+        <TableCell
+            sx={{
+                minWidth: 'min-content',
+                maxWidth: 'min-content',
+            }}
+        >
+            <Box sx={{ maxWidth: 'fit-content' }}>
+                <Tooltip
+                    title={`${volumeInGB.toFixed(4)} ${intl.formatMessage({
+                        id: 'admin.billing.table.history.tooltip.dataVolume',
+                    })}`}
+                >
+                    <Typography>{`${volumeInGB.toFixed(2)} GB`}</Typography>
+                </Tooltip>
+            </Box>
+        </TableCell>
+    );
+};
+
+export default DataVolume;

--- a/src/components/tables/cells/billing/DataVolume.tsx
+++ b/src/components/tables/cells/billing/DataVolume.tsx
@@ -5,7 +5,6 @@ interface Props {
     volumeInGB: number;
 }
 
-// TODO (stats) we can combine this with the Docs component.
 const DataVolume = ({ volumeInGB }: Props) => {
     const intl = useIntl();
 

--- a/src/components/tables/cells/billing/TimeStamp.tsx
+++ b/src/components/tables/cells/billing/TimeStamp.tsx
@@ -4,10 +4,9 @@ import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
 
 interface Props {
     date: string | Date;
-    timestamp: string;
 }
 
-function TimeStamp({ date, timestamp }: Props) {
+function TimeStamp({ date }: Props) {
     const intl = useIntl();
 
     return (
@@ -17,7 +16,7 @@ function TimeStamp({ date, timestamp }: Props) {
                     <FormattedMessage
                         id="admin.billing.table.history.tooltip.month"
                         values={{
-                            timestamp: intl.formatDate(timestamp, {
+                            timestamp: intl.formatDate(date, {
                                 day: 'numeric',
                                 month: 'short',
                                 year: 'numeric',

--- a/src/components/tables/cells/billing/TimeStamp.tsx
+++ b/src/components/tables/cells/billing/TimeStamp.tsx
@@ -1,13 +1,16 @@
 import { Box, TableCell } from '@mui/material';
 import CustomWidthTooltip from 'components/shared/CustomWidthTooltip';
 import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
+import { stripTimeFromDate } from 'utils/billing-utils';
 
 interface Props {
-    date: string | Date;
+    date: string;
 }
 
 function TimeStamp({ date }: Props) {
     const intl = useIntl();
+
+    const strippedDate = stripTimeFromDate(date);
 
     return (
         <TableCell>
@@ -31,7 +34,11 @@ function TimeStamp({ date }: Props) {
                 placement="bottom-start"
             >
                 <Box>
-                    <FormattedDate month="long" year="numeric" value={date} />
+                    <FormattedDate
+                        month="long"
+                        year="numeric"
+                        value={strippedDate}
+                    />
                 </Box>
             </CustomWidthTooltip>
         </TableCell>

--- a/src/components/tables/cells/stats/Bytes.tsx
+++ b/src/components/tables/cells/stats/Bytes.tsx
@@ -7,21 +7,10 @@ import { useIntl } from 'react-intl';
 interface Props {
     read?: boolean;
     val?: number | null;
-    messageId?: string;
 }
 
-const evaluateTooltipMessageId = (messageId?: string, read?: boolean) => {
-    if (messageId) {
-        return messageId;
-    } else {
-        return read
-            ? 'entityTable.stats.bytes_read'
-            : 'entityTable.stats.bytes_written';
-    }
-};
-
 // TODO (stats) we can combine this with the Docs component.
-const Bytes = ({ read, val, messageId }: Props) => {
+const Bytes = ({ read, val }: Props) => {
     const intl = useIntl();
     const statsLoading = val === null;
     const defaultedVal = val ?? 0;
@@ -44,7 +33,9 @@ const Bytes = ({ read, val, messageId }: Props) => {
             <Box sx={{ maxWidth: 'fit-content' }}>
                 <Tooltip
                     title={`${defaultedVal} ${intl.formatMessage({
-                        id: evaluateTooltipMessageId(messageId, read),
+                        id: read
+                            ? 'entityTable.stats.bytes_read'
+                            : 'entityTable.stats.bytes_written',
                     })}`}
                 >
                     <Typography

--- a/src/context/SWR.tsx
+++ b/src/context/SWR.tsx
@@ -14,6 +14,15 @@ export const singleCallSettings = {
 
 export const DEFAULT_POLLING = 2500;
 
+export const EXTENDED_POLL_INTERVAL = 30000;
+
+export const extendedPollSettings = {
+    errorRetryCount: 3,
+    errorRetryInterval: EXTENDED_POLL_INTERVAL / 2,
+    refreshInterval: EXTENDED_POLL_INTERVAL,
+    revalidateOnFocus: false,
+};
+
 const SwrConfigProvider = ({ children }: BaseComponentProps) => {
     const supabaseClient = useClient();
     const intl = useIntl();

--- a/src/hooks/billing/useBillingCatalogStats.ts
+++ b/src/hooks/billing/useBillingCatalogStats.ts
@@ -3,6 +3,7 @@ import { extendedPollSettings } from 'context/SWR';
 import { useSelectNew } from 'hooks/supabase-swr/hooks/useSelect';
 import {
     useBilling_billingHistory,
+    useBilling_billingHistoryInitialized,
     useBilling_selectedTenant,
 } from 'stores/Billing/hooks';
 import { CatalogStats_Billing } from 'types';
@@ -10,6 +11,7 @@ import { hasLength } from 'utils/misc-utils';
 
 function useBillingCatalogStats() {
     const selectedTenant = useBilling_selectedTenant();
+    const historyInitialized = useBilling_billingHistoryInitialized();
     const billingHistory = useBilling_billingHistory();
 
     const { data, error, mutate, isValidating } = useSelectNew(
@@ -22,8 +24,12 @@ function useBillingCatalogStats() {
         extendedPollSettings
     );
 
+    const defaultResponse = historyInitialized ? [] : null;
+
     return {
-        billingStats: data ? (data.data as CatalogStats_Billing[]) : null,
+        billingStats: data
+            ? (data.data as CatalogStats_Billing[])
+            : defaultResponse,
         error,
         mutate,
         isValidating,

--- a/src/hooks/billing/useBillingCatalogStats.ts
+++ b/src/hooks/billing/useBillingCatalogStats.ts
@@ -1,4 +1,5 @@
 import { getStatsForBilling } from 'api/stats';
+import { extendedPollSettings } from 'context/SWR';
 import { useSelectNew } from 'hooks/supabase-swr/hooks/useSelect';
 import {
     useBilling_billingHistory,
@@ -6,8 +7,6 @@ import {
 } from 'stores/Billing/hooks';
 import { CatalogStats_Billing } from 'types';
 import { hasLength } from 'utils/misc-utils';
-
-const INTERVAL = 30000;
 
 function useBillingCatalogStats() {
     const selectedTenant = useBilling_selectedTenant();
@@ -20,12 +19,7 @@ function useBillingCatalogStats() {
                   billingHistory[0].billed_month
               )
             : null,
-        {
-            errorRetryCount: 3,
-            errorRetryInterval: INTERVAL / 2,
-            refreshInterval: INTERVAL,
-            revalidateOnFocus: false,
-        }
+        extendedPollSettings
     );
 
     return {

--- a/src/hooks/billing/useBillingCatalogStats.ts
+++ b/src/hooks/billing/useBillingCatalogStats.ts
@@ -1,6 +1,9 @@
 import { getStatsForBilling } from 'api/stats';
 import { useSelectNew } from 'hooks/supabase-swr/hooks/useSelect';
-import { useBilling_selectedTenant } from 'stores/Billing/hooks';
+import {
+    useBilling_billingHistory,
+    useBilling_selectedTenant,
+} from 'stores/Billing/hooks';
 import { CatalogStats_Billing } from 'types';
 import { hasLength } from 'utils/misc-utils';
 
@@ -8,9 +11,15 @@ const INTERVAL = 30000;
 
 function useBillingCatalogStats() {
     const selectedTenant = useBilling_selectedTenant();
+    const billingHistory = useBilling_billingHistory();
 
     const { data, error, mutate, isValidating } = useSelectNew(
-        hasLength(selectedTenant) ? getStatsForBilling([selectedTenant]) : null,
+        hasLength(selectedTenant) && hasLength(billingHistory)
+            ? getStatsForBilling(
+                  [selectedTenant],
+                  billingHistory[0].billed_month
+              )
+            : null,
         {
             errorRetryCount: 3,
             errorRetryInterval: INTERVAL / 2,

--- a/src/hooks/billing/useBillingHistory.ts
+++ b/src/hooks/billing/useBillingHistory.ts
@@ -1,7 +1,7 @@
 import { PostgrestFilterBuilder } from '@supabase/postgrest-js';
 import { useSelectNew } from 'hooks/supabase-swr/hooks/useSelect';
 import { useBilling_selectedTenant } from 'stores/Billing/hooks';
-import { BillingRecord } from 'stores/Billing/types';
+import { FormattedBillingRecord } from 'stores/Billing/types';
 import { CatalogStats_Billing } from 'types';
 import { formatBillingCatalogStats } from 'utils/billing-utils';
 import { hasLength } from 'utils/misc-utils';
@@ -12,7 +12,7 @@ interface Props {
 
 const INTERVAL = 30000;
 
-const defaultResponse: BillingRecord[] = [];
+const defaultResponse: FormattedBillingRecord[] = [];
 
 function useBillingHistory({ query }: Props) {
     const selectedTenant = useBilling_selectedTenant();

--- a/src/hooks/billing/useBillingHistory.ts
+++ b/src/hooks/billing/useBillingHistory.ts
@@ -1,37 +1,29 @@
-import { PostgrestFilterBuilder } from '@supabase/postgrest-js';
+import { BillingRecord, getBillingRecord } from 'api/billing';
 import { useSelectNew } from 'hooks/supabase-swr/hooks/useSelect';
 import { useBilling_selectedTenant } from 'stores/Billing/hooks';
-import { FormattedBillingRecord } from 'stores/Billing/types';
-import { CatalogStats_Billing } from 'types';
-import { formatBillingCatalogStats } from 'utils/billing-utils';
 import { hasLength } from 'utils/misc-utils';
-
-interface Props {
-    query: PostgrestFilterBuilder<CatalogStats_Billing>;
-}
 
 const INTERVAL = 30000;
 
-const defaultResponse: FormattedBillingRecord[] = [];
+const defaultResponse: BillingRecord[] = [];
 
-function useBillingHistory({ query }: Props) {
+function useBillingHistory(currentMonth: string | Date) {
     const selectedTenant = useBilling_selectedTenant();
 
-    const { data, error, mutate, isValidating } =
-        useSelectNew<CatalogStats_Billing>(
-            hasLength(selectedTenant) ? query : null,
-            {
-                errorRetryCount: 3,
-                errorRetryInterval: INTERVAL / 2,
-                refreshInterval: INTERVAL,
-                revalidateOnFocus: false,
-            }
-        );
+    const { data, error, mutate, isValidating } = useSelectNew<BillingRecord>(
+        hasLength(selectedTenant)
+            ? getBillingRecord(selectedTenant, currentMonth)
+            : null,
+        {
+            errorRetryCount: 3,
+            errorRetryInterval: INTERVAL / 2,
+            refreshInterval: INTERVAL,
+            revalidateOnFocus: false,
+        }
+    );
 
     return {
-        billingHistory: data
-            ? formatBillingCatalogStats(data.data)
-            : defaultResponse,
+        billingHistory: data ? data.data : defaultResponse,
         error,
         mutate,
         isValidating,

--- a/src/hooks/billing/useBillingRecord.ts
+++ b/src/hooks/billing/useBillingRecord.ts
@@ -7,7 +7,7 @@ const INTERVAL = 30000;
 
 const defaultResponse: BillingRecord[] = [];
 
-function useBillingHistory(currentMonth: string | Date) {
+function useBillingRecord(currentMonth: string | Date) {
     const selectedTenant = useBilling_selectedTenant();
 
     const { data, error, mutate, isValidating } = useSelectNew<BillingRecord>(
@@ -23,11 +23,11 @@ function useBillingHistory(currentMonth: string | Date) {
     );
 
     return {
-        billingHistory: data ? data.data : defaultResponse,
+        billingRecord: data ? data.data : defaultResponse,
         error,
         mutate,
         isValidating,
     };
 }
 
-export default useBillingHistory;
+export default useBillingRecord;

--- a/src/hooks/billing/useBillingRecord.ts
+++ b/src/hooks/billing/useBillingRecord.ts
@@ -1,12 +1,12 @@
 import { BillingRecord, getBillingRecord } from 'api/billing';
+import { extendedPollSettings } from 'context/SWR';
 import { useSelectNew } from 'hooks/supabase-swr/hooks/useSelect';
 import { useBilling_selectedTenant } from 'stores/Billing/hooks';
 import { hasLength } from 'utils/misc-utils';
 
-const INTERVAL = 30000;
-
 const defaultResponse: BillingRecord[] = [];
 
+// TODO (typing): Correct the return type of useSelectNew. In this instance, data is an object and not an array.
 function useBillingRecord(currentMonth: string | Date) {
     const selectedTenant = useBilling_selectedTenant();
 
@@ -14,12 +14,7 @@ function useBillingRecord(currentMonth: string | Date) {
         hasLength(selectedTenant)
             ? getBillingRecord(selectedTenant, currentMonth)
             : null,
-        {
-            errorRetryCount: 3,
-            errorRetryInterval: INTERVAL / 2,
-            refreshInterval: INTERVAL,
-            revalidateOnFocus: false,
-        }
+        extendedPollSettings
     );
 
     return {

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -437,7 +437,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.billing.table.history.label.tasks': `Tasks`,
     'admin.billing.table.history.label.totalCost': `Total Cost`,
     'admin.billing.table.history.tooltip.month': `This billing period began on {timestamp}`,
-    'admin.billing.table.history.tooltip.dataVolume': `bytes of data processed by tasks`,
+    'admin.billing.table.history.tooltip.dataVolume': `GB of data processed by tasks`,
     'admin.billing.table.history.emptyTableDefault.header': `No information found.`,
     'admin.billing.table.history.emptyTableDefault.message': `We couldn't find any billing information on file. Only administrators of a tenant are able to review billing information.`,
 

--- a/src/stores/Billing/Store.ts
+++ b/src/stores/Billing/Store.ts
@@ -6,13 +6,9 @@ import {
     getStoreWithHydrationSettings,
 } from 'stores/Hydration';
 import { BillingStoreNames } from 'stores/names';
-import {
-    evaluateSpecType,
-    formatBillingRecords,
-    stripTimeFromDate,
-} from 'utils/billing-utils';
+import { evaluateSpecType, stripTimeFromDate } from 'utils/billing-utils';
 import { devtoolsOptions } from 'utils/store-utils';
-import { create } from 'zustand';
+import { create, StoreApi } from 'zustand';
 import { devtools, NamedSet } from 'zustand/middleware';
 
 const getInitialStateData = (): Pick<
@@ -26,7 +22,10 @@ const getInitialStateData = (): Pick<
     };
 };
 
-export const getInitialState = (set: NamedSet<BillingState>): BillingState => {
+export const getInitialState = (
+    set: NamedSet<BillingState>,
+    get: StoreApi<BillingState>['getState']
+): BillingState => {
     return {
         ...getInitialStateData(),
         ...getStoreWithHydrationSettings('Billing', set),
@@ -50,10 +49,29 @@ export const getInitialState = (set: NamedSet<BillingState>): BillingState => {
         setBillingHistory: (value) => {
             set(
                 produce((state: BillingState) => {
-                    state.billingHistory = formatBillingRecords(value);
+                    state.billingHistory = value;
                 }),
                 false,
                 'Billing Details Set'
+            );
+        },
+
+        updateBillingHistory: (value) => {
+            set(
+                produce((state: BillingState) => {
+                    const { billingHistory } = get();
+
+                    const evaluatedBillingHistory = billingHistory.filter(
+                        (record) =>
+                            record.billed_month !== value[0].billed_month
+                    );
+
+                    evaluatedBillingHistory.push(value[0]);
+
+                    state.billingHistory = evaluatedBillingHistory;
+                }),
+                false,
+                'Billing Details Updated'
             );
         },
 
@@ -109,6 +127,6 @@ export const getInitialState = (set: NamedSet<BillingState>): BillingState => {
 
 export const createBillingStore = (key: BillingStoreNames.GENERAL) => {
     return create<BillingState>()(
-        devtools((set) => getInitialState(set), devtoolsOptions(key))
+        devtools((set, get) => getInitialState(set, get), devtoolsOptions(key))
     );
 };

--- a/src/stores/Billing/Store.ts
+++ b/src/stores/Billing/Store.ts
@@ -13,10 +13,14 @@ import { devtools, NamedSet } from 'zustand/middleware';
 
 const getInitialStateData = (): Pick<
     BillingState,
-    'billingHistory' | 'dataByTaskGraphDetails' | 'selectedTenant'
+    | 'billingHistory'
+    | 'billingHistoryInitialized'
+    | 'dataByTaskGraphDetails'
+    | 'selectedTenant'
 > => {
     return {
         billingHistory: [],
+        billingHistoryInitialized: false,
         dataByTaskGraphDetails: [],
         selectedTenant: '',
     };
@@ -56,19 +60,31 @@ export const getInitialState = (
             );
         },
 
+        setBillingHistoryInitialized: (value) => {
+            set(
+                produce((state: BillingState) => {
+                    state.billingHistoryInitialized = value;
+                }),
+                false,
+                'Billing History Initialized'
+            );
+        },
+
         updateBillingHistory: (value) => {
             set(
                 produce((state: BillingState) => {
-                    const { billingHistory } = get();
+                    if (value[0].max_concurrent_tasks > 0) {
+                        const { billingHistory } = get();
 
-                    const evaluatedBillingHistory = billingHistory.filter(
-                        (record) =>
-                            record.billed_month !== value[0].billed_month
-                    );
+                        const evaluatedBillingHistory = billingHistory.filter(
+                            (record) =>
+                                record.billed_month !== value[0].billed_month
+                        );
 
-                    evaluatedBillingHistory.push(value[0]);
+                        evaluatedBillingHistory.push(value[0]);
 
-                    state.billingHistory = evaluatedBillingHistory;
+                        state.billingHistory = evaluatedBillingHistory;
+                    }
                 }),
                 false,
                 'Billing Details Updated'

--- a/src/stores/Billing/Store.ts
+++ b/src/stores/Billing/Store.ts
@@ -8,7 +8,7 @@ import {
 import { BillingStoreNames } from 'stores/names';
 import {
     evaluateSpecType,
-    formatBillingCatalogStats,
+    formatBillingRecords,
     stripTimeFromDate,
 } from 'utils/billing-utils';
 import { devtoolsOptions } from 'utils/store-utils';
@@ -50,7 +50,7 @@ export const getInitialState = (set: NamedSet<BillingState>): BillingState => {
         setBillingHistory: (value) => {
             set(
                 produce((state: BillingState) => {
-                    state.billingHistory = formatBillingCatalogStats(value);
+                    state.billingHistory = formatBillingRecords(value);
                 }),
                 false,
                 'Billing Details Set'

--- a/src/stores/Billing/hooks.ts
+++ b/src/stores/Billing/hooks.ts
@@ -17,6 +17,13 @@ export const useBilling_setBillingHistory = () => {
     );
 };
 
+export const useBilling_updateBillingHistory = () => {
+    return useZustandStore<BillingState, BillingState['updateBillingHistory']>(
+        BillingStoreNames.GENERAL,
+        (state) => state.updateBillingHistory
+    );
+};
+
 export const useBilling_dataByTaskGraphDetails = () => {
     return useZustandStore<
         BillingState,

--- a/src/stores/Billing/hooks.ts
+++ b/src/stores/Billing/hooks.ts
@@ -3,6 +3,20 @@ import { BillingState } from 'stores/Billing/types';
 import { BillingStoreNames } from 'stores/names';
 
 // Selector Hooks
+export const useBilling_billingHistoryInitialized = () => {
+    return useZustandStore<
+        BillingState,
+        BillingState['billingHistoryInitialized']
+    >(BillingStoreNames.GENERAL, (state) => state.billingHistoryInitialized);
+};
+
+export const useBilling_setBillingHistoryInitialized = () => {
+    return useZustandStore<
+        BillingState,
+        BillingState['setBillingHistoryInitialized']
+    >(BillingStoreNames.GENERAL, (state) => state.setBillingHistoryInitialized);
+};
+
 export const useBilling_billingHistory = () => {
     return useZustandStore<BillingState, BillingState['billingHistory']>(
         BillingStoreNames.GENERAL,

--- a/src/stores/Billing/types.ts
+++ b/src/stores/Billing/types.ts
@@ -20,6 +20,9 @@ export interface BillingState extends StoreWithHydration {
     dataByTaskGraphDetails: DataVolumeByTask[];
     setDataByTaskGraphDetails: (value: CatalogStats_Billing[]) => void;
 
+    billingHistoryInitialized: boolean;
+    setBillingHistoryInitialized: (value: boolean) => void;
+
     billingHistory: BillingRecord[];
     setBillingHistory: (value: BillingRecord[]) => void;
     updateBillingHistory: (value: BillingRecord[]) => void;

--- a/src/stores/Billing/types.ts
+++ b/src/stores/Billing/types.ts
@@ -1,7 +1,8 @@
+import { BillingRecord } from 'api/billing';
 import { StoreWithHydration } from 'stores/Hydration';
 import { CatalogStats_Billing, Entity } from 'types';
 
-export interface BillingRecord {
+export interface FormattedBillingRecord {
     date: Date;
     timestamp: string;
     dataVolume: number;
@@ -31,8 +32,8 @@ export interface BillingState extends StoreWithHydration {
     dataByTaskGraphDetails: DataVolumeByTask[];
     setDataByTaskGraphDetails: (value: CatalogStats_Billing[]) => void;
 
-    billingHistory: BillingRecord[];
-    setBillingHistory: (value: CatalogStats_Billing[]) => void;
+    billingHistory: FormattedBillingRecord[];
+    setBillingHistory: (value: BillingRecord[]) => void;
 
     resetState: () => void;
 }

--- a/src/stores/Billing/types.ts
+++ b/src/stores/Billing/types.ts
@@ -2,18 +2,6 @@ import { BillingRecord } from 'api/billing';
 import { StoreWithHydration } from 'stores/Hydration';
 import { CatalogStats_Billing, Entity } from 'types';
 
-export interface FormattedBillingRecord {
-    date: Date;
-    timestamp: string;
-    dataVolume: number;
-    taskCount: number;
-    totalCost: number;
-    pricingTier: string | null;
-    taskRate: number | null;
-    gbFree: number | null;
-    includedTasks: number | null;
-}
-
 export interface DataVolumeByTask {
     catalogName: string;
     date: Date;
@@ -32,8 +20,9 @@ export interface BillingState extends StoreWithHydration {
     dataByTaskGraphDetails: DataVolumeByTask[];
     setDataByTaskGraphDetails: (value: CatalogStats_Billing[]) => void;
 
-    billingHistory: FormattedBillingRecord[];
+    billingHistory: BillingRecord[];
     setBillingHistory: (value: BillingRecord[]) => void;
+    updateBillingHistory: (value: BillingRecord[]) => void;
 
     resetState: () => void;
 }

--- a/src/stores/Tables/Billing/Hydrator.tsx
+++ b/src/stores/Tables/Billing/Hydrator.tsx
@@ -1,6 +1,6 @@
 import { PostgrestFilterBuilder } from '@supabase/postgrest-js';
 import { useZustandStore } from 'context/Zustand/provider';
-import useBillingHistory from 'hooks/billing/useBillingHistory';
+import useBillingRecord from 'hooks/billing/useBillingRecord';
 import { useEffect } from 'react';
 import { useUnmount } from 'react-use';
 import { SelectTableStoreNames } from 'stores/names';
@@ -35,7 +35,11 @@ export const BillingHistoryTableHydrator = ({
 
     const hydrateState = useBillingTable_hydrateContinuously();
 
-    const { billingHistory, error, isValidating } = useBillingHistory('');
+    const {
+        billingRecord: billingHistory,
+        error,
+        isValidating,
+    } = useBillingRecord('');
 
     useEffect(() => {
         setQuery(query);

--- a/src/stores/Tables/Billing/Hydrator.tsx
+++ b/src/stores/Tables/Billing/Hydrator.tsx
@@ -11,7 +11,10 @@ import {
 } from 'stores/Tables/Store';
 import { BaseComponentProps, CatalogStats_Billing } from 'types';
 
-// Hydrator
+// TODO (billing): Use this method to hydrate the billing select table store when
+//   a database table containing billing history is available. Currently, this component is
+//   is no longer in use since the billing history table in the UI must source data from
+//   the billing_report RPC.
 interface TableHydratorProps extends BaseComponentProps {
     query: PostgrestFilterBuilder<CatalogStats_Billing>;
 }
@@ -32,9 +35,7 @@ export const BillingHistoryTableHydrator = ({
 
     const hydrateState = useBillingTable_hydrateContinuously();
 
-    const { billingHistory, error, isValidating } = useBillingHistory({
-        query,
-    });
+    const { billingHistory, error, isValidating } = useBillingHistory('');
 
     useEffect(() => {
         setQuery(query);

--- a/src/stores/Tables/Billing/types.ts
+++ b/src/stores/Tables/Billing/types.ts
@@ -1,10 +1,10 @@
 import { PostgrestError } from '@supabase/postgrest-js';
-import { FormattedBillingRecord } from 'stores/Billing/types';
+import { BillingRecord } from 'api/billing';
 import { SelectableTableStore } from 'stores/Tables/Store';
 
 export interface BillingTableState extends SelectableTableStore {
     hydrateContinuously: (
-        data: FormattedBillingRecord[],
+        data: BillingRecord[],
         error?: PostgrestError
     ) => void;
 }

--- a/src/stores/Tables/Billing/types.ts
+++ b/src/stores/Tables/Billing/types.ts
@@ -1,10 +1,10 @@
 import { PostgrestError } from '@supabase/postgrest-js';
-import { BillingRecord } from 'stores/Billing/types';
+import { FormattedBillingRecord } from 'stores/Billing/types';
 import { SelectableTableStore } from 'stores/Tables/Store';
 
 export interface BillingTableState extends SelectableTableStore {
     hydrateContinuously: (
-        data: BillingRecord[],
+        data: FormattedBillingRecord[],
         error?: PostgrestError
     ) => void;
 }

--- a/src/utils/billing-utils.ts
+++ b/src/utils/billing-utils.ts
@@ -1,8 +1,5 @@
-import { BillingRecord } from 'api/billing';
-import { isEqual, parseISO } from 'date-fns';
-import { isEmpty, sum } from 'lodash';
+import { parseISO } from 'date-fns';
 import prettyBytes from 'pretty-bytes';
-import { FormattedBillingRecord } from 'stores/Billing/types';
 import { CatalogStats_Billing, Entity } from 'types';
 
 export const TOTAL_CARD_HEIGHT = 300;
@@ -11,8 +8,6 @@ export const TOTAL_CARD_HEIGHT = 300;
 export const CARD_AREA_HEIGHT = TOTAL_CARD_HEIGHT - 72;
 
 export const BYTES_PER_GB = 1073741824;
-
-const FREE_TASK_COUNT = 2;
 
 export enum FREE_GB_BY_TIER {
     FREE = 20,
@@ -30,147 +25,10 @@ export const evaluateSpecType = (query: CatalogStats_Billing): Entity => {
     }
 };
 
-const evaluateTotalCost = (dataVolume: number, taskCount: number) => {
-    const freeBytes = 10 * BYTES_PER_GB;
-
-    const dataVolumeOverLimit =
-        dataVolume > freeBytes ? dataVolume - freeBytes : 0;
-
-    const taskCountOverLimit =
-        taskCount > FREE_TASK_COUNT ? taskCount - FREE_TASK_COUNT : 0;
-
-    return (
-        (dataVolumeOverLimit / BYTES_PER_GB) * 0.75 + taskCountOverLimit * 20
-    );
-};
-
-const evaluateDataVolume = (stats: CatalogStats_Billing[]): number => {
-    const taskBytes: number[] = stats.map((query) => {
-        if (Object.hasOwn(query.flow_document.taskStats, 'capture')) {
-            return query.bytes_written_by_me;
-        } else if (
-            Object.hasOwn(query.flow_document.taskStats, 'materialize')
-        ) {
-            return query.bytes_read_by_me;
-        } else {
-            return query.bytes_written_by_me + query.bytes_read_by_me;
-        }
-    });
-
-    return sum(taskBytes);
-};
-
 export const stripTimeFromDate = (date: string) => {
     const [truncatedDateStr] = date.split('T', 1);
 
     return parseISO(truncatedDateStr);
-};
-
-const getInitialBillingRecord = (date: string): FormattedBillingRecord => {
-    const truncatedDate = stripTimeFromDate(date);
-
-    return {
-        date: truncatedDate,
-        timestamp: date,
-        dataVolume: 0,
-        taskCount: 0,
-        totalCost: 0,
-        pricingTier: null,
-        taskRate: null,
-        gbFree: null,
-        includedTasks: null,
-    };
-};
-
-// TODO (billing): Remove this helper function to translate data returned from
-//   the new RPC when available.
-export const formatBillingRecords = (
-    value: BillingRecord[]
-): FormattedBillingRecord[] => {
-    const billingHistory: FormattedBillingRecord[] = value.map((record) => ({
-        date: new Date(record.billed_month),
-        timestamp: record.billed_month,
-        dataVolume: record.total_processed_data_gb * BYTES_PER_GB,
-        taskCount: record.max_concurrent_tasks,
-        totalCost: record.subtotal / 100,
-        pricingTier: 'personal',
-        taskRate: 20,
-        gbFree: FREE_GB_BY_TIER.PERSONAL,
-        includedTasks: 2,
-    }));
-
-    return billingHistory;
-};
-
-export const formatBillingCatalogStats = (
-    value: CatalogStats_Billing[]
-): FormattedBillingRecord[] => {
-    const taskStatData = value.filter((query) =>
-        Object.hasOwn(query.flow_document, 'taskStats')
-    );
-
-    let sortedStats: {
-        [date: string]: CatalogStats_Billing[];
-    } = {};
-
-    taskStatData.forEach((query) => {
-        if (Object.hasOwn(sortedStats, query.ts)) {
-            sortedStats[query.ts].push(query);
-        } else {
-            sortedStats = {
-                ...sortedStats,
-                [query.ts]: [query],
-            };
-        }
-    });
-
-    const billingHistory: FormattedBillingRecord[] = [];
-
-    if (!isEmpty(sortedStats)) {
-        Object.entries(sortedStats).forEach(([ts, stats]) => {
-            const billingRecordIndex = billingHistory.findIndex((record) =>
-                isEqual(record.date, stripTimeFromDate(ts))
-            );
-
-            const taskCount = stats.length;
-            const dataVolume = evaluateDataVolume(stats);
-            const totalCost = evaluateTotalCost(dataVolume, taskCount);
-
-            if (billingRecordIndex === -1) {
-                const { date, pricingTier, taskRate, gbFree, includedTasks } =
-                    getInitialBillingRecord(ts);
-
-                billingHistory.push({
-                    date,
-                    timestamp: ts,
-                    dataVolume,
-                    taskCount,
-                    totalCost,
-                    pricingTier: pricingTier ?? 'personal',
-                    taskRate: taskRate ?? 20,
-                    gbFree: gbFree ?? FREE_GB_BY_TIER.PERSONAL,
-                    includedTasks: includedTasks ?? 2,
-                });
-            } else {
-                const { date, pricingTier, taskRate, gbFree, includedTasks } =
-                    billingHistory[billingRecordIndex];
-
-                billingHistory[billingRecordIndex] = {
-                    date,
-                    timestamp: ts,
-                    dataVolume,
-                    taskCount,
-                    totalCost,
-                    pricingTier: pricingTier ?? 'personal',
-                    taskRate: taskRate ?? 20,
-                    gbFree: gbFree ?? FREE_GB_BY_TIER.PERSONAL,
-                    includedTasks: includedTasks ?? 2,
-                };
-            }
-        });
-    }
-
-    return billingHistory;
 };
 
 export enum SeriesNames {
@@ -186,7 +44,8 @@ export interface SeriesConfig {
 
 export const formatDataVolumeForDisplay = (
     seriesConfigs: SeriesConfig[],
-    tooltipConfig: any
+    tooltipConfig: any,
+    dataVolumeInBytes?: boolean
 ): string => {
     const filteredSeries =
         seriesConfigs.length === 1
@@ -195,11 +54,18 @@ export const formatDataVolumeForDisplay = (
                   (series) => series.seriesName === tooltipConfig.seriesName
               );
 
-    const dataVolumeInBytes = filteredSeries
+    const config = filteredSeries
         .flatMap(({ data }) => data)
         .find(([month]) => month === tooltipConfig.name);
 
-    return dataVolumeInBytes
-        ? prettyBytes(dataVolumeInBytes[1], { minimumFractionDigits: 2 })
-        : `${tooltipConfig.value[1]} GB`;
+    if (config) {
+        return dataVolumeInBytes
+            ? prettyBytes(config[1], {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+              })
+            : `${config[1].toFixed(2)} GB`;
+    } else {
+        return `${tooltipConfig.value[1]} GB`;
+    }
 };


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Update the billing history table, data volume by month chart, and tasks by month chart so that data is sourced from the `billing_report` RPC.

1. Fetch billing data for previous billing cycles only when initializing the _Billing_ page.

1. Fetch billing data for the current billing cycle every thirty seconds.

## Screenshots

<img width="1258" alt="pr_screenshot-633-billing_rpc-page_loading" src="https://github.com/estuary/ui/assets/77648584/19249148-6c87-4628-a33d-74d3d20fbd53">

<br />

<img width="1026" alt="pr_screenshot-633-billing_rpc-default" src="https://github.com/estuary/ui/assets/77648584/1b46a940-769c-420e-8c08-62414d314634">

<br />

<img width="1026" alt="pr_screenshot-633-billing_rpc-no_data_usage" src="https://github.com/estuary/ui/assets/77648584/2264f0a0-576f-4062-8b24-6279af63dbb7">
