### PR TITLE
PROD - Fix materialization edit loading with an empty form

### DIFF
--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -112,11 +112,6 @@ function EndpointConfig({
             const defaultConfig = createJSONFormDefaults(schema);
             setEndpointConfig(defaultConfig);
             setPreviousEndpointConfig(defaultConfig);
-        } else if (!connectorTag) {
-            // This will reset the schema so the form is re-rendered correctly
-            //  without this the form would do a quick rendering of the previous
-            //  connector and then immedietly replace that with the new connector
-            setEndpointSchema({});
         }
     }, [
         setServerUpdateRequired,


### PR DESCRIPTION
## Changes

This perf tweak is NOT good. Materialization edit broke due to this

## Tests

Manually tested Materialization edit and Capture Edit

## Issues

Prod issue from user

## Content

None

## Screenshots

You can edit again
![image](https://github.com/estuary/ui/assets/270078/9b15bb79-2cd9-40a4-a690-3a781f13bd55)

