### PR TITLE
Phil/evolution wording

### DIFF
--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -132,7 +132,7 @@ const CTAs: ResolvedIntlConfig['messages'] = {
     'cta.configure': `Configure`,
     'cta.showAll': `Show All`,
     'cta.reload': `Reload`,
-    'cta.evolve': `Create New Collection Versions`,
+    'cta.evolve': `Create new versions`,
 };
 
 const Data: ResolvedIntlConfig['messages'] = {
@@ -1045,8 +1045,8 @@ const EntityEvolution: ResolvedIntlConfig['messages'] = {
     'entityEvolution.failure.errorTitle': `Update Failed`,
     'entityEvolution.serverUnreachable': `${CommonMessages['common.failedFetch']} while trying to update collections`,
     'entityEvolution.error.title': `Changes Rejected Due to Incompatible Schema Updates`,
-    'entityEvolution.error.message': `Schema changes will break downstream tasks. To avoid this, click below and then publish a new version of the affected collections.`,
-    'entityEvolution.error.note': `Note: This may result in additional cost as new collection versions are backfilled.`,
+    'entityEvolution.error.message': `Schema changes will break downstream tasks. To avoid this, click below to create new versions.`,
+    'entityEvolution.error.note': `Note: This may result in additional cost as new versions are backfilled.`,
 };
 
 const DraftErrors: ResolvedIntlConfig['messages'] = {

--- a/src/utils/name-utils.ts
+++ b/src/utils/name-utils.ts
@@ -1,4 +1,9 @@
 const COLLECTION_VERSION_RE = new RegExp('.*[_-][vV](\\d+)$');
+
+// This function is currently unused, as we only pass the `old_name` to the evolutions handler.
+// In the future, we'd like to present a more comprehensive message, with a suggested action for each
+// incompatible collection, and at that point this will once again be needed. This function will also
+// be needed by another future feature allowing users to manually re-create collections.
 export const suggestedName = (oldName: string) => {
     const regExMatch = COLLECTION_VERSION_RE.exec(oldName);
 
@@ -17,7 +22,10 @@ export const incrementCollectionNames = (collections: string[]) => {
     return collections.map((collectionName) => {
         return {
             old_name: collectionName,
-            new_name: suggestedName(collectionName),
+            // Leave `new_name` unset for now, which will allow the evolutions
+            // handler to only re-create materialization bindings in cases where
+            // collections use the `x-infer-schema` attribute.
+            // new_name: suggestedName(collectionName),
         };
     });
 };


### PR DESCRIPTION
## Changes

Minor updates around handling of schema evolution, one for wording, and another to omit the `new_name` when evolving collections to allow the backend the flexibility to avoid re-creating collections when it's desirable.

## Tests

still working on it ;)

## Issues


## Content

The wording of evolutions-related content was updated.

## Screenshots

...