### PR TITLE
Handle guard errors better

### DIFF
--- a/src/app/guards/LegalGuard.tsx
+++ b/src/app/guards/LegalGuard.tsx
@@ -1,18 +1,41 @@
+import FullPageError from 'components/fullPage/Error';
 import FullPageSpinner from 'components/fullPage/Spinner';
 import ClickToAccept from 'directives/ClickToAccept';
 import FullPageWrapper from 'directives/FullPageWrapper';
+import { FormattedMessage } from 'react-intl';
 import { BaseComponentProps } from 'types';
 import useDirectiveGuard from './hooks';
 
 const SELECTED_DIRECTIVE = 'clickToAccept';
 
 function LegalGuard({ children }: BaseComponentProps) {
-    const { directive, loading, status, mutate } =
+    const { directive, error, loading, status, mutate } =
         useDirectiveGuard(SELECTED_DIRECTIVE);
 
     if (loading || status === null) {
         return <FullPageSpinner />;
-    } else if (status !== 'fulfilled') {
+    }
+
+    if (error) {
+        return (
+            <FullPageError
+                error={error}
+                message={
+                    <FormattedMessage
+                        id="legal.error.failedToFetch.message"
+                        values={{
+                            privacy: (
+                                <FormattedMessage id="legal.docs.privacy" />
+                            ),
+                            terms: <FormattedMessage id="legal.docs.terms" />,
+                        }}
+                    />
+                }
+            />
+        );
+    }
+
+    if (status !== 'fulfilled') {
         return (
             <FullPageWrapper>
                 <ClickToAccept

--- a/src/app/guards/TenantGuard.tsx
+++ b/src/app/guards/TenantGuard.tsx
@@ -1,9 +1,11 @@
+import FullPageError from 'components/fullPage/Error';
 import FullPageSpinner from 'components/fullPage/Spinner';
 import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import useUserGrants from 'hooks/useUserGrants';
 import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { BaseComponentProps } from 'types';
 import OnboardGuard from './OnboardGuard';
 
@@ -24,13 +26,27 @@ function TenantGuard({ children }: BaseComponentProps) {
         userGrants,
         isValidating: checkingGrants,
         mutate,
+        error,
     } = useUserGrants({
         singleCall: true,
     });
 
     if (checkingGrants) {
         return <FullPageSpinner />;
-    } else if (userGrants.length === 0 || showBeta) {
+    }
+
+    if (error) {
+        return (
+            <FullPageError
+                error={error}
+                message={
+                    <FormattedMessage id="tenant.error.failedToFetch.message" />
+                }
+            />
+        );
+    }
+
+    if (userGrants.length === 0 || showBeta) {
         return <OnboardGuard grantsMutate={mutate} forceDisplay={showBeta} />;
     } else {
         // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/app/guards/hooks.ts
+++ b/src/app/guards/hooks.ts
@@ -3,10 +3,19 @@ import { exchangeBearerToken } from 'api/directives';
 import { DIRECTIVES } from 'directives/shared';
 import { UserClaims } from 'directives/types';
 import useAppliedDirectives from 'hooks/useAppliedDirectives';
-import { useSnackbar } from 'notistack';
+import { OptionsObject, useSnackbar } from 'notistack';
 import { useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { AppliedDirective } from 'types';
+
+const snackbarSettings: OptionsObject = {
+    anchorOrigin: {
+        vertical: 'top',
+        horizontal: 'center',
+    },
+    preventDuplicate: true,
+    variant: 'info',
+};
 
 const useDirectiveGuard = (
     selectedDirective: keyof typeof DIRECTIVES,
@@ -84,20 +93,23 @@ const useDirectiveGuard = (
                 }
             }
 
+            // Show message to tell user we are still waiting
+            if (directiveState === 'waiting') {
+                enqueueSnackbar(
+                    intl.formatMessage({
+                        id: 'directives.waiting',
+                    }),
+                    snackbarSettings
+                );
+            }
+
             // Show a message to remind the user why they are seeing the directive page
             if (directiveState === 'in progress') {
                 enqueueSnackbar(
                     intl.formatMessage({
                         id: 'directives.returning',
                     }),
-                    {
-                        anchorOrigin: {
-                            vertical: 'top',
-                            horizontal: 'center',
-                        },
-                        preventDuplicate: true,
-                        variant: 'info',
-                    }
+                    snackbarSettings
                 );
             }
 
@@ -119,6 +131,7 @@ const useDirectiveGuard = (
         directiveState,
         enqueueSnackbar,
         intl,
+        options,
         options?.forceNew,
         options?.token,
         selectedDirective,

--- a/src/app/guards/hooks.ts
+++ b/src/app/guards/hooks.ts
@@ -93,18 +93,11 @@ const useDirectiveGuard = (
                 }
             }
 
-            // Show message to tell user we are still waiting
-            if (directiveState === 'waiting') {
-                enqueueSnackbar(
-                    intl.formatMessage({
-                        id: 'directives.waiting',
-                    }),
-                    snackbarSettings
-                );
-            }
-
             // Show a message to remind the user why they are seeing the directive page
-            if (directiveState === 'in progress') {
+            if (
+                directiveState === 'in progress' ||
+                directiveState === 'waiting'
+            ) {
                 enqueueSnackbar(
                     intl.formatMessage({
                         id: 'directives.returning',

--- a/src/components/fullPage/Error.tsx
+++ b/src/components/fullPage/Error.tsx
@@ -5,6 +5,8 @@ import { ErrorDetails } from 'components/shared/Error/types';
 import FullPageWrapper from 'directives/FullPageWrapper';
 import { ReactElement } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { useMount } from 'react-use';
+import { CustomEvents, logRocketEvent } from 'services/logrocket';
 
 interface Props {
     error: ErrorDetails;
@@ -12,6 +14,10 @@ interface Props {
     title?: ReactElement | string;
 }
 function FullPageError({ error, message, title }: Props) {
+    useMount(() => {
+        logRocketEvent(CustomEvents.FULL_PAGE_ERROR_DISPLAYED);
+    });
+
     return (
         <FullPageWrapper>
             <Stack spacing={2}>

--- a/src/components/fullPage/Error.tsx
+++ b/src/components/fullPage/Error.tsx
@@ -1,17 +1,36 @@
-import { Typography } from '@mui/material';
+import { Divider, Stack, Typography } from '@mui/material';
+import MessageWithLink from 'components/content/MessageWithLink';
 import Error from 'components/shared/Error';
+import { ErrorDetails } from 'components/shared/Error/types';
 import FullPageWrapper from 'directives/FullPageWrapper';
 import { ReactElement } from 'react';
+import { FormattedMessage } from 'react-intl';
 
 interface Props {
-    error: any;
-    title: ReactElement | string;
+    error: ErrorDetails;
+    message?: ReactElement;
+    title?: ReactElement | string;
 }
-function FullPageError({ error, title }: Props) {
+function FullPageError({ error, message, title }: Props) {
     return (
-        <FullPageWrapper fullWidth={true}>
-            <Typography>{title}</Typography>
-            <Error error={error} />
+        <FullPageWrapper>
+            <Stack spacing={2}>
+                <Typography variant="h5">
+                    {title ? (
+                        title
+                    ) : (
+                        <FormattedMessage id="common.failedFetch" />
+                    )}
+                </Typography>
+                {message ? (
+                    <Typography variant="subtitle1">{message}</Typography>
+                ) : null}
+                <Typography variant="subtitle1">
+                    <MessageWithLink messageID="fullPage.instructions" />
+                </Typography>
+                <Divider />
+                <Error error={error} condensed />
+            </Stack>
         </FullPageWrapper>
     );
 }

--- a/src/context/SWR.tsx
+++ b/src/context/SWR.tsx
@@ -57,7 +57,7 @@ const SwrConfigProvider = ({ children }: BaseComponentProps) => {
                     },
 
                     // Start with a quick retry in case the problem was ephemeral
-                    errorRetryInterval: 1000,
+                    errorRetryInterval: 2500,
 
                     // TODO (SWR) this is nice but we need some UX built out before turning it back on
                     revalidateOnFocus: false,

--- a/src/directives/ClickToAccept.tsx
+++ b/src/directives/ClickToAccept.tsx
@@ -52,8 +52,8 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
 
             if (showErrors) setShowErrors(!checked);
         },
-        submit: async (event?: any) => {
-            event?.preventDefault();
+        submit: async (event: any) => {
+            event.preventDefault();
 
             if (!acknowledgedDocuments) {
                 setShowErrors(true);
@@ -167,7 +167,6 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
                     <FormControlLabel
                         control={
                             <Checkbox
-                                checked={acknowledgedDocuments}
                                 value={acknowledgedDocuments}
                                 required
                                 icon={<Square style={{ fontSize: 14 }} />}

--- a/src/directives/ClickToAccept.tsx
+++ b/src/directives/ClickToAccept.tsx
@@ -14,7 +14,6 @@ import { Square } from 'iconoir-react';
 import CheckSquare from 'icons/CheckSquare';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useEffectOnce } from 'react-use';
 import { jobStatusPoller } from 'services/supabase';
 import { getUrls } from 'utils/env-utils';
 import {
@@ -38,13 +37,9 @@ const submit_clickToAccept = async (directive: any) => {
 const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
     trackEvent(`${directiveName}:Viewed`);
 
-    // If the user is waiting
-    //  Preselect the acknolwedgment
-    //  Show the form as saving
-    const waiting = status === 'waiting';
     const [acknowledgedDocuments, setAcknowledgedDocuments] =
-        useState<boolean>(waiting);
-    const [saving, setSaving] = useState(waiting);
+        useState<boolean>(false);
+    const [saving, setSaving] = useState(false);
 
     const [showErrors, setShowErrors] = useState(false);
     const [serverError, setServerError] = useState<string | null>(null);
@@ -93,12 +88,6 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
             }
         },
     };
-
-    useEffectOnce(() => {
-        if (waiting) {
-            void handlers.submit();
-        }
-    });
 
     return (
         <>
@@ -178,7 +167,6 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
                     <FormControlLabel
                         control={
                             <Checkbox
-                                disabled={waiting}
                                 checked={acknowledgedDocuments}
                                 value={acknowledgedDocuments}
                                 required

--- a/src/directives/ClickToAccept.tsx
+++ b/src/directives/ClickToAccept.tsx
@@ -14,6 +14,7 @@ import { Square } from 'iconoir-react';
 import CheckSquare from 'icons/CheckSquare';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { useEffectOnce } from 'react-use';
 import { jobStatusPoller } from 'services/supabase';
 import { getUrls } from 'utils/env-utils';
 import {
@@ -37,9 +38,14 @@ const submit_clickToAccept = async (directive: any) => {
 const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
     trackEvent(`${directiveName}:Viewed`);
 
+    // If the user is waiting
+    //  Preselect the acknolwedgment
+    //  Show the form as saving
+    const waiting = status === 'waiting';
     const [acknowledgedDocuments, setAcknowledgedDocuments] =
-        useState<boolean>(false);
-    const [saving, setSaving] = useState(false);
+        useState<boolean>(waiting);
+    const [saving, setSaving] = useState(waiting);
+
     const [showErrors, setShowErrors] = useState(false);
     const [serverError, setServerError] = useState<string | null>(null);
 
@@ -51,8 +57,8 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
 
             if (showErrors) setShowErrors(!checked);
         },
-        submit: async (event: any) => {
-            event.preventDefault();
+        submit: async (event?: any) => {
+            event?.preventDefault();
 
             if (!acknowledgedDocuments) {
                 setShowErrors(true);
@@ -87,6 +93,12 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
             }
         },
     };
+
+    useEffectOnce(() => {
+        if (waiting) {
+            void handlers.submit();
+        }
+    });
 
     return (
         <>
@@ -166,6 +178,8 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
                     <FormControlLabel
                         control={
                             <Checkbox
+                                disabled={waiting}
+                                checked={acknowledgedDocuments}
                                 value={acknowledgedDocuments}
                                 required
                                 icon={<Square style={{ fontSize: 14 }} />}

--- a/src/directives/Onboard/OrganizationName.tsx
+++ b/src/directives/Onboard/OrganizationName.tsx
@@ -3,35 +3,23 @@ import {
     useOnboardingStore_nameInvalid,
     useOnboardingStore_nameMissing,
     useOnboardingStore_requestedTenant,
-    useOnboardingStore_setNameInvalid,
-    useOnboardingStore_setNameMissing,
     useOnboardingStore_setRequestedTenant,
 } from 'directives/Onboard/Store/hooks';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { hasLength, PREFIX_NAME_PATTERN } from 'utils/misc-utils';
+import { PREFIX_NAME_PATTERN } from 'utils/misc-utils';
 
 function OrganizationNameField() {
     const intl = useIntl();
 
     // Onboarding Store
     const nameInvalid = useOnboardingStore_nameInvalid();
-    const setNameInvalid = useOnboardingStore_setNameInvalid();
-
     const nameMissing = useOnboardingStore_nameMissing();
-    const setNameMissing = useOnboardingStore_setNameMissing();
-
     const requestedTenant = useOnboardingStore_requestedTenant();
     const setRequestedTenant = useOnboardingStore_setRequestedTenant();
 
     const handlers = {
         update: (updatedValue: string) => {
-            const pattern = new RegExp(`^${PREFIX_NAME_PATTERN}$`);
-
-            setNameInvalid(!pattern.test(updatedValue));
-
             setRequestedTenant(updatedValue);
-
-            if (nameMissing) setNameMissing(!hasLength(updatedValue));
         },
     };
 
@@ -42,6 +30,7 @@ function OrganizationNameField() {
             </FormLabel>
 
             <TextField
+                value={requestedTenant}
                 size="small"
                 placeholder={intl.formatMessage({
                     id: 'tenant.input.placeholder',
@@ -55,7 +44,6 @@ function OrganizationNameField() {
                 error={nameMissing || nameInvalid}
                 id="requestedTenant"
                 label={<FormattedMessage id="common.tenant.creationForm" />}
-                value={requestedTenant}
                 onChange={(event) => handlers.update(event.target.value)}
                 required
                 inputProps={{

--- a/src/directives/Onboard/Store/create.ts
+++ b/src/directives/Onboard/Store/create.ts
@@ -1,9 +1,12 @@
 import { OnboardingState } from 'directives/Onboard/Store/types';
 import produce from 'immer';
 import { OnboardingStoreNames } from 'stores/names';
+import { hasLength, PREFIX_NAME_PATTERN } from 'utils/misc-utils';
 import { devtoolsOptions } from 'utils/store-utils';
 import { create, StoreApi } from 'zustand';
 import { devtools, NamedSet } from 'zustand/middleware';
+
+const namePattern = new RegExp(`^${PREFIX_NAME_PATTERN}$`);
 
 const getInitialStateData = (): Pick<
     OnboardingState,
@@ -29,6 +32,8 @@ const getInitialState = (
     setRequestedTenant: (value) => {
         set(
             produce((state: OnboardingState) => {
+                state.nameMissing = !hasLength(value);
+                state.nameInvalid = !namePattern.test(value);
                 state.requestedTenant = value;
             }),
             false,

--- a/src/directives/shared.ts
+++ b/src/directives/shared.ts
@@ -85,25 +85,37 @@ export const DIRECTIVES: Directives = {
             };
         },
         calculateStatus: (appliedDirective?) => {
+            const isOutdated = () => {
+                return (
+                    appliedDirective?.user_claims?.version &&
+                    appliedDirective.user_claims.version !==
+                        CLICK_TO_ACCEPT_LATEST_VERSION
+                );
+            };
+
             // If there is no directive to check it is unfulfilled
             if (!appliedDirective || isEmpty(appliedDirective)) {
                 return 'unfulfilled';
             }
 
-            // If directive already queued and no claim is there we can just use that directive again
-            if (
-                appliedDirective.job_status.type === 'queued' &&
-                !appliedDirective.user_claims
-            ) {
-                return 'in progress';
+            // If directive already queued and ...
+            if (appliedDirective.job_status.type === 'queued') {
+                // no claim is there we can just use that directive again
+                if (!appliedDirective.user_claims) {
+                    return 'in progress';
+                }
+
+                // queued claim is outdate
+                if (isOutdated()) {
+                    return 'outdated';
+                }
+
+                // queued claim is current
+                return 'waiting';
             }
 
             // If previous claim is outdate then we need a new directive
-            if (
-                appliedDirective.user_claims?.version &&
-                appliedDirective.user_claims.version !==
-                    CLICK_TO_ACCEPT_LATEST_VERSION
-            ) {
+            if (isOutdated()) {
                 return 'outdated';
             }
 

--- a/src/directives/types.ts
+++ b/src/directives/types.ts
@@ -13,6 +13,7 @@ export interface Directives {
 export type DirectiveStates =
     | 'unfulfilled'
     | 'in progress'
+    | 'waiting'
     | 'fulfilled'
     | 'outdated'
     | 'errored';

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -178,7 +178,7 @@ const ConfirmationDialog: ResolvedIntlConfig['messages'] = {
 };
 
 const FullPage: ResolvedIntlConfig['messages'] = {
-    'fullPage.instructions': `Please try again and, if the error persists {docLink}`,
+    'fullPage.instructions': `Please reload the page and, if the error persists {docLink}`,
     'fullPage.instructions.docLink': `contact support`,
     'fullPage.instructions.docPath': `mailto:support@estuary.dev`,
 };

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -184,7 +184,7 @@ const FullPage: ResolvedIntlConfig['messages'] = {
 };
 
 const EntitiesHydrator: ResolvedIntlConfig['messages'] = {
-    'entitiesHydrator.error': `Unable to load auth roles.`,
+    'entitiesHydrator.error.failedToFetch': `There was an issue while checking if you have any roles.`,
 };
 
 const Navigation: ResolvedIntlConfig['messages'] = {

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -82,6 +82,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
 
     // Used in directives
     'directives.returning': `Welcome back. You still need to provide some information before using the application.`,
+    'directives.waiting': `Welcome back. You have already provided the required information and are waiting on a response.`,
 
     // User in filters for tables
     'filter.time.today': `Today`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -82,7 +82,6 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
 
     // Used in directives
     'directives.returning': `Welcome back. You still need to provide some information before using the application.`,
-    'directives.waiting': `Welcome back. You have already provided the required information and are waiting on a response.`,
 
     // User in filters for tables
     'filter.time.today': `Today`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -178,7 +178,7 @@ const ConfirmationDialog: ResolvedIntlConfig['messages'] = {
 };
 
 const FullPage: ResolvedIntlConfig['messages'] = {
-    'fullPage.instructions': `Please reload the page and, if the error persists {docLink}`,
+    'fullPage.instructions': `Please try again. If the error persists, {docLink}`,
     'fullPage.instructions.docLink': `contact support`,
     'fullPage.instructions.docPath': `mailto:support@estuary.dev`,
 };
@@ -425,7 +425,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
 
     'admin.billing.header': `Billing`,
     'admin.billing.message.paidTier': `The {pricingTier} tier includes two tasks and {gbFree}GB every month. Thereafter you pay $0.75/GB with a \${taskRate} minimum per task.`,
-    'admin.billing.error.paymentMethodsError': `There was an error connecting with our payment provider.  Please try again later.`,
+    'admin.billing.error.paymentMethodsError': `There was an error connecting with our payment provider. Please try again later.`,
     'admin.billing.error.undefinedPricingTier': `An issue was encountered gathering information about the pricing tier associated with this tenant. Please {docLink}.`,
     'admin.billing.error.undefinedPricingTier.docLink': `contact support`,
     'admin.billing.error.undefinedPricingTier.docPath': `mailto:support@estuary.dev`,
@@ -870,7 +870,7 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.collectionSelector.schemaInference.alert.lowDocumentCount.message': `Fewer documents than desired were found. This could mean that your collection isn't seeing very much data.`,
     'workflows.collectionSelector.schemaInference.alert.generalError.header': `Server Error`,
     'workflows.collectionSelector.schemaInference.alert.inferenceService.message': `This is not something you did wrong. An error was encountered while inferring the shape of the documents in this collection.`,
-    'workflows.collectionSelector.schemaInference.alert.patchService.message': `This is not something you did wrong. An error was encountered while applying the inferred schema. Please try again and, if the error persists {docLink}`,
+    'workflows.collectionSelector.schemaInference.alert.patchService.message': `This is not something you did wrong. An error was encountered while applying the inferred schema. Please try again. If the error persists, {docLink}`,
     'workflows.collectionSelector.schemaInference.alert.patchService.message.docLink': `contact support`,
     'workflows.collectionSelector.schemaInference.alert.patchService.message.docPath': `mailto:support@estuary.dev`,
     'workflows.collectionSelector.schemaInference.cta.continue': `Apply Inferred Schema`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -38,6 +38,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'common.synchronized': `Synchronized`,
     'common.outOfSync': `Out of Sync`,
     'common.readOnly': `Read-Only`,
+    'common.failedFetch': `Unable to reach server`,
 
     // Aria
     'aria.openExpand': `show more`,
@@ -176,10 +177,14 @@ const ConfirmationDialog: ResolvedIntlConfig['messages'] = {
     'confirm.loseData': `You have unsaved work. If you continue, you will lose your changes.`,
 };
 
+const FullPage: ResolvedIntlConfig['messages'] = {
+    'fullPage.instructions': `Please try again and, if the error persists {docLink}`,
+    'fullPage.instructions.docLink': `contact support`,
+    'fullPage.instructions.docPath': `mailto:support@estuary.dev`,
+};
+
 const EntitiesHydrator: ResolvedIntlConfig['messages'] = {
-    'entitiesHydrator.error': `Unable to load auth roles. Please try again and, if the error persists {docLink}`,
-    'entitiesHydrator.error.docLink': `contact support`,
-    'entitiesHydrator.error.docPath': `mailto:support@estuary.dev`,
+    'entitiesHydrator.error': `Unable to load auth roles.`,
 };
 
 const Navigation: ResolvedIntlConfig['messages'] = {
@@ -655,11 +660,11 @@ const CaptureCreate: ResolvedIntlConfig['messages'] = {
     'captureCreate.collectionSelector.instructions': `The collections bound to your capture. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Collection tab.`,
 
     'captureCreate.test.failedErrorTitle': `Configuration Test Failed`,
-    'captureCreate.test.serverUnreachable': `Unable to reach server while testing configuration.`,
+    'captureCreate.test.serverUnreachable': `${CommonMessages['common.failedFetch']} while testing configuration.`,
 
     'captureCreate.save.failedErrorTitle': `Capture Save Failed`,
     'captureCreate.save.failure.errorTitle': `Capture Save Failed`,
-    'captureCreate.save.serverUnreachable': `Unable to reach server while saving capture`,
+    'captureCreate.save.serverUnreachable': `${CommonMessages['common.failedFetch']} while saving capture`,
     'captureCreate.save.waitMessage': `Please wait while we test, save, and publish your capture.`,
 
     'captureCreate.generate.failedErrorTitle': `Generating Specification Failed`,
@@ -691,11 +696,11 @@ const CaptureEdit: ResolvedIntlConfig['messages'] = {
     'captureEdit.collectionSelector.instructions': `The collections bound to your existing capture. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Collection tab.`,
 
     'captureEdit.test.failedErrorTitle': `Configuration Test Failed`,
-    'captureEdit.test.serverUnreachable': `Unable to reach server while testing configuration.`,
+    'captureEdit.test.serverUnreachable': `${CommonMessages['common.failedFetch']} while testing configuration.`,
 
     'captureEdit.save.failedErrorTitle': `Capture Save Failed`,
     'captureEdit.save.failure.errorTitle': `Capture Save Failed`,
-    'captureEdit.save.serverUnreachable': `Unable to reach server while saving capture`,
+    'captureEdit.save.serverUnreachable': `${CommonMessages['common.failedFetch']} while saving capture`,
     'captureEdit.save.waitMessage': `Please wait while we test, save, and publish your capture.`,
 
     'captureEdit.generate.failedErrorTitle': `Generating Specification Failed`,
@@ -737,12 +742,12 @@ const MaterializationCreate: ResolvedIntlConfig['messages'] = {
     'materializationCreate.noAccessGrants': `You do not have the necessary ${CommonMessages['terms.permissions']} to create a materialization. Please contact an administrator.`,
     'materializationCreate.save.failure': `Materialization creation failed. See below for details:`,
     'materializationCreate.save.failure.errorTitle': `Materialization Save Failed`,
-    'materializationCreate.save.serverUnreachable': `Unable to reach server while saving materialization`,
+    'materializationCreate.save.serverUnreachable': `${CommonMessages['common.failedFetch']} while saving materialization`,
     'materializationCreate.tenant.label': `Prefix`,
 
     'materializationCreate.generate.failure.errorTitle': `Materialization Preparation Failed`,
 
-    'materializationCreate.test.serverUnreachable': `Unable to reach server while testing configuration`,
+    'materializationCreate.test.serverUnreachable': `${CommonMessages['common.failedFetch']} while testing configuration`,
     'materializationCreate.test.inProgress': `Please wait while we try to connect to the destination.`,
 
     'materializationCreate.collectionSelector.heading': `Collection Selector`,
@@ -774,12 +779,12 @@ const MaterializationEdit: ResolvedIntlConfig['messages'] = {
     'materializationEdit.noAccessGrants': `You do not have the necessary ${CommonMessages['terms.permissions']} to edit a materialization. Please contact an administrator.`,
     'materializationEdit.save.failure': `Materialization edit failed. See below for details:`,
     'materializationEdit.save.failure.errorTitle': `Materialization Save Failed`,
-    'materializationEdit.save.serverUnreachable': `Unable to reach server while saving materialization`,
+    'materializationEdit.save.serverUnreachable': `${CommonMessages['common.failedFetch']} while saving materialization`,
     'materializationEdit.tenant.label': `Prefix`,
 
     'materializationEdit.generate.failure.errorTitle': `Materialization Preparation Failed`,
 
-    'materializationEdit.test.serverUnreachable': `Unable to reach server while testing configuration`,
+    'materializationEdit.test.serverUnreachable': `${CommonMessages['common.failedFetch']} while testing configuration`,
     'materializationEdit.test.inProgress': `Please wait while we try to connect to the destination.`,
 
     'materializationEdit.collectionSelector.heading': `Collection Selector`,
@@ -896,7 +901,7 @@ const OAuth: ResolvedIntlConfig['messages'] = {
 };
 
 const Supabase: ResolvedIntlConfig['messages'] = {
-    'supabase.poller.failed.title': `Unable To Reach Server`,
+    'supabase.poller.failed.title': `${CommonMessages['common.failedFetch']}`,
     'supabase.poller.failed.message': `We encountered a problem retrieving the status of this action. Please check your network connection and try again.`,
 };
 
@@ -911,6 +916,7 @@ const Legal: ResolvedIntlConfig['messages'] = {
     'legal.docs.errorTitle': 'Please accept',
     'legal.docs.errorMessage':
         'Before you can continue using the application you must accept the listed documents.',
+    'legal.error.failedToFetch.message': `There was an issue while checking if you have accepted the latest {privacy} and {terms}.`,
 };
 
 const Tenant: ResolvedIntlConfig['messages'] = {
@@ -945,6 +951,8 @@ const Tenant: ResolvedIntlConfig['messages'] = {
     'tenant.grantDirective.error.message.help': `For additional context, please {docLink}.`,
     'tenant.grantDirective.error.message.help.docLink': `contact support`,
     'tenant.grantDirective.error.message.help.docPath': `mailto:support@estuary.dev`,
+
+    'tenant.error.failedToFetch.message': `There was an issue while checking if you have access to a tenant.`,
 };
 
 const Details: ResolvedIntlConfig['messages'] = {
@@ -1032,7 +1040,7 @@ const SchemaEditor_Collection: ResolvedIntlConfig['messages'] = {
 
 const EntityEvolution: ResolvedIntlConfig['messages'] = {
     'entityEvolution.failure.errorTitle': `Update Failed`,
-    'entityEvolution.serverUnreachable': `Unable to reach server while trying to update collections`,
+    'entityEvolution.serverUnreachable': `${CommonMessages['common.failedFetch']} while trying to update collections`,
     'entityEvolution.error.title': `Changes Rejected Due to Incompatible Schema Updates`,
     'entityEvolution.error.message': `Schema changes will break downstream tasks. To avoid this, click below and then publish a new version of the affected collections.`,
     'entityEvolution.error.note': `Note: This may result in additional cost as new collection versions are backfilled.`,
@@ -1053,6 +1061,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...ErrorBoundry,
     ...RouteTitles,
     ...EntitiesHydrator,
+    ...FullPage,
     ...Header,
     ...Navigation,
     ...ConfirmationDialog,

--- a/src/services/logrocket.ts
+++ b/src/services/logrocket.ts
@@ -39,6 +39,7 @@ export enum CustomEvents {
     DIRECTIVE = 'Directive',
     ERROR_BOUNDARY_DISPLAYED = 'Error_Boundary_Displayed',
     ERROR_BOUNDARY_PAYMENT_METHODS = 'Error_Boundary_Displayed:PaymentMethods',
+    FULL_PAGE_ERROR_DISPLAYED = 'Full_Page_Error_Displayed',
 }
 
 const logRocketSettings = getLogRocketSettings();

--- a/src/stores/Entities/Hydrator.tsx
+++ b/src/stores/Entities/Hydrator.tsx
@@ -1,6 +1,6 @@
-import MessageWithLink from 'components/content/MessageWithLink';
 import FullPageError from 'components/fullPage/Error';
 import FullPageSpinner from 'components/fullPage/Spinner';
+import { FormattedMessage } from 'react-intl';
 import { BaseComponentProps } from 'types';
 import {
     useEntitiesStore_hydrated,
@@ -24,7 +24,9 @@ export const EntitiesHydrator = ({ children }: BaseComponentProps) => {
         return (
             <FullPageError
                 error={hydrationErrors}
-                title={<MessageWithLink messageID="entitiesHydrator.error" />}
+                message={
+                    <FormattedMessage id="entitiesHydrator.error.failedToFetch" />
+                }
             />
         );
     }

--- a/src/stores/Entities/hooks.ts
+++ b/src/stores/Entities/hooks.ts
@@ -1,4 +1,3 @@
-import { singleCallSettings } from 'context/SWR';
 import { useZustandStore } from 'context/Zustand/provider';
 import { useEffect } from 'react';
 import { GlobalStoreNames } from 'stores/names';
@@ -96,13 +95,9 @@ export const useSidePanelDocsStore_resetState = () => {
 export const useHydrateState = () => {
     const hydrateState = useEntitiesStore_hydrateState();
 
-    const response = useSWR(
-        'entities_hydrator',
-        () => {
-            return hydrateState();
-        },
-        singleCallSettings
-    );
+    const response = useSWR('entities_hydrator', () => {
+        return hydrateState();
+    });
 
     // The rest of the stuff we need to handle hydration
     const setHydrationErrors = useEntitiesStore_setHydrationErrors();

--- a/src/stores/Entities/hooks.ts
+++ b/src/stores/Entities/hooks.ts
@@ -1,3 +1,4 @@
+import { singleCallSettings } from 'context/SWR';
 import { useZustandStore } from 'context/Zustand/provider';
 import { useEffect } from 'react';
 import { GlobalStoreNames } from 'stores/names';
@@ -95,9 +96,13 @@ export const useSidePanelDocsStore_resetState = () => {
 export const useHydrateState = () => {
     const hydrateState = useEntitiesStore_hydrateState();
 
-    const response = useSWR('entities_hydrator', () => {
-        return hydrateState();
-    });
+    const response = useSWR(
+        'entities_hydrator',
+        () => {
+            return hydrateState();
+        },
+        singleCallSettings
+    );
 
     // The rest of the stuff we need to handle hydration
     const setHydrationErrors = useEntitiesStore_setHydrationErrors();


### PR DESCRIPTION
## Changes

1. Full page error - make it a bit more usable for a user
2. Legal Guard - better error handling
3. Tenant Guard - better error handling
4. Grant Guard - left alone. Need to convert it's error handle to `FullPageError` component but that can happen later.
5. SWR - bumped the initial retry time up a little bit

## Tests

Manually tested by stopping supabase.

## Issues

Discussion from slack

## Content

Sharing some common language
Some new messages for when there is an error following the pattern: `There was an issue while checking if you [have access to a tenant, ...].`

## Screenshots

### Legal Stuff Errors
#### Server down
![image](https://github.com/estuary/ui/assets/270078/82375173-1275-48b9-b066-9c827031cb99)

##### Query issue
![image](https://github.com/estuary/ui/assets/270078/0797d784-e1c1-458e-a08a-a419115555ce)


### Tenant Error
#### Server down
![image](https://github.com/estuary/ui/assets/270078/d1141e00-fc41-45b6-8e2f-bf2e9a7858f7)

### Auth Roles Error
![image](https://github.com/estuary/ui/assets/270078/82a92396-55fd-4663-9354-03a92be435d8)
