### PR TITLE
Expand access grant-related features

### DIFF
--- a/src/api/roleGrants.ts
+++ b/src/api/roleGrants.ts
@@ -1,0 +1,15 @@
+import { insertSupabase, TABLES } from 'services/supabase';
+import { Capability } from 'types';
+
+export const createRoleGrant = (
+    subject_role: string,
+    object_role: string,
+    capability: Capability
+) => {
+    return insertSupabase(TABLES.ROLE_GRANTS, {
+        subject_role,
+        object_role,
+        capability,
+        detail: 'Applied via UI',
+    });
+};

--- a/src/api/roleGrants.ts
+++ b/src/api/roleGrants.ts
@@ -10,6 +10,5 @@ export const createRoleGrant = (
         subject_role,
         object_role,
         capability,
-        detail: 'Applied via UI',
     });
 };

--- a/src/app/guards/hooks.ts
+++ b/src/app/guards/hooks.ts
@@ -19,7 +19,7 @@ const snackbarSettings: OptionsObject = {
 
 const useDirectiveGuard = (
     selectedDirective: keyof typeof DIRECTIVES,
-    options?: { forceNew?: boolean; token?: string }
+    options?: { forceNew?: boolean; token?: string; hideAlert?: boolean }
 ) => {
     const intl = useIntl();
     const { enqueueSnackbar } = useSnackbar();
@@ -100,7 +100,10 @@ const useDirectiveGuard = (
         }
 
         // Show a message to remind the user why they are seeing the directive page
-        if (directiveState === 'in progress' || directiveState === 'waiting') {
+        if (
+            !options?.hideAlert &&
+            (directiveState === 'in progress' || directiveState === 'waiting')
+        ) {
             enqueueSnackbar(
                 intl.formatMessage({
                     id: 'directives.returning',
@@ -122,6 +125,7 @@ const useDirectiveGuard = (
         intl,
         options?.forceNew,
         options?.token,
+        options?.hideAlert,
         selectedDirective,
         serverError,
     ]);

--- a/src/components/admin/AccessGrants.tsx
+++ b/src/components/admin/AccessGrants.tsx
@@ -3,7 +3,6 @@ import { authenticatedRoutes } from 'app/routes';
 import AdminTabs from 'components/admin/Tabs';
 import MessageWithLink from 'components/content/MessageWithLink';
 import AccessGrantsTable from 'components/tables/AccessGrants';
-import AccessLinksButton from 'components/tables/AccessGrants/AccessLinks/Dialog/Button';
 import usePageTitle from 'hooks/usePageTitle';
 import { FormattedMessage } from 'react-intl';
 
@@ -18,25 +17,13 @@ function AccessGrants() {
             <AdminTabs />
 
             <Stack spacing={2} sx={{ m: 2 }}>
-                <Stack
-                    direction="row"
-                    spacing={2}
-                    sx={{ justifyContent: 'space-between' }}
-                >
-                    <Box>
-                        <Typography
-                            component="div"
-                            variant="h6"
-                            sx={{ mb: 0.5 }}
-                        >
-                            <FormattedMessage id="terms.permissions" />
-                        </Typography>
+                <Box>
+                    <Typography component="div" variant="h6" sx={{ mb: 0.5 }}>
+                        <FormattedMessage id="terms.permissions" />
+                    </Typography>
 
-                        <MessageWithLink messageID="admin.roles.message" />
-                    </Box>
-
-                    <AccessLinksButton />
-                </Stack>
+                    <MessageWithLink messageID="admin.roles.message" />
+                </Box>
 
                 <Divider />
             </Stack>

--- a/src/components/content/MessageWithButton.tsx
+++ b/src/components/content/MessageWithButton.tsx
@@ -6,6 +6,7 @@ interface Props {
     messageId: string;
     clickHandler: MouseEventHandler<HTMLButtonElement>;
     buttonVariant?: ButtonProps['variant'];
+    disabled?: boolean;
     messageValues?: { [key: string]: any };
 }
 
@@ -13,6 +14,7 @@ function MessageWithButton({
     messageId,
     clickHandler,
     buttonVariant = 'text',
+    disabled,
     messageValues,
 }: Props) {
     return (
@@ -25,6 +27,7 @@ function MessageWithButton({
                         <Button
                             variant={buttonVariant}
                             size="small"
+                            disabled={disabled}
                             onClick={clickHandler}
                         >
                             <FormattedMessage id={`${messageId}.button`} />

--- a/src/components/content/MessageWithButton.tsx
+++ b/src/components/content/MessageWithButton.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, ButtonProps, Typography } from '@mui/material';
+import { MouseEventHandler } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+interface Props {
+    messageId: string;
+    clickHandler: MouseEventHandler<HTMLButtonElement>;
+    buttonVariant?: ButtonProps['variant'];
+}
+
+function MessageWithButton({
+    messageId,
+    clickHandler,
+    buttonVariant = 'text',
+}: Props) {
+    return (
+        <Typography component="div" sx={{ lineHeight: 1 }}>
+            <FormattedMessage
+                id={messageId}
+                tagName={Box}
+                values={{
+                    button: (
+                        <Button
+                            variant={buttonVariant}
+                            size="small"
+                            onClick={clickHandler}
+                        >
+                            <FormattedMessage id={`${messageId}.button`} />
+                        </Button>
+                    ),
+                }}
+            />
+        </Typography>
+    );
+}
+
+export default MessageWithButton;

--- a/src/components/content/MessageWithButton.tsx
+++ b/src/components/content/MessageWithButton.tsx
@@ -6,15 +6,17 @@ interface Props {
     messageId: string;
     clickHandler: MouseEventHandler<HTMLButtonElement>;
     buttonVariant?: ButtonProps['variant'];
+    messageValues?: { [key: string]: any };
 }
 
 function MessageWithButton({
     messageId,
     clickHandler,
     buttonVariant = 'text',
+    messageValues,
 }: Props) {
     return (
-        <Typography component="div" sx={{ lineHeight: 1 }}>
+        <Typography component="div">
             <FormattedMessage
                 id={messageId}
                 tagName={Box}
@@ -28,6 +30,7 @@ function MessageWithButton({
                             <FormattedMessage id={`${messageId}.button`} />
                         </Button>
                     ),
+                    ...messageValues,
                 }}
             />
         </Typography>

--- a/src/components/content/MessageWithButton.tsx
+++ b/src/components/content/MessageWithButton.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ButtonProps, Typography } from '@mui/material';
+import { Button, ButtonProps, Typography } from '@mui/material';
 import { MouseEventHandler } from 'react';
 import { FormattedMessage } from 'react-intl';
 
@@ -18,10 +18,9 @@ function MessageWithButton({
     messageValues,
 }: Props) {
     return (
-        <Typography component="div">
+        <Typography>
             <FormattedMessage
                 id={messageId}
-                tagName={Box}
                 values={{
                     button: (
                         <Button

--- a/src/components/hero/AcceptDemoInvitation.tsx
+++ b/src/components/hero/AcceptDemoInvitation.tsx
@@ -11,8 +11,9 @@ import { useEntitiesStore_mutate } from 'stores/Entities/hooks';
 
 interface Props {
     tenant: string;
-    setOpen: Dispatch<SetStateAction<boolean>>;
+    loading: boolean;
     setLoading: Dispatch<SetStateAction<boolean>>;
+    setOpen: Dispatch<SetStateAction<boolean>>;
     goToFilteredTable: () => void;
 }
 
@@ -20,8 +21,9 @@ const directiveName = 'acceptDemoTenant';
 
 function AcceptDemoInvitation({
     tenant,
-    setOpen,
+    loading,
     setLoading,
+    setOpen,
     goToFilteredTable,
 }: Props) {
     const { directive, mutate } = useDirectiveGuard(directiveName, {
@@ -95,6 +97,7 @@ function AcceptDemoInvitation({
                     userTenant: <b>{tenant}</b>,
                 }}
                 clickHandler={applyDirective}
+                disabled={loading}
             />
         </>
     );

--- a/src/components/hero/AcceptDemoInvitation.tsx
+++ b/src/components/hero/AcceptDemoInvitation.tsx
@@ -49,7 +49,7 @@ function AcceptDemoInvitation({ tenant, setOpen, goToFilteredTable }: Props) {
 
                     void mutate().finally(() => {
                         if (mutateAuthRoles) {
-                            mutateAuthRoles();
+                            void mutateAuthRoles();
                         }
 
                         setOpen(false);

--- a/src/components/hero/AcceptDemoInvitation.tsx
+++ b/src/components/hero/AcceptDemoInvitation.tsx
@@ -12,12 +12,18 @@ import { useEntitiesStore_mutate } from 'stores/Entities/hooks';
 interface Props {
     tenant: string;
     setOpen: Dispatch<SetStateAction<boolean>>;
+    setLoading: Dispatch<SetStateAction<boolean>>;
     goToFilteredTable: () => void;
 }
 
 const directiveName = 'acceptDemoTenant';
 
-function AcceptDemoInvitation({ tenant, setOpen, goToFilteredTable }: Props) {
+function AcceptDemoInvitation({
+    tenant,
+    setOpen,
+    setLoading,
+    goToFilteredTable,
+}: Props) {
     const { directive, mutate } = useDirectiveGuard(directiveName, {
         hideAlert: true,
     });
@@ -28,6 +34,8 @@ function AcceptDemoInvitation({ tenant, setOpen, goToFilteredTable }: Props) {
 
     const applyDirective = async (): Promise<void> => {
         if (directive) {
+            setLoading(true);
+
             const response = await submitDirective(
                 directiveName,
                 directive,
@@ -35,6 +43,7 @@ function AcceptDemoInvitation({ tenant, setOpen, goToFilteredTable }: Props) {
             );
 
             if (response.error) {
+                setLoading(false);
                 return setServerError(response.error as PostgrestError);
             }
 
@@ -52,6 +61,7 @@ function AcceptDemoInvitation({ tenant, setOpen, goToFilteredTable }: Props) {
                             void mutateAuthRoles();
                         }
 
+                        setLoading(false);
                         setOpen(false);
                         goToFilteredTable();
                     });
@@ -59,6 +69,7 @@ function AcceptDemoInvitation({ tenant, setOpen, goToFilteredTable }: Props) {
                 async (payload: any) => {
                     trackEvent(`${directiveName}:Error`, directive);
 
+                    setLoading(false);
                     setServerError(payload.job_status.error);
                 }
             );

--- a/src/components/hero/AcceptDemoInvitation.tsx
+++ b/src/components/hero/AcceptDemoInvitation.tsx
@@ -1,0 +1,92 @@
+import { Box } from '@mui/material';
+import { PostgrestError } from '@supabase/postgrest-js';
+import { submitDirective } from 'api/directives';
+import useDirectiveGuard from 'app/guards/hooks';
+import MessageWithButton from 'components/content/MessageWithButton';
+import Error from 'components/shared/Error';
+import { jobStatusQuery, trackEvent } from 'directives/shared';
+import { Dispatch, SetStateAction, useState } from 'react';
+import { jobStatusPoller } from 'services/supabase';
+import { useEntitiesStore_mutate } from 'stores/Entities/hooks';
+
+interface Props {
+    tenant: string;
+    setOpen: Dispatch<SetStateAction<boolean>>;
+    goToFilteredTable: () => void;
+}
+
+const directiveName = 'acceptDemoTenant';
+
+function AcceptDemoInvitation({ tenant, setOpen, goToFilteredTable }: Props) {
+    const { directive, mutate } = useDirectiveGuard(directiveName, {
+        hideAlert: true,
+    });
+
+    const mutateAuthRoles = useEntitiesStore_mutate();
+
+    const [serverError, setServerError] = useState<PostgrestError | null>(null);
+
+    const applyDirective = async (): Promise<void> => {
+        if (directive) {
+            const response = await submitDirective(
+                directiveName,
+                directive,
+                tenant
+            );
+
+            if (response.error) {
+                return setServerError(response.error as PostgrestError);
+            }
+
+            const data = response.data[0];
+
+            jobStatusPoller(
+                jobStatusQuery(data),
+                async () => {
+                    trackEvent(`${directiveName}:Complete`, directive);
+
+                    setServerError(null);
+
+                    void mutate().finally(() => {
+                        if (mutateAuthRoles) {
+                            mutateAuthRoles();
+                        }
+
+                        setOpen(false);
+                        goToFilteredTable();
+                    });
+                },
+                async (payload: any) => {
+                    trackEvent(`${directiveName}:Error`, directive);
+
+                    setServerError(payload.job_status.error);
+                }
+            );
+        }
+    };
+
+    return (
+        <>
+            {serverError ? (
+                <Box sx={{ mb: 3 }}>
+                    <Error
+                        error={serverError}
+                        condensed={true}
+                        hideTitle={true}
+                    />
+                </Box>
+            ) : null}
+
+            <MessageWithButton
+                messageId="home.hero.demo.demoTenant"
+                messageValues={{
+                    sharableTenant: <b>demo/</b>,
+                    userTenant: <b>{tenant}</b>,
+                }}
+                clickHandler={applyDirective}
+            />
+        </>
+    );
+}
+
+export default AcceptDemoInvitation;

--- a/src/components/hero/Demo.tsx
+++ b/src/components/hero/Demo.tsx
@@ -15,11 +15,13 @@ function HeroDemo() {
                 <DemoStep step={2} />
                 <DemoStep step={3} />
             </Grid>
+
             <Grid container>
                 <DemoButton step={1} type="captures" />
                 <DemoButton step={2} type="collections" />
                 <DemoButton step={3} type="materializations" />
             </Grid>
+
             <Grid
                 item
                 xs={12}

--- a/src/components/hero/DemoButton.tsx
+++ b/src/components/hero/DemoButton.tsx
@@ -1,12 +1,17 @@
 import { Box, Grid, Link } from '@mui/material';
 import { authenticatedRoutes } from 'app/routes';
+import DemoDialog from 'components/hero/DemoDialog';
 import { semiTransparentBackgroundIntensified } from 'context/Theme';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
+import {
+    useEntitiesStore_capabilities_adminable,
+    useEntitiesStore_capabilities_readable,
+} from 'stores/Entities/hooks';
 import { getPathWithParams } from 'utils/misc-utils';
 
-const FILTER_TABLE_PROPS = {
+export const FILTER_TABLE_PROPS = {
     captures: {
         'cap-sq': 'demo/wikipedia/recent-changes',
     },
@@ -25,6 +30,15 @@ interface Props {
 
 function DemoButton({ step, type }: Props) {
     const navigate = useNavigate();
+
+    const adminCapabilities = useEntitiesStore_capabilities_adminable();
+    const objectRoles = Object.keys(adminCapabilities);
+
+    const readCapabilities = useEntitiesStore_capabilities_readable();
+    const demoAccessExists = Object.keys(readCapabilities).includes('demo/');
+
+    const [open, setOpen] = useState(false);
+
     const goToFilteredTable = useCallback(() => {
         navigate(
             getPathWithParams(
@@ -34,32 +48,49 @@ function DemoButton({ step, type }: Props) {
         );
     }, [navigate, type]);
 
+    const evaluateObjectRoles = useCallback(
+        () => (demoAccessExists ? goToFilteredTable() : setOpen(true)),
+        [demoAccessExists, goToFilteredTable]
+    );
+
     return (
-        <Grid
-            item
-            xs={4}
-            sx={{
-                display: 'flex',
-                justifyContent: 'center',
-            }}
-        >
-            <Box
+        <>
+            <Grid
+                item
+                xs={4}
                 sx={{
-                    bgcolor: (theme) =>
-                        semiTransparentBackgroundIntensified[
-                            theme.palette.mode
-                        ],
-                    p: 2,
-                    textAlign: 'center',
-                    width: '75%',
-                    mt: 2,
+                    display: 'flex',
+                    justifyContent: 'center',
                 }}
             >
-                <Link onClick={goToFilteredTable} sx={{ cursor: 'pointer' }}>
-                    <FormattedMessage id={`home.hero.${step}.button`} />
-                </Link>
-            </Box>
-        </Grid>
+                <Box
+                    sx={{
+                        bgcolor: (theme) =>
+                            semiTransparentBackgroundIntensified[
+                                theme.palette.mode
+                            ],
+                        p: 2,
+                        textAlign: 'center',
+                        width: '75%',
+                        mt: 2,
+                    }}
+                >
+                    <Link
+                        onClick={evaluateObjectRoles}
+                        sx={{ cursor: 'pointer' }}
+                    >
+                        <FormattedMessage id={`home.hero.${step}.button`} />
+                    </Link>
+                </Box>
+            </Grid>
+
+            <DemoDialog
+                objectRoles={objectRoles}
+                open={open}
+                setOpen={setOpen}
+                goToFilteredTable={goToFilteredTable}
+            />
+        </>
     );
 }
 

--- a/src/components/hero/DemoDialog.tsx
+++ b/src/components/hero/DemoDialog.tsx
@@ -29,6 +29,10 @@ function DemoDialog({ objectRoles, open, setOpen, goToFilteredTable }: Props) {
             onClose={closeDialog}
         >
             <DialogContent sx={{ display: 'flex', alignItems: 'center' }}>
+                <Box sx={{ mr: 3 }}>
+                    <Logo width={50} />
+                </Box>
+
                 {objectRoles.length > 0 ? (
                     <AcceptDemoInvitation
                         tenant={objectRoles[0]}
@@ -40,10 +44,6 @@ function DemoDialog({ objectRoles, open, setOpen, goToFilteredTable }: Props) {
                         <FormattedMessage id="admin.users.prefixInvitation.header" />
                     </Typography>
                 )}
-
-                <Box sx={{ ml: 3 }}>
-                    <Logo width={50} />
-                </Box>
             </DialogContent>
         </Dialog>
     );

--- a/src/components/hero/DemoDialog.tsx
+++ b/src/components/hero/DemoDialog.tsx
@@ -1,0 +1,52 @@
+import { Box, Dialog, DialogContent, Typography } from '@mui/material';
+import AcceptDemoInvitation from 'components/hero/AcceptDemoInvitation';
+import Logo from 'components/navigation/Logo';
+import { Dispatch, SetStateAction } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+const TITLE_ID = 'accept-demo-tenant-dialog-title';
+
+interface Props {
+    objectRoles: string[];
+    open: boolean;
+    setOpen: Dispatch<SetStateAction<boolean>>;
+    goToFilteredTable: () => void;
+}
+
+function DemoDialog({ objectRoles, open, setOpen, goToFilteredTable }: Props) {
+    const closeDialog = (event: React.MouseEvent<HTMLElement>) => {
+        event.preventDefault();
+
+        setOpen(false);
+    };
+
+    return (
+        <Dialog
+            open={open}
+            maxWidth="md"
+            fullWidth
+            aria-labelledby={TITLE_ID}
+            onClose={closeDialog}
+        >
+            <DialogContent sx={{ display: 'flex', alignItems: 'center' }}>
+                {objectRoles.length > 0 ? (
+                    <AcceptDemoInvitation
+                        tenant={objectRoles[0]}
+                        setOpen={setOpen}
+                        goToFilteredTable={goToFilteredTable}
+                    />
+                ) : (
+                    <Typography>
+                        <FormattedMessage id="admin.users.prefixInvitation.header" />
+                    </Typography>
+                )}
+
+                <Box sx={{ ml: 3 }}>
+                    <Logo width={50} />
+                </Box>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default DemoDialog;

--- a/src/components/hero/DemoDialog.tsx
+++ b/src/components/hero/DemoDialog.tsx
@@ -1,7 +1,15 @@
-import { Box, Dialog, DialogContent, Typography } from '@mui/material';
+import {
+    Box,
+    Collapse,
+    Dialog,
+    DialogContent,
+    LinearProgress,
+    Stack,
+    Typography,
+} from '@mui/material';
 import AcceptDemoInvitation from 'components/hero/AcceptDemoInvitation';
 import Logo from 'components/navigation/Logo';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 const TITLE_ID = 'accept-demo-tenant-dialog-title';
@@ -14,6 +22,8 @@ interface Props {
 }
 
 function DemoDialog({ objectRoles, open, setOpen, goToFilteredTable }: Props) {
+    const [loading, setLoading] = useState(false);
+
     const closeDialog = (event: React.MouseEvent<HTMLElement>) => {
         event.preventDefault();
 
@@ -28,22 +38,34 @@ function DemoDialog({ objectRoles, open, setOpen, goToFilteredTable }: Props) {
             aria-labelledby={TITLE_ID}
             onClose={closeDialog}
         >
-            <DialogContent sx={{ display: 'flex', alignItems: 'center' }}>
-                <Box sx={{ mr: 3 }}>
-                    <Logo width={50} />
-                </Box>
+            <DialogContent
+                sx={{ p: 0, display: 'flex', flexDirection: 'column' }}
+            >
+                <Collapse in={loading}>
+                    <LinearProgress sx={{ flexGrow: 1 }} />
+                </Collapse>
 
-                {objectRoles.length > 0 ? (
-                    <AcceptDemoInvitation
-                        tenant={objectRoles[0]}
-                        setOpen={setOpen}
-                        goToFilteredTable={goToFilteredTable}
-                    />
-                ) : (
-                    <Typography>
-                        <FormattedMessage id="admin.users.prefixInvitation.header" />
-                    </Typography>
-                )}
+                <Stack
+                    direction="row"
+                    sx={{ px: 3, py: 2, alignItems: 'center' }}
+                >
+                    <Box sx={{ mr: 3 }}>
+                        <Logo width={50} />
+                    </Box>
+
+                    {objectRoles.length > 0 ? (
+                        <AcceptDemoInvitation
+                            tenant={objectRoles[0]}
+                            setOpen={setOpen}
+                            setLoading={setLoading}
+                            goToFilteredTable={goToFilteredTable}
+                        />
+                    ) : (
+                        <Typography>
+                            <FormattedMessage id="admin.users.prefixInvitation.header" />
+                        </Typography>
+                    )}
+                </Stack>
             </DialogContent>
         </Dialog>
     );

--- a/src/components/hero/DemoDialog.tsx
+++ b/src/components/hero/DemoDialog.tsx
@@ -56,8 +56,9 @@ function DemoDialog({ objectRoles, open, setOpen, goToFilteredTable }: Props) {
                     {objectRoles.length > 0 ? (
                         <AcceptDemoInvitation
                             tenant={objectRoles[0]}
-                            setOpen={setOpen}
+                            loading={loading}
                             setLoading={setLoading}
+                            setOpen={setOpen}
                             goToFilteredTable={goToFilteredTable}
                         />
                     ) : (

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -1,5 +1,16 @@
 import { Box, Grid } from '@mui/material';
+import { PostgrestError } from '@supabase/postgrest-js';
+import { submitDirective } from 'api/directives';
+import useDirectiveGuard from 'app/guards/hooks';
+import MessageWithButton from 'components/content/MessageWithButton';
 import HeroTabs from 'components/hero/Tabs';
+import AlertBox from 'components/shared/AlertBox';
+import { jobStatusQuery, trackEvent } from 'directives/shared';
+import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { jobStatusPoller } from 'services/supabase';
+import { useEntitiesStore_capabilities_adminable } from 'stores/Entities/hooks';
+import { hasLength } from 'utils/misc-utils';
 import HeroDemo from './Demo';
 import HeroDetail from './Detail';
 import { useHeroTabs } from './hooks';
@@ -7,8 +18,53 @@ import DemoImage from './Images/Demo';
 import WelcomeImage from './Images/Welcome';
 import HeroOverview from './Overview';
 
+const directiveName = 'acceptDemoTenant';
+
 function HeroImageAndDescription() {
     const { activeTab } = useHeroTabs();
+
+    const { directive, status, mutate } = useDirectiveGuard(directiveName, {
+        hideAlert: true,
+    });
+
+    const adminCapabilities = useEntitiesStore_capabilities_adminable();
+    const objectRoles = Object.keys(adminCapabilities);
+
+    const [serverError, setServerError] = useState<string | null>(null);
+
+    const applyDirective = async (): Promise<void> => {
+        if (directive) {
+            const response = await submitDirective(
+                directiveName,
+                directive,
+                objectRoles[0]
+            );
+
+            if (response.error) {
+                return setServerError(
+                    (response.error as PostgrestError).message
+                );
+            }
+
+            const data = response.data[0];
+
+            jobStatusPoller(
+                jobStatusQuery(data),
+                async () => {
+                    trackEvent(`${directiveName}:Complete`, directive);
+
+                    setServerError(null);
+
+                    void mutate();
+                },
+                async (payload: any) => {
+                    trackEvent(`${directiveName}:Error`, directive);
+
+                    setServerError(payload.job_status.error);
+                }
+            );
+        }
+    };
 
     return (
         <Box sx={{ mx: 'auto', pb: 3, maxWidth: 1000 }}>
@@ -23,6 +79,39 @@ function HeroImageAndDescription() {
                 >
                     <HeroTabs />
                 </Grid>
+
+                {activeTab === 'demo' &&
+                hasLength(objectRoles) &&
+                status !== null &&
+                status !== 'fulfilled' ? (
+                    <>
+                        {serverError ? (
+                            <Grid item xs={12}>
+                                <AlertBox short severity="error">
+                                    <MessageWithButton
+                                        messageId="home.hero.demo.alert.demoTenant"
+                                        clickHandler={applyDirective}
+                                    />
+                                </AlertBox>
+                            </Grid>
+                        ) : null}
+
+                        <Grid item xs={12} sx={{ pb: 2 }}>
+                            <AlertBox
+                                short
+                                severity="info"
+                                title={
+                                    <FormattedMessage id="home.hero.demo.alert.demoTenant.header" />
+                                }
+                            >
+                                <MessageWithButton
+                                    messageId="home.hero.demo.alert.demoTenant"
+                                    clickHandler={applyDirective}
+                                />
+                            </AlertBox>
+                        </Grid>
+                    </>
+                ) : null}
 
                 <Grid
                     item

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -1,16 +1,5 @@
 import { Box, Grid } from '@mui/material';
-import { PostgrestError } from '@supabase/postgrest-js';
-import { submitDirective } from 'api/directives';
-import useDirectiveGuard from 'app/guards/hooks';
-import MessageWithButton from 'components/content/MessageWithButton';
 import HeroTabs from 'components/hero/Tabs';
-import AlertBox from 'components/shared/AlertBox';
-import { jobStatusQuery, trackEvent } from 'directives/shared';
-import { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
-import { jobStatusPoller } from 'services/supabase';
-import { useEntitiesStore_capabilities_adminable } from 'stores/Entities/hooks';
-import { hasLength } from 'utils/misc-utils';
 import HeroDemo from './Demo';
 import HeroDetail from './Detail';
 import { useHeroTabs } from './hooks';
@@ -18,53 +7,8 @@ import DemoImage from './Images/Demo';
 import WelcomeImage from './Images/Welcome';
 import HeroOverview from './Overview';
 
-const directiveName = 'acceptDemoTenant';
-
 function HeroImageAndDescription() {
     const { activeTab } = useHeroTabs();
-
-    const { directive, status, mutate } = useDirectiveGuard(directiveName, {
-        hideAlert: true,
-    });
-
-    const adminCapabilities = useEntitiesStore_capabilities_adminable();
-    const objectRoles = Object.keys(adminCapabilities);
-
-    const [serverError, setServerError] = useState<string | null>(null);
-
-    const applyDirective = async (): Promise<void> => {
-        if (directive) {
-            const response = await submitDirective(
-                directiveName,
-                directive,
-                objectRoles[0]
-            );
-
-            if (response.error) {
-                return setServerError(
-                    (response.error as PostgrestError).message
-                );
-            }
-
-            const data = response.data[0];
-
-            jobStatusPoller(
-                jobStatusQuery(data),
-                async () => {
-                    trackEvent(`${directiveName}:Complete`, directive);
-
-                    setServerError(null);
-
-                    void mutate();
-                },
-                async (payload: any) => {
-                    trackEvent(`${directiveName}:Error`, directive);
-
-                    setServerError(payload.job_status.error);
-                }
-            );
-        }
-    };
 
     return (
         <Box sx={{ mx: 'auto', pb: 3, maxWidth: 1000 }}>
@@ -79,39 +23,6 @@ function HeroImageAndDescription() {
                 >
                     <HeroTabs />
                 </Grid>
-
-                {activeTab === 'demo' &&
-                hasLength(objectRoles) &&
-                status !== null &&
-                status !== 'fulfilled' ? (
-                    <>
-                        {serverError ? (
-                            <Grid item xs={12}>
-                                <AlertBox short severity="error">
-                                    <MessageWithButton
-                                        messageId="home.hero.demo.alert.demoTenant"
-                                        clickHandler={applyDirective}
-                                    />
-                                </AlertBox>
-                            </Grid>
-                        ) : null}
-
-                        <Grid item xs={12} sx={{ pb: 2 }}>
-                            <AlertBox
-                                short
-                                severity="info"
-                                title={
-                                    <FormattedMessage id="home.hero.demo.alert.demoTenant.header" />
-                                }
-                            >
-                                <MessageWithButton
-                                    messageId="home.hero.demo.alert.demoTenant"
-                                    clickHandler={applyDirective}
-                                />
-                            </AlertBox>
-                        </Grid>
-                    </>
-                ) : null}
 
                 <Grid
                     item

--- a/src/components/navigation/Logo.tsx
+++ b/src/components/navigation/Logo.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
-import darkLogo from 'images/pictorial-marks/pictorial-mark__slate.png';
+import darkLogo from 'images/pictorial-marks/pictorial-mark__multi-blue.png';
 import lightLogo from 'images/pictorial-marks/pictorial-mark__white.png';
 import { useIntl } from 'react-intl';
 

--- a/src/components/shared/toolbar/SelectTextField.tsx
+++ b/src/components/shared/toolbar/SelectTextField.tsx
@@ -1,0 +1,70 @@
+import {
+    InputAdornment,
+    MenuItem,
+    Select,
+    SelectChangeEvent,
+    TextField,
+} from '@mui/material';
+import { ChangeEventHandler } from 'react';
+
+interface Props {
+    label: string;
+    defaultSelectValue: string;
+    selectValues: string[];
+    selectChangeHandler: (event: SelectChangeEvent<string>) => void;
+    textChangeHandler: ChangeEventHandler<
+        HTMLInputElement | HTMLTextAreaElement
+    >;
+    errorExists?: boolean;
+}
+
+function SelectTextField({
+    label,
+    defaultSelectValue,
+    selectValues,
+    selectChangeHandler,
+    textChangeHandler,
+    errorExists,
+}: Props) {
+    return (
+        <TextField
+            InputProps={{
+                startAdornment: (
+                    <InputAdornment position="start">
+                        {selectValues.length === 1 ? (
+                            selectValues[0]
+                        ) : (
+                            <Select
+                                size="small"
+                                variant="standard"
+                                value={defaultSelectValue}
+                                disableUnderline
+                                onChange={selectChangeHandler}
+                                sx={{
+                                    '& .MuiSelect-select': {
+                                        paddingBottom: 0.2,
+                                    },
+                                }}
+                            >
+                                {selectValues.map((value) => (
+                                    <MenuItem key={value} value={value}>
+                                        {value}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        )}
+                    </InputAdornment>
+                ),
+                sx: { borderRadius: 3 },
+            }}
+            label={label}
+            variant="outlined"
+            size="small"
+            error={errorExists}
+            onChange={textChangeHandler}
+            sx={{ flexGrow: 1 }}
+        />
+    );
+}
+
+export default SelectTextField;

--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/Button.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/Button.tsx
@@ -1,5 +1,5 @@
 import { Box, Button } from '@mui/material';
-import SharePrefixDialog from 'components/tables/AccessGrants/AccessLinks/Dialog';
+import PrefixInvitationDialog from 'components/tables/AccessGrants/AccessLinks/Dialog';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useEntitiesStore_capabilities_adminable } from 'stores/Entities/hooks';
@@ -21,10 +21,10 @@ function AccessLinksButton() {
                 }}
                 sx={{ whiteSpace: 'nowrap' }}
             >
-                <FormattedMessage id="admin.users.cta.sharePrefix" />
+                <FormattedMessage id="admin.users.cta.prefixInvitation" />
             </Button>
 
-            <SharePrefixDialog
+            <PrefixInvitationDialog
                 objectRoles={objectRoles}
                 open={open}
                 setOpen={setOpen}

--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
@@ -107,7 +107,7 @@ function GenerateInvitation({
             <Grid item xs={4} md={2}>
                 <AutocompletedField
                     label={intl.formatMessage({
-                        id: 'admin.users.sharePrefix.label.capability',
+                        id: 'admin.users.prefixInvitation.label.capability',
                     })}
                     options={capabilityOptions}
                     defaultValue={capabilityOptions[0]}
@@ -118,7 +118,7 @@ function GenerateInvitation({
             <Grid item xs={4} md={2}>
                 <AutocompletedField
                     label={intl.formatMessage({
-                        id: 'admin.users.sharePrefix.label.type',
+                        id: 'admin.users.prefixInvitation.label.type',
                     })}
                     options={typeOptions}
                     defaultValue={typeOptions[0]}
@@ -131,7 +131,7 @@ function GenerateInvitation({
                     onClick={handlers.generateInvitation}
                     sx={{ flexGrow: 1 }}
                 >
-                    <FormattedMessage id="admin.users.sharePrefix.cta.generateLink" />
+                    <FormattedMessage id="admin.users.prefixInvitation.cta.generateLink" />
                 </Button>
             </Grid>
         </Grid>

--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
@@ -11,7 +11,7 @@ import {
     SelectableTableStore,
     selectableTableStoreSelectors,
 } from 'stores/Tables/Store';
-import { hasLength } from 'utils/misc-utils';
+import { hasLength, PREFIX_NAME_PATTERN } from 'utils/misc-utils';
 
 interface Props {
     objectRoles: string[];
@@ -19,7 +19,7 @@ interface Props {
     setServerError: React.Dispatch<React.SetStateAction<PostgrestError | null>>;
 }
 
-const namePattern = new RegExp(`^[a-zA-Z0-9-_./]+$`);
+const namePattern = new RegExp(`^${PREFIX_NAME_PATTERN}[/]$`);
 
 // The write capability should be obscured to the user. It is more challenging
 // for a user to understand the nuances of this grant and likely will not be used
@@ -76,9 +76,11 @@ function GenerateInvitation({
 
             const value = event.target.value.replaceAll(/\s/g, '_');
 
-            setSuffixInvalid(hasLength(value) && !namePattern.test(value));
-
             const processedValue = value.endsWith('/') ? value : `${value}/`;
+
+            setSuffixInvalid(
+                hasLength(processedValue) && !namePattern.test(processedValue)
+            );
 
             setSuffix(processedValue);
         },
@@ -125,7 +127,7 @@ function GenerateInvitation({
             <Grid item xs={12} md={5} sx={{ display: 'flex' }}>
                 <SelectTextField
                     label={intl.formatMessage({
-                        id: 'admin.users.prefixInvitation.label.prefix',
+                        id: 'common.tenant',
                     })}
                     defaultSelectValue={prefix}
                     selectValues={objectRoles}

--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
@@ -11,7 +11,11 @@ import {
     SelectableTableStore,
     selectableTableStoreSelectors,
 } from 'stores/Tables/Store';
-import { hasLength, PREFIX_NAME_PATTERN } from 'utils/misc-utils';
+import {
+    appendWithForwardSlash,
+    hasLength,
+    PREFIX_NAME_PATTERN,
+} from 'utils/misc-utils';
 
 interface Props {
     objectRoles: string[];
@@ -63,7 +67,7 @@ function GenerateInvitation({
 
             setPrefixMissing(!hasLength(value));
 
-            const processedValue = value.endsWith('/') ? value : `${value}/`;
+            const processedValue = appendWithForwardSlash(value);
 
             setPrefix(processedValue);
         },
@@ -76,7 +80,7 @@ function GenerateInvitation({
 
             const value = event.target.value.replaceAll(/\s/g, '_');
 
-            const processedValue = value.endsWith('/') ? value : `${value}/`;
+            const processedValue = appendWithForwardSlash(value);
 
             setSuffixInvalid(
                 hasLength(processedValue) && !namePattern.test(processedValue)

--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/GenerateInvitation.tsx
@@ -1,15 +1,8 @@
-import {
-    Button,
-    Grid,
-    InputAdornment,
-    MenuItem,
-    Select,
-    SelectChangeEvent,
-    TextField,
-} from '@mui/material';
+import { Button, Grid, SelectChangeEvent } from '@mui/material';
 import { PostgrestError } from '@supabase/postgrest-js';
 import { generateGrantDirective } from 'api/directives';
 import AutocompletedField from 'components/shared/toolbar/AutocompletedField';
+import SelectTextField from 'components/shared/toolbar/SelectTextField';
 import { useZustandStore } from 'context/Zustand/provider';
 import { ChangeEvent, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -130,44 +123,15 @@ function GenerateInvitation({
     return (
         <Grid container spacing={2} sx={{ mb: 5, pt: 1 }}>
             <Grid item xs={12} md={5} sx={{ display: 'flex' }}>
-                <TextField
-                    InputProps={{
-                        startAdornment: (
-                            <InputAdornment position="start">
-                                {objectRoles.length === 1 ? (
-                                    objectRoles[0]
-                                ) : (
-                                    <Select
-                                        size="small"
-                                        variant="standard"
-                                        value={prefix}
-                                        disableUnderline
-                                        onChange={handlers.setGrantPrefix}
-                                        sx={{
-                                            '& .MuiSelect-select': {
-                                                paddingBottom: 0.2,
-                                            },
-                                        }}
-                                    >
-                                        {objectRoles.map((role) => (
-                                            <MenuItem key={role} value={role}>
-                                                {role}
-                                            </MenuItem>
-                                        ))}
-                                    </Select>
-                                )}
-                            </InputAdornment>
-                        ),
-                        sx: { borderRadius: 3 },
-                    }}
+                <SelectTextField
                     label={intl.formatMessage({
-                        id: 'admin.prefix.issueGrant.label.sharedPrefix',
+                        id: 'admin.users.prefixInvitation.label.prefix',
                     })}
-                    variant="outlined"
-                    size="small"
-                    error={prefixMissing || suffixInvalid}
-                    onChange={handlers.setGrantSuffix}
-                    sx={{ flexGrow: 1 }}
+                    defaultSelectValue={prefix}
+                    selectValues={objectRoles}
+                    selectChangeHandler={handlers.setGrantPrefix}
+                    textChangeHandler={handlers.setGrantSuffix}
+                    errorExists={prefixMissing || suffixInvalid}
                 />
             </Grid>
 

--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/index.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/index.tsx
@@ -23,7 +23,7 @@ interface Props {
     setOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-function SharePrefixDialog({ objectRoles, open, setOpen }: Props) {
+function PrefixInvitationDialog({ objectRoles, open, setOpen }: Props) {
     const theme = useTheme();
 
     const [serverError, setServerError] = useState<PostgrestError | null>(null);
@@ -52,7 +52,7 @@ function SharePrefixDialog({ objectRoles, open, setOpen }: Props) {
                 }}
             >
                 <Typography variant="h6">
-                    <FormattedMessage id="admin.users.sharePrefix.header" />
+                    <FormattedMessage id="admin.users.prefixInvitation.header" />
                 </Typography>
 
                 <IconButton onClick={closeDialog}>
@@ -67,7 +67,7 @@ function SharePrefixDialog({ objectRoles, open, setOpen }: Props) {
 
             <DialogContent>
                 {/* <Typography sx={{ mb: 3 }}>
-                    <FormattedMessage id="admin.users.sharePrefix.message" />
+                    <FormattedMessage id="admin.users.prefixInvitation.message" />
                 </Typography> */}
 
                 {serverError ? (
@@ -92,4 +92,4 @@ function SharePrefixDialog({ objectRoles, open, setOpen }: Props) {
     );
 }
 
-export default SharePrefixDialog;
+export default PrefixInvitationDialog;

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/Button.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/Button.tsx
@@ -1,0 +1,36 @@
+import { Box, Button } from '@mui/material';
+import ShareDataDialog from 'components/tables/AccessGrants/DataSharing/Dialog';
+import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useEntitiesStore_capabilities_adminable } from 'stores/Entities/hooks';
+
+function DataShareButton() {
+    const [open, setOpen] = useState<boolean>(false);
+
+    const adminCapabilities = useEntitiesStore_capabilities_adminable();
+    const objectRoles = Object.keys(adminCapabilities);
+
+    return objectRoles.length > 0 ? (
+        <Box>
+            <Button
+                variant="outlined"
+                onClick={(event) => {
+                    event.preventDefault();
+
+                    setOpen(true);
+                }}
+                sx={{ whiteSpace: 'nowrap' }}
+            >
+                <FormattedMessage id="admin.prefix.cta.issueGrant" />
+            </Button>
+
+            <ShareDataDialog
+                objectRoles={objectRoles}
+                open={open}
+                setOpen={setOpen}
+            />
+        </Box>
+    ) : null;
+}
+
+export default DataShareButton;

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
@@ -165,7 +165,7 @@ function GenerateGrant({
 
     return (
         <Grid container spacing={2} sx={{ mb: 5, pt: 1 }}>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={4} sx={{ display: 'flex' }}>
                 <TextField
                     InputProps={{
                         startAdornment: (
@@ -208,6 +208,7 @@ function GenerateGrant({
                     size="small"
                     error={objectMissing || objectInvalid}
                     onChange={handlers.evaluateObjectRoleSuffix}
+                    sx={{ flexGrow: 1 }}
                 />
             </Grid>
 

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
@@ -25,6 +25,8 @@ interface Props {
     setServerError: React.Dispatch<React.SetStateAction<PostgrestError | null>>;
 }
 
+const namePattern = new RegExp(`^[a-zA-Z0-9-_./]+$`);
+
 // The write capability should be obscured to the user. It is more challenging
 // for a user to understand the nuances of this grant and likely will not be used
 // outside of advanced cases.
@@ -42,6 +44,12 @@ function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
         selectableTableStoreSelectors.query.hydrate
     );
 
+    const [objectMissing, setObjectMissing] = useState(false);
+    const [objectInvalid, setObjectInvalid] = useState(false);
+
+    const [subjectMissing, setSubjectMissing] = useState(false);
+    const [subjectInvalid, setSubjectInvalid] = useState(false);
+
     const [objectRole, setObjectRole] = useState<string>('');
     const [subjectRole, setSubjectRole] = useState<string>('');
     const [capability, setCapability] = useState<Capability>(
@@ -53,6 +61,9 @@ function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
             if (serverError) {
                 setServerError(null);
             }
+
+            setObjectMissing(!hasLength(value));
+            setObjectInvalid(!namePattern.test(value));
 
             const processedValue = value.endsWith('/') ? value : `${value}/`;
 
@@ -66,6 +77,10 @@ function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
             }
 
             const value = event.target.value;
+
+            setSubjectMissing(!hasLength(value));
+            setSubjectInvalid(!namePattern.test(value));
+
             const processedValue = value.endsWith('/') ? value : `${value}/`;
 
             setSubjectRole(processedValue);
@@ -117,6 +132,7 @@ function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
                             })}
                             variant="outlined"
                             size="small"
+                            error={objectMissing || objectInvalid}
                         />
                     )}
                     freeSolo
@@ -136,6 +152,7 @@ function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
                     InputProps={{
                         sx: { borderRadius: 3 },
                     }}
+                    error={subjectMissing || subjectInvalid}
                     onChange={handlers.evaluateSubjectRole}
                     sx={{ flexGrow: 1 }}
                 />
@@ -154,6 +171,12 @@ function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
 
             <Grid item xs={4} md={3} sx={{ display: 'flex' }}>
                 <Button
+                    disabled={
+                        objectMissing ||
+                        objectInvalid ||
+                        subjectMissing ||
+                        subjectInvalid
+                    }
                     onClick={handlers.generateRoleGrant}
                     sx={{ flexGrow: 1 }}
                 >

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
@@ -1,15 +1,8 @@
-import {
-    Button,
-    Grid,
-    InputAdornment,
-    MenuItem,
-    Select,
-    SelectChangeEvent,
-    TextField,
-} from '@mui/material';
+import { Button, Grid, SelectChangeEvent, TextField } from '@mui/material';
 import { PostgrestError } from '@supabase/postgrest-js';
 import { createRoleGrant } from 'api/roleGrants';
 import AutocompletedField from 'components/shared/toolbar/AutocompletedField';
+import SelectTextField from 'components/shared/toolbar/SelectTextField';
 import { useZustandStore } from 'context/Zustand/provider';
 import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -165,49 +158,15 @@ function GenerateGrant({
     return (
         <Grid container spacing={2} sx={{ mb: 5, pt: 1 }}>
             <Grid item xs={12} md={4} sx={{ display: 'flex' }}>
-                <TextField
-                    InputProps={{
-                        startAdornment: (
-                            <InputAdornment position="start">
-                                {objectRoles.length === 1 ? (
-                                    objectRoles[0]
-                                ) : (
-                                    <Select
-                                        size="small"
-                                        variant="standard"
-                                        value={objectPrefix}
-                                        disableUnderline
-                                        onChange={
-                                            handlers.evaluateObjectRolePrefix
-                                        }
-                                        sx={{
-                                            '& .MuiSelect-select': {
-                                                paddingBottom: 0.2,
-                                            },
-                                        }}
-                                    >
-                                        {objectRoles.map((prefix) => (
-                                            <MenuItem
-                                                key={prefix}
-                                                value={prefix}
-                                            >
-                                                {prefix}
-                                            </MenuItem>
-                                        ))}
-                                    </Select>
-                                )}
-                            </InputAdornment>
-                        ),
-                        sx: { borderRadius: 3 },
-                    }}
+                <SelectTextField
                     label={intl.formatMessage({
                         id: 'admin.prefix.issueGrant.label.sharedPrefix',
                     })}
-                    variant="outlined"
-                    size="small"
-                    error={objectMissing || objectInvalid}
-                    onChange={handlers.evaluateObjectRoleSuffix}
-                    sx={{ flexGrow: 1 }}
+                    defaultSelectValue={objectPrefix}
+                    selectValues={objectRoles}
+                    selectChangeHandler={handlers.evaluateObjectRolePrefix}
+                    textChangeHandler={handlers.evaluateObjectRoleSuffix}
+                    errorExists={objectMissing || objectInvalid}
                 />
             </Grid>
 

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
@@ -83,7 +83,6 @@ function GenerateGrant({
             const value = event.target.value;
 
             setObjectMissing(!hasLength(value));
-            setObjectInvalid(!namePattern.test(value));
 
             setObjectPrefix(value);
         },

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
@@ -1,0 +1,167 @@
+import {
+    Autocomplete,
+    AutocompleteRenderInputParams,
+    Button,
+    Grid,
+    TextField,
+} from '@mui/material';
+import { PostgrestError } from '@supabase/postgrest-js';
+import { createRoleGrant } from 'api/roleGrants';
+import AutocompletedField from 'components/shared/toolbar/AutocompletedField';
+import { useZustandStore } from 'context/Zustand/provider';
+import { ChangeEvent, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { SelectTableStoreNames } from 'stores/names';
+import {
+    SelectableTableStore,
+    selectableTableStoreSelectors,
+} from 'stores/Tables/Store';
+import { Capability } from 'types';
+import { hasLength } from 'utils/misc-utils';
+
+interface Props {
+    objectRoles: string[];
+    serverError: PostgrestError | null;
+    setServerError: React.Dispatch<React.SetStateAction<PostgrestError | null>>;
+}
+
+// The write capability should be obscured to the user. It is more challenging
+// for a user to understand the nuances of this grant and likely will not be used
+// outside of advanced cases.
+
+const capabilityOptions: Capability[] = ['read', 'admin'];
+
+function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
+    const intl = useIntl();
+
+    const hydrate = useZustandStore<
+        SelectableTableStore,
+        SelectableTableStore['hydrate']
+    >(
+        SelectTableStoreNames.ACCESS_GRANTS_PREFIXES,
+        selectableTableStoreSelectors.query.hydrate
+    );
+
+    const [objectRole, setObjectRole] = useState<string>('');
+    const [subjectRole, setSubjectRole] = useState<string>('');
+    const [capability, setCapability] = useState<Capability>(
+        capabilityOptions[0]
+    );
+
+    const handlers = {
+        evaluateObjectRole: (_event: React.SyntheticEvent, value: string) => {
+            if (serverError) {
+                setServerError(null);
+            }
+
+            const processedValue = value.endsWith('/') ? value : `${value}/`;
+
+            setObjectRole(processedValue);
+        },
+        evaluateSubjectRole: (
+            event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+        ) => {
+            if (serverError) {
+                setServerError(null);
+            }
+
+            const value = event.target.value;
+            const processedValue = value.endsWith('/') ? value : `${value}/`;
+
+            setSubjectRole(processedValue);
+        },
+        setGrantCapability: (_event: React.SyntheticEvent, value: string) => {
+            if (serverError) {
+                setServerError(null);
+            }
+
+            setCapability(value as Capability);
+        },
+        generateRoleGrant: (event: React.MouseEvent<HTMLElement>) => {
+            event.preventDefault();
+
+            createRoleGrant(subjectRole, objectRole, capability).then(
+                (response) => {
+                    if (response.error) {
+                        setServerError(response.error);
+                    } else if (hasLength(response.data)) {
+                        if (serverError) {
+                            setServerError(null);
+                        }
+
+                        hydrate();
+                    }
+                },
+                (error) => setServerError(error)
+            );
+        },
+    };
+
+    return (
+        <Grid container spacing={2} sx={{ mb: 5, pt: 1 }}>
+            <Grid item xs={12} md={4}>
+                <Autocomplete
+                    options={objectRoles}
+                    renderInput={({
+                        InputProps,
+                        ...params
+                    }: AutocompleteRenderInputParams) => (
+                        <TextField
+                            {...params}
+                            InputProps={{
+                                ...InputProps,
+                                sx: { borderRadius: 3 },
+                            }}
+                            label={intl.formatMessage({
+                                id: 'admin.prefix.issueGrant.label.sharedEntity',
+                            })}
+                            variant="outlined"
+                            size="small"
+                        />
+                    )}
+                    freeSolo
+                    disableClearable
+                    onInputChange={handlers.evaluateObjectRole}
+                />
+            </Grid>
+
+            <Grid item xs={4} md={3} sx={{ display: 'flex' }}>
+                <TextField
+                    variant="outlined"
+                    size="small"
+                    label={intl.formatMessage({
+                        id: 'admin.prefix.issueGrant.label.sharedWith',
+                    })}
+                    placeholder="acmeCo/"
+                    InputProps={{
+                        sx: { borderRadius: 3 },
+                    }}
+                    onChange={handlers.evaluateSubjectRole}
+                    sx={{ flexGrow: 1 }}
+                />
+            </Grid>
+
+            <Grid item xs={4} md={2}>
+                <AutocompletedField
+                    label={intl.formatMessage({
+                        id: 'admin.users.prefixInvitation.label.capability',
+                    })}
+                    options={capabilityOptions}
+                    defaultValue={capabilityOptions[0]}
+                    changeHandler={handlers.setGrantCapability}
+                />
+            </Grid>
+
+            <Grid item xs={4} md={3} sx={{ display: 'flex' }}>
+                <Button
+                    onClick={handlers.generateRoleGrant}
+                    sx={{ flexGrow: 1 }}
+                >
+                    <FormattedMessage id="admin.prefix.issueGrant.cta.generateGrant" />
+                </Button>
+            </Grid>
+        </Grid>
+    );
+}
+
+export default GenerateGrant;

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
@@ -21,7 +21,11 @@ import {
     selectableTableStoreSelectors,
 } from 'stores/Tables/Store';
 import { Capability } from 'types';
-import { hasLength, PREFIX_NAME_PATTERN } from 'utils/misc-utils';
+import {
+    appendWithForwardSlash,
+    hasLength,
+    PREFIX_NAME_PATTERN,
+} from 'utils/misc-utils';
 
 interface Props {
     objectRoles: string[];
@@ -94,8 +98,7 @@ function GenerateGrant({
 
             const value = event.target.value.replaceAll(/\s/g, '_');
 
-            const processedValue =
-                hasLength(value) && !value.endsWith('/') ? `${value}/` : value;
+            const processedValue = appendWithForwardSlash(value);
 
             setObjectInvalid(
                 hasLength(processedValue) && !namePattern.test(processedValue)
@@ -112,7 +115,7 @@ function GenerateGrant({
 
             const value = event.target.value.replaceAll(/\s/g, '_');
 
-            const processedValue = value.endsWith('/') ? value : `${value}/`;
+            const processedValue = appendWithForwardSlash(value);
 
             setSubjectMissing(!hasLength(processedValue));
             setSubjectInvalid(!namePattern.test(processedValue));

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant.tsx
@@ -128,7 +128,7 @@ function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
                                 sx: { borderRadius: 3 },
                             }}
                             label={intl.formatMessage({
-                                id: 'admin.prefix.issueGrant.label.sharedEntity',
+                                id: 'admin.prefix.issueGrant.label.sharedPrefix',
                             })}
                             variant="outlined"
                             size="small"
@@ -148,7 +148,6 @@ function GenerateGrant({ objectRoles, serverError, setServerError }: Props) {
                     label={intl.formatMessage({
                         id: 'admin.prefix.issueGrant.label.sharedWith',
                     })}
-                    placeholder="acmeCo/"
                     InputProps={{
                         sx: { borderRadius: 3 },
                     }}

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
@@ -8,6 +8,7 @@ import {
     useTheme,
 } from '@mui/material';
 import { PostgrestError } from '@supabase/postgrest-js';
+import AlertBox from 'components/shared/AlertBox';
 import Error from 'components/shared/Error';
 import GenerateGrant from 'components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant';
 import { Cancel } from 'iconoir-react';
@@ -71,11 +72,19 @@ function ShareDataDialog({ objectRoles, open, setOpen }: Props) {
 
                 {serverError ? (
                     <Box sx={{ mb: 3 }}>
-                        <Error
-                            error={serverError}
-                            condensed={true}
-                            hideTitle={true}
-                        />
+                        {serverError.code === '42501' ? (
+                            <AlertBox severity="error" short>
+                                <Typography>
+                                    <FormattedMessage id="admin.prefix.issueGrant.error.invalidPrefix" />
+                                </Typography>
+                            </AlertBox>
+                        ) : (
+                            <Error
+                                error={serverError}
+                                condensed={true}
+                                hideTitle={true}
+                            />
+                        )}
                     </Box>
                 ) : null}
 

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
@@ -92,6 +92,7 @@ function ShareDataDialog({ objectRoles, open, setOpen }: Props) {
                     objectRoles={objectRoles}
                     serverError={serverError}
                     setServerError={setServerError}
+                    setOpen={setOpen}
                 />
             </DialogContent>
         </Dialog>

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
@@ -1,0 +1,92 @@
+import {
+    Box,
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    Typography,
+    useTheme,
+} from '@mui/material';
+import { PostgrestError } from '@supabase/postgrest-js';
+import Error from 'components/shared/Error';
+import GenerateGrant from 'components/tables/AccessGrants/DataSharing/Dialog/GenerateGrant';
+import { Cancel } from 'iconoir-react';
+import { Dispatch, SetStateAction, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+const TITLE_ID = 'share-data-dialog-title';
+
+interface Props {
+    objectRoles: string[];
+    open: boolean;
+    setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+function ShareDataDialog({ objectRoles, open, setOpen }: Props) {
+    const theme = useTheme();
+
+    const [serverError, setServerError] = useState<PostgrestError | null>(null);
+
+    const closeDialog = (event: React.MouseEvent<HTMLElement>) => {
+        event.preventDefault();
+
+        setServerError(null);
+        setOpen(false);
+    };
+
+    return (
+        <Dialog
+            open={open}
+            maxWidth="md"
+            fullWidth
+            aria-labelledby={TITLE_ID}
+            onClose={closeDialog}
+        >
+            <DialogTitle
+                component="div"
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                }}
+            >
+                <Typography variant="h6">
+                    <FormattedMessage id="admin.prefix.issueGrant.header" />
+                </Typography>
+
+                <IconButton onClick={closeDialog}>
+                    <Cancel
+                        style={{
+                            fontSize: '1rem',
+                            color: theme.palette.text.primary,
+                        }}
+                    />
+                </IconButton>
+            </DialogTitle>
+
+            <DialogContent>
+                {/* <Typography sx={{ mb: 3 }}>
+                    <FormattedMessage id="admin.prefix.issueGrant.message" />
+                </Typography> */}
+
+                {serverError ? (
+                    <Box sx={{ mb: 3 }}>
+                        <Error
+                            error={serverError}
+                            condensed={true}
+                            hideTitle={true}
+                        />
+                    </Box>
+                ) : null}
+
+                <GenerateGrant
+                    objectRoles={objectRoles}
+                    serverError={serverError}
+                    setServerError={setServerError}
+                />
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default ShareDataDialog;

--- a/src/components/tables/AccessGrants/PrefixRows.tsx
+++ b/src/components/tables/AccessGrants/PrefixRows.tsx
@@ -1,0 +1,59 @@
+import { TableCell, TableRow } from '@mui/material';
+import TimeStamp from 'components/tables/cells/TimeStamp';
+
+interface RowProps {
+    row: any;
+}
+
+interface RowsProps {
+    data: any[];
+}
+
+export const prefixTableColumns = [
+    {
+        field: 'object_role',
+        headerIntlKey: 'entityTable.data.sharedEntity',
+    },
+    {
+        field: 'subject_role',
+        headerIntlKey: 'entityTable.data.sharedWith',
+    },
+    {
+        field: 'capability',
+        headerIntlKey: 'entityTable.data.capability',
+    },
+    {
+        field: 'updated_at',
+        headerIntlKey: 'entityTable.data.lastUpdated',
+    },
+];
+
+function Row({ row }: RowProps) {
+    return (
+        <TableRow key={`Entity-${row.id}`}>
+            <TableCell>{row.object_role}</TableCell>
+
+            {row.subject_role ? (
+                <TableCell>{row.subject_role}</TableCell>
+            ) : (
+                <TableCell> </TableCell>
+            )}
+
+            <TableCell>{row.capability}</TableCell>
+
+            <TimeStamp time={row.updated_at} enableRelative />
+        </TableRow>
+    );
+}
+
+function PrefixRows({ data }: RowsProps) {
+    return (
+        <>
+            {data.map((row) => {
+                return <Row row={row} key={row.id} />;
+            })}
+        </>
+    );
+}
+
+export default PrefixRows;

--- a/src/components/tables/AccessGrants/PrefixRows.tsx
+++ b/src/components/tables/AccessGrants/PrefixRows.tsx
@@ -12,7 +12,7 @@ interface RowsProps {
 export const prefixTableColumns = [
     {
         field: 'object_role',
-        headerIntlKey: 'entityTable.data.sharedEntity',
+        headerIntlKey: 'entityTable.data.sharedPrefix',
     },
     {
         field: 'subject_role',

--- a/src/components/tables/AccessGrants/Rows.tsx
+++ b/src/components/tables/AccessGrants/Rows.tsx
@@ -11,7 +11,11 @@ interface RowsProps {
     showUser?: boolean;
 }
 
-const commonTableColumns = [
+export const userTableColumns = [
+    {
+        field: 'user_full_name',
+        headerIntlKey: 'entityTable.data.userFullName',
+    },
     {
         field: 'capability',
         headerIntlKey: 'entityTable.data.capability',
@@ -26,19 +30,24 @@ const commonTableColumns = [
     },
 ];
 
-export const userTableColumns = [
-    {
-        field: 'user_full_name',
-        headerIntlKey: 'entityTable.data.userFullName',
-    },
-].concat(commonTableColumns);
-
 export const prefixTableColumns = [
     {
         field: 'subject_role',
-        headerIntlKey: 'entityTable.data.catalogPrefix',
+        headerIntlKey: 'entityTable.data.sharedEntity',
     },
-].concat(commonTableColumns);
+    {
+        field: 'capability',
+        headerIntlKey: 'entityTable.data.capability',
+    },
+    {
+        field: 'object_role',
+        headerIntlKey: 'entityTable.data.sharedWith',
+    },
+    {
+        field: 'updated_at',
+        headerIntlKey: 'entityTable.data.lastUpdated',
+    },
+];
 
 function Row({ row }: RowProps) {
     return (

--- a/src/components/tables/AccessGrants/UserRows.tsx
+++ b/src/components/tables/AccessGrants/UserRows.tsx
@@ -8,7 +8,6 @@ interface RowProps {
 
 interface RowsProps {
     data: any[];
-    showUser?: boolean;
 }
 
 export const userTableColumns = [
@@ -23,25 +22,6 @@ export const userTableColumns = [
     {
         field: 'object_role',
         headerIntlKey: 'entityTable.data.objectRole',
-    },
-    {
-        field: 'updated_at',
-        headerIntlKey: 'entityTable.data.lastUpdated',
-    },
-];
-
-export const prefixTableColumns = [
-    {
-        field: 'subject_role',
-        headerIntlKey: 'entityTable.data.sharedEntity',
-    },
-    {
-        field: 'capability',
-        headerIntlKey: 'entityTable.data.capability',
-    },
-    {
-        field: 'object_role',
-        headerIntlKey: 'entityTable.data.sharedWith',
     },
     {
         field: 'updated_at',
@@ -75,25 +55,16 @@ function Row({ row }: RowProps) {
     );
 }
 
-function Rows({ data, showUser }: RowsProps) {
+function UserRows({ data }: RowsProps) {
     return (
         <>
             {data.map((row) => {
                 const isUser = row.user_full_name || row.user_email;
-                if (showUser) {
-                    if (isUser) {
-                        return <Row row={row} key={row.id} />;
-                    } else {
-                        return null;
-                    }
-                } else if (isUser) {
-                    return null;
-                } else {
-                    return <Row row={row} key={row.id} />;
-                }
+
+                return isUser ? <Row row={row} key={row.id} /> : null;
             })}
         </>
     );
 }
 
-export default Rows;
+export default UserRows;

--- a/src/components/tables/AccessGrants/index.tsx
+++ b/src/components/tables/AccessGrants/index.tsx
@@ -1,11 +1,13 @@
-import { Box } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { getGrants, getGrants_Users } from 'api/combinedGrantsExt';
+import AccessLinksButton from 'components/tables/AccessGrants/AccessLinks/Dialog/Button';
 import Rows, {
     prefixTableColumns,
     userTableColumns,
 } from 'components/tables/AccessGrants/Rows';
 import EntityTable from 'components/tables/EntityTable';
 import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { SelectTableStoreNames } from 'stores/names';
 import useTableState, { TablePrefix } from 'stores/Tables/hooks';
 import TableHydrator from 'stores/Tables/Hydrator';
@@ -89,6 +91,16 @@ function AccessGrantsTable({ tablePrefix, showUser }: Props) {
                         showUser
                             ? SelectTableStoreNames.ACCESS_GRANTS_USERS
                             : SelectTableStoreNames.ACCESS_GRANTS_PREFIXES
+                    }
+                    showToolbar
+                    toolbar={
+                        showUser ? (
+                            <AccessLinksButton />
+                        ) : (
+                            <Button variant="outlined">
+                                <FormattedMessage id="admin.prefix.cta.issueGrant" />
+                            </Button>
+                        )
                     }
                 />
             </TableHydrator>

--- a/src/components/tables/AccessGrants/index.tsx
+++ b/src/components/tables/AccessGrants/index.tsx
@@ -2,10 +2,12 @@ import { Box } from '@mui/material';
 import { getGrants, getGrants_Users } from 'api/combinedGrantsExt';
 import AccessLinksButton from 'components/tables/AccessGrants/AccessLinks/Dialog/Button';
 import DataShareButton from 'components/tables/AccessGrants/DataSharing/Dialog/Button';
-import Rows, {
+import PrefixRows, {
     prefixTableColumns,
+} from 'components/tables/AccessGrants/PrefixRows';
+import UserRows, {
     userTableColumns,
-} from 'components/tables/AccessGrants/Rows';
+} from 'components/tables/AccessGrants/UserRows';
 import EntityTable from 'components/tables/EntityTable';
 import { useMemo } from 'react';
 import { SelectTableStoreNames } from 'stores/names';
@@ -27,10 +29,7 @@ function AccessGrantsTable({ tablePrefix, showUser }: Props) {
         setSortDirection,
         columnToSort,
         setColumnToSort,
-    } = useTableState(
-        tablePrefix,
-        showUser ? 'user_full_name' : 'subject_role'
-    );
+    } = useTableState(tablePrefix, showUser ? 'user_full_name' : 'object_role');
 
     const query = useMemo(() => {
         if (showUser) {
@@ -74,9 +73,13 @@ function AccessGrantsTable({ tablePrefix, showUser }: Props) {
                         disableDoclink: true,
                     }}
                     columns={showUser ? userTableColumns : prefixTableColumns}
-                    renderTableRows={(data) => (
-                        <Rows data={data} showUser={showUser} />
-                    )}
+                    renderTableRows={(data) =>
+                        showUser ? (
+                            <UserRows data={data} />
+                        ) : (
+                            <PrefixRows data={data} />
+                        )
+                    }
                     pagination={pagination}
                     setPagination={setPagination}
                     searchQuery={searchQuery}

--- a/src/components/tables/AccessGrants/index.tsx
+++ b/src/components/tables/AccessGrants/index.tsx
@@ -1,13 +1,13 @@
-import { Box, Button } from '@mui/material';
+import { Box } from '@mui/material';
 import { getGrants, getGrants_Users } from 'api/combinedGrantsExt';
 import AccessLinksButton from 'components/tables/AccessGrants/AccessLinks/Dialog/Button';
+import DataShareButton from 'components/tables/AccessGrants/DataSharing/Dialog/Button';
 import Rows, {
     prefixTableColumns,
     userTableColumns,
 } from 'components/tables/AccessGrants/Rows';
 import EntityTable from 'components/tables/EntityTable';
 import { useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { SelectTableStoreNames } from 'stores/names';
 import useTableState, { TablePrefix } from 'stores/Tables/hooks';
 import TableHydrator from 'stores/Tables/Hydrator';
@@ -94,13 +94,7 @@ function AccessGrantsTable({ tablePrefix, showUser }: Props) {
                     }
                     showToolbar
                     toolbar={
-                        showUser ? (
-                            <AccessLinksButton />
-                        ) : (
-                            <Button variant="outlined">
-                                <FormattedMessage id="admin.prefix.cta.issueGrant" />
-                            </Button>
-                        )
+                        showUser ? <AccessLinksButton /> : <DataShareButton />
                     }
                 />
             </TableHydrator>

--- a/src/directives/shared.ts
+++ b/src/directives/shared.ts
@@ -64,10 +64,7 @@ export const DIRECTIVES: Directives = {
 
             // If the status is not success AND they submitted something... we need a new directive
             if (appliedDirective.job_status.type !== 'success') {
-                if (
-                    appliedDirective.user_claims?.tenant &&
-                    appliedDirective.user_claims.tenant.length > 0
-                ) {
+                if (!stillNeeded()) {
                     return 'outdated';
                 }
             }

--- a/src/directives/shared.ts
+++ b/src/directives/shared.ts
@@ -31,6 +31,56 @@ export const jobStatusQuery = (data: AppliedDirective<UserClaims>) => {
 };
 
 export const DIRECTIVES: Directives = {
+    acceptDemoTenant: {
+        token: '14c0beec-422f-4e95-94f1-567107b26840',
+        queryFilter: (queryBuilder) => {
+            return queryBuilder;
+        },
+        generateUserClaim: (args: any[]) => {
+            return {
+                tenant: args[0],
+            };
+        },
+        calculateStatus: (appliedDirective) => {
+            const stillNeeded = () => {
+                return !hasLength(appliedDirective?.user_claims?.tenant);
+            };
+
+            // If there is no directive to check it is unfulfilled
+            if (!appliedDirective || isEmpty(appliedDirective)) {
+                return 'unfulfilled';
+            }
+
+            // If directive already queued and no claim is there we can just use that directive again
+            if (appliedDirective.job_status.type === 'queued') {
+                // no claim is there we can just use that directive again
+                if (stillNeeded()) {
+                    return 'in progress';
+                }
+
+                // queued claim is current
+                return 'waiting';
+            }
+
+            // If the status is not success AND they submitted something... we need a new directive
+            if (appliedDirective.job_status.type !== 'success') {
+                if (
+                    appliedDirective.user_claims?.tenant &&
+                    appliedDirective.user_claims.tenant.length > 0
+                ) {
+                    return 'outdated';
+                }
+            }
+
+            // If it was success and passed all the other checks we're good
+            if (appliedDirective.job_status.type === 'success') {
+                return 'fulfilled';
+            }
+
+            // Catch all for edge cases like a "invalidClaim" status
+            return 'unfulfilled';
+        },
+    },
     betaOnboard: {
         token: '453e00cd-e12a-4ce5-b12d-3837aa385751',
         queryFilter: (queryBuilder) => {

--- a/src/directives/types.ts
+++ b/src/directives/types.ts
@@ -5,6 +5,7 @@ import { AppliedDirective, JoinedAppliedDirective } from 'types';
 
 // THESE MUST STAY IN SYNC WITH THE DB
 export interface Directives {
+    acceptDemoTenant: DirectiveSettings<AcceptDemoTenantClaim>;
     betaOnboard: DirectiveSettings<OnboardClaim>;
     clickToAccept: DirectiveSettings<ClickToAcceptClaim>;
     grant: DirectiveSettings<GrantClaim>;
@@ -17,6 +18,10 @@ export type DirectiveStates =
     | 'fulfilled'
     | 'outdated'
     | 'errored';
+
+export interface AcceptDemoTenantClaim {
+    tenant: string;
+}
 
 export interface ClickToAcceptClaim {
     version: string;
@@ -31,7 +36,11 @@ export interface OnboardClaim {
     survey: any;
 }
 
-export type UserClaims = ClickToAcceptClaim | GrantClaim | OnboardClaim;
+export type UserClaims =
+    | AcceptDemoTenantClaim
+    | ClickToAcceptClaim
+    | GrantClaim
+    | OnboardClaim;
 
 export interface DirectiveSettings<T> {
     token: string;

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -267,6 +267,10 @@ const Home: ResolvedIntlConfig['messages'] = {
     'home.hero.companyDetails.step1': `Set up real-time data ingestion from your sources. Click “New Capture” to get started.`,
     'home.hero.companyDetails.step2': `Keep destination systems up to date with Materializations: low latency views of your data.`,
 
+    'home.hero.demo.alert.demoTenant.header': `Testing out Flow just got easier`,
+    'home.hero.demo.alert.demoTenant': `Estuary has shared a demo tenant with you to help you see Flow in action while you get set up. To accept it, {button}. You can undo this anytime through data sharing on the Admin page.`,
+    'home.hero.demo.alert.demoTenant.button': `click here`,
+
     'home.hero.1.title': `Wikipedia Data`,
     'home.hero.1.message': `Flow {emphasis} about 100 events per second from the Wikipedia’s API.`,
     'home.hero.1.message.emphasis': `captures`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -470,6 +470,12 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.users.prefixInvitation.cta.generateLink': `Generate Invitation`,
 
     'admin.prefix.cta.issueGrant': `Grant Access`,
+    'admin.prefix.issueGrant.header': `Share Data`,
+    'admin.prefix.issueGrant.message': `This is a placeholder for a description.`,
+    'admin.prefix.issueGrant.label.capability': `Capability`,
+    'admin.prefix.issueGrant.label.sharedEntity': `Shared Entity`,
+    'admin.prefix.issueGrant.label.sharedWith': `Shared With`,
+    'admin.prefix.issueGrant.cta.generateGrant': `Grant Access`,
 
     'admin.cookies': `Cookie Preferences`,
     'admin.cookies.message': `Click below to configure your cookie preferences.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -480,6 +480,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.prefix.issueGrant.label.sharedPrefix': `Shared Prefix`,
     'admin.prefix.issueGrant.label.sharedWith': `Shared With`,
     'admin.prefix.issueGrant.cta.generateGrant': `Grant Access`,
+    'admin.prefix.issueGrant.error.invalidPrefix': `The value entered in the Shared Prefix text field is not an extension of an existing prefix.`,
 
     'admin.cookies': `Cookie Preferences`,
     'admin.cookies.message': `Click below to configure your cookie preferences.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -367,7 +367,7 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.data.writesTo': `Writes To`,
     'entityTable.data.readsFrom': `Reads From`,
     'entityTable.data.status': `Status`,
-    'entityTable.data.userFullName': `User`,
+    'entityTable.data.userFullName': `Name`,
     'entityTable.data.capability': `Capability`,
     'entityTable.data.objectRole': `Object`,
     'entityTable.data.lastPubUserFullName': `Last Updated By`,
@@ -376,7 +376,7 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.data.bucket': `Bucket`,
     'entityTable.data.prefix': `Prefix`,
     'entityTable.data.storagePrefix': `Prefix`,
-    'entityTable.data.sharedEntity': `Shared Entity`,
+    'entityTable.data.sharedPrefix': `Shared Prefix`,
     'entityTable.data.sharedWith': `Shared With`,
 
     'entityTable.stats.bytes_read': `Bytes Read`,
@@ -469,11 +469,11 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.users.prefixInvitation.label.type': `Type`,
     'admin.users.prefixInvitation.cta.generateLink': `Generate Invitation`,
 
-    'admin.prefix.cta.issueGrant': `Share Data`,
+    'admin.prefix.cta.issueGrant': `Grant Access`,
     'admin.prefix.issueGrant.header': `Share Data`,
     'admin.prefix.issueGrant.message': `This is a placeholder for a description.`,
     'admin.prefix.issueGrant.label.capability': `Capability`,
-    'admin.prefix.issueGrant.label.sharedEntity': `Shared Entity`,
+    'admin.prefix.issueGrant.label.sharedPrefix': `Shared Prefix`,
     'admin.prefix.issueGrant.label.sharedWith': `Shared With`,
     'admin.prefix.issueGrant.cta.generateGrant': `Grant Access`,
 
@@ -496,7 +496,7 @@ const AccessGrants: ResolvedIntlConfig['messages'] = {
     'accessGrantsTable.users.title': `Organization Membership`,
     'accessGrantsTable.prefixes.title': `Data Sharing`,
     'accessGrantsTable.users.filterLabel': `Filter User or Object`,
-    'accessGrantsTable.prefixes.filterLabel': `Filter Namespace`,
+    'accessGrantsTable.prefixes.filterLabel': `Filter Prefixes`,
     'accessGrants.message1': `No results found.`,
     'accessGrants.message2': `We couldn't find any results matching your search. Please try a different filter.`,
 

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -267,9 +267,9 @@ const Home: ResolvedIntlConfig['messages'] = {
     'home.hero.companyDetails.step1': `Set up real-time data ingestion from your sources. Click “New Capture” to get started.`,
     'home.hero.companyDetails.step2': `Keep destination systems up to date with Materializations: low latency views of your data.`,
 
-    'home.hero.demo.alert.demoTenant.header': `Testing out Flow just got easier`,
-    'home.hero.demo.alert.demoTenant': `Estuary has shared a demo tenant with you to help you see Flow in action while you get set up. To accept it, {button}. You can undo this anytime through data sharing on the Admin page.`,
-    'home.hero.demo.alert.demoTenant.button': `click here`,
+    'home.hero.demo.demoTenant.header': `Testing out Flow just got easier`,
+    'home.hero.demo.demoTenant': `Estuary has a public {sharableTenant} tenant that can help you see Flow in action while you get set up. To give your tenant, {userTenant}, read access to it, {button}. You can undo this anytime through data sharing on the Admin page.`,
+    'home.hero.demo.demoTenant.button': `click here`,
 
     'home.hero.1.title': `Wikipedia Data`,
     'home.hero.1.message': `Flow {emphasis} about 100 events per second from the Wikipedia’s API.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -480,6 +480,8 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.prefix.issueGrant.label.sharedPrefix': `Shared Prefix`,
     'admin.prefix.issueGrant.label.sharedWith': `Shared With`,
     'admin.prefix.issueGrant.cta.generateGrant': `Grant Access`,
+    'admin.prefix.issueGrant.notification.success.title': `Grant Created Successfully`,
+    'admin.prefix.issueGrant.notification.success.message': `{objectRole} has been shared with {subjectRole}.`,
     'admin.prefix.issueGrant.error.invalidPrefix': `The value entered in the Shared Prefix text field is not an extension of an existing prefix.`,
 
     'admin.cookies': `Cookie Preferences`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -270,7 +270,7 @@ const Home: ResolvedIntlConfig['messages'] = {
     'home.hero.companyDetails.step2': `Keep destination systems up to date with Materializations: low latency views of your data.`,
 
     'home.hero.demo.demoTenant.header': `Testing out Flow just got easier`,
-    'home.hero.demo.demoTenant': `Estuary has a public {sharableTenant} tenant that can help you see Flow in action while you get set up. To give your tenant, {userTenant}, read access to it, {button}. You can undo this anytime through data sharing on the Admin page.`,
+    'home.hero.demo.demoTenant': `Estuary has a public {sharableTenant} tenant that can help you see Flow in action while you get set up. To give your tenant, {userTenant}, read access to it, {button}.`,
     'home.hero.demo.demoTenant.button': `click here`,
 
     'home.hero.1.title': `Wikipedia Data`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -469,7 +469,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.users.prefixInvitation.label.type': `Type`,
     'admin.users.prefixInvitation.cta.generateLink': `Generate Invitation`,
 
-    'admin.prefix.cta.issueGrant': `Grant Access`,
+    'admin.prefix.cta.issueGrant': `Share Data`,
     'admin.prefix.issueGrant.header': `Share Data`,
     'admin.prefix.issueGrant.message': `This is a placeholder for a description.`,
     'admin.prefix.issueGrant.label.capability': `Capability`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -471,7 +471,6 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.users.cta.prefixInvitation': `Manage Invitations`,
     'admin.users.prefixInvitation.header': `Manage Invitations`,
     'admin.users.prefixInvitation.message': `This is a placeholder for a description.`,
-    'admin.users.prefixInvitation.label.prefix': `Prefix`,
     'admin.users.prefixInvitation.label.capability': `Capability`,
     'admin.users.prefixInvitation.label.type': `Type`,
     'admin.users.prefixInvitation.cta.generateLink': `Generate Invitation`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -471,6 +471,7 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.users.cta.prefixInvitation': `Manage Invitations`,
     'admin.users.prefixInvitation.header': `Manage Invitations`,
     'admin.users.prefixInvitation.message': `This is a placeholder for a description.`,
+    'admin.users.prefixInvitation.label.prefix': `Prefix`,
     'admin.users.prefixInvitation.label.capability': `Capability`,
     'admin.users.prefixInvitation.label.type': `Type`,
     'admin.users.prefixInvitation.cta.generateLink': `Generate Invitation`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -376,6 +376,8 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.data.bucket': `Bucket`,
     'entityTable.data.prefix': `Prefix`,
     'entityTable.data.storagePrefix': `Prefix`,
+    'entityTable.data.sharedEntity': `Shared Entity`,
+    'entityTable.data.sharedWith': `Shared With`,
 
     'entityTable.stats.bytes_read': `Bytes Read`,
     'entityTable.stats.docs_read': `Docs Read`,
@@ -460,16 +462,18 @@ const AdminPage: ResolvedIntlConfig['messages'] = {
     'admin.billing.paymentMethods.table.label.actions': `Actions`,
     'admin.billing.paymentMethods.table.emptyTableDefault.message': `No payment methods available.`,
 
-    'admin.users.cta.sharePrefix': `Manage Invitations`,
-    'admin.users.sharePrefix.header': `Manage Invitations`,
-    'admin.users.sharePrefix.message': `This is a placeholder for a description.`,
-    'admin.users.sharePrefix.label.capability': `Capability`,
-    'admin.users.sharePrefix.label.type': `Type`,
-    'admin.users.sharePrefix.cta.generateLink': `Generate Invitation`,
+    'admin.users.cta.prefixInvitation': `Manage Invitations`,
+    'admin.users.prefixInvitation.header': `Manage Invitations`,
+    'admin.users.prefixInvitation.message': `This is a placeholder for a description.`,
+    'admin.users.prefixInvitation.label.capability': `Capability`,
+    'admin.users.prefixInvitation.label.type': `Type`,
+    'admin.users.prefixInvitation.cta.generateLink': `Generate Invitation`,
+
+    'admin.prefix.cta.issueGrant': `Grant Access`,
 
     'admin.cookies': `Cookie Preferences`,
     'admin.cookies.message': `Click below to configure your cookie preferences.`,
-    'admin.tabs.users': `Users`,
+    'admin.tabs.users': `Account Access`,
     'admin.tabs.connectors': `Connectors`,
     'admin.tabs.api': `CLI-API`,
     'admin.tabs.billing': `Billing`,
@@ -483,10 +487,10 @@ const Welcome: ResolvedIntlConfig['messages'] = {
 
 const AccessGrants: ResolvedIntlConfig['messages'] = {
     'accessGrantsTable.header': `Captures`,
-    'accessGrantsTable.users.title': `Users`,
-    'accessGrantsTable.prefixes.title': `Prefixes`,
+    'accessGrantsTable.users.title': `Organization Membership`,
+    'accessGrantsTable.prefixes.title': `Data Sharing`,
     'accessGrantsTable.users.filterLabel': `Filter User or Object`,
-    'accessGrantsTable.prefixes.filterLabel': `Filter Prefix or Object`,
+    'accessGrantsTable.prefixes.filterLabel': `Filter Namespace`,
     'accessGrants.message1': `No results found.`,
     'accessGrants.message2': `We couldn't find any results matching your search. Please try a different filter.`,
 

--- a/src/stores/Entities/Store.ts
+++ b/src/stores/Entities/Store.ts
@@ -9,7 +9,11 @@ import { EntitiesState } from './types';
 
 const getInitialStateData = (): Pick<
     EntitiesState,
-    'capabilities' | 'hydrated' | 'hydrationErrors' | 'hydrationErrorsExist'
+    | 'capabilities'
+    | 'hydrated'
+    | 'hydrationErrors'
+    | 'hydrationErrorsExist'
+    | 'mutate'
 > => ({
     hydrated: false,
     hydrationErrors: null,
@@ -19,6 +23,7 @@ const getInitialStateData = (): Pick<
         read: {},
         write: {},
     },
+    mutate: null,
 });
 
 const getInitialState = (
@@ -50,6 +55,16 @@ const getInitialState = (
             }),
             false,
             'Entities hydration errors'
+        );
+    },
+
+    setMutate: (value) => {
+        set(
+            produce((state: EntitiesState) => {
+                state.mutate = value;
+            }),
+            false,
+            'Entities mutator set'
         );
     },
 

--- a/src/stores/Entities/hooks.ts
+++ b/src/stores/Entities/hooks.ts
@@ -84,6 +84,18 @@ export const useEntitiesStore_setHydrationErrors = () => {
         (state) => state.setHydrationErrors
     );
 };
+export const useEntitiesStore_mutate = () => {
+    return useZustandStore<EntitiesState, EntitiesState['mutate']>(
+        GlobalStoreNames.ENTITIES,
+        (state) => state.mutate
+    );
+};
+const useEntitiesStore_setMutate = () => {
+    return useZustandStore<EntitiesState, EntitiesState['setMutate']>(
+        GlobalStoreNames.ENTITIES,
+        (state) => state.setMutate
+    );
+};
 
 export const useSidePanelDocsStore_resetState = () => {
     return useZustandStore<EntitiesState, EntitiesState['resetState']>(
@@ -108,21 +120,25 @@ export const useHydrateState = () => {
     const setHydrationErrors = useEntitiesStore_setHydrationErrors();
     const setCapabilities = useEntitiesStore_setCapabilities();
     const setHydrated = useEntitiesStore_setHydrated();
+    const setMutate = useEntitiesStore_setMutate();
 
     // Once we are done validating update all the settings
     useEffect(() => {
         if (!response.isValidating) {
             setHydrationErrors(response.error);
             setCapabilities(response.data?.data ?? null);
+            setMutate(response.mutate);
             setHydrated(true);
         }
     }, [
         response.data?.data,
         response.error,
         response.isValidating,
+        response.mutate,
         setCapabilities,
         setHydrated,
         setHydrationErrors,
+        setMutate,
     ]);
 
     return response;

--- a/src/stores/Entities/types.ts
+++ b/src/stores/Entities/types.ts
@@ -1,5 +1,6 @@
 import { PostgrestResponse } from '@supabase/postgrest-js';
 import { StoreWithHydration } from 'stores/Hydration';
+import { KeyedMutator } from 'swr';
 import { AuthRoles, Schema } from 'types';
 
 interface ObjectRoleMetadata {
@@ -22,4 +23,7 @@ export interface EntitiesState extends StoreWithHydration {
 
     hydrationErrors: any;
     setHydrationErrors: (val: EntitiesState['hydrationErrors']) => void;
+
+    mutate: KeyedMutator<PostgrestResponse<AuthRoles>> | null;
+    setMutate: (value: EntitiesState['mutate']) => void;
 }

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -22,6 +22,9 @@ export const hasLength = (val: string | any[] | null | undefined): boolean => {
     return Boolean(val && val.length > 0);
 };
 
+export const appendWithForwardSlash = (value: string): string =>
+    hasLength(value) && !value.endsWith('/') ? `${value}/` : value;
+
 export const getPathWithParams = (
     baseURL: string,
     params: { [key: string]: string | string[] } | URLSearchParams


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Allow users to share data between prefixes.

1. Allow users to opt into the `demo/` tenant.

1. Update the prefix field in the _Manage Invitations_ dialog presented on the _Access Grants_ page to be a combination of a `Select` and `TextField` MUI component.

1. Update the content and layout of the _Access Grants_ page to align with the latest set of mocks.

## Tests

_Describe the approach to testing._

## Content

Content was generated for the two, new dialogs introduced in this PR and considerably adjusted on the _Access Grants_ page. See the language file (i.e., _src/lang/en-US.ts_) for changes.

## Screenshots

**Opt into the `demo/` tenant dialog**

This dialog appears when one of the _See the [entity]_ CTAs is clicked (e.g., _See the Capture_).

<img width="903" alt="pr_screenshot-644-demo_opt_in-share_demo_dialog" src="https://github.com/estuary/ui/assets/77648584/35a8ece9-d3c5-42ab-b29e-6e6baf5958ac">

<br />
<br />

**Opt into the `demo/` tenant dialog | Loading state**

<img width="902" alt="pr_screenshot-644-demo_opt_in-share_demo_dialog-loading" src="https://github.com/estuary/ui/assets/77648584/b32953a3-e6b6-41a9-9a47-fd5c49a94201">

<br />
<br />

**Access Grants page**

<img width="902" alt="pr_screenshot-644-demo_opt_in-access_grants_page" src="https://github.com/estuary/ui/assets/77648584/6844b7cb-14a7-4c6f-839c-1eb9ff10dd9a">

<br />
<br />

**Access Grants page | Manage invitations dialog | Multi-tenant**

<img width="902" alt="pr_screenshot-644-demo_opt_in-manage_invite_dialog" src="https://github.com/estuary/ui/assets/77648584/49653118-7040-436a-adfb-9e25514a5703">

<br />
<br />

**Access Grants page | Data sharing dialog | Single-tenant**

<img width="903" alt="pr_screenshot-644-demo_opt_in-share_data_dialog-single_tenant" src="https://github.com/estuary/ui/assets/77648584/559db5ca-fdfb-4a34-85d0-5acb3661a3e9">

<br />
<br />

**Access Grants page | Data sharing dialog | Multi-tenant**

<img width="684" alt="pr_screenshot-644-demo_opt_in-share_data_dialog-multi_tenant" src="https://github.com/estuary/ui/assets/77648584/b3465883-59a3-4d89-899d-3aceb2f0b41e">

<br />
<br />

**Access Grants page | Data sharing dialog | All-fields completed**

<img width="902" alt="pr_screenshot-644-demo_opt_in-share_demo_dialog-completed" src="https://github.com/estuary/ui/assets/77648584/52581902-cb90-4982-9e10-056a1afa4d60">

<br />
<br />

**Access Grants page | Data sharing dialog | Success Notification**

<img width="902" alt="pr_screenshot-644-demo_opt_in-share_demo_dialog-success_notification" src="https://github.com/estuary/ui/assets/77648584/e10046a6-d9f4-460f-8b9d-6dbc0d714454">