### PR TITLE
prod: update derivation and catalog name in transform create store

### DIFF
--- a/src/components/transformation/create/index.tsx
+++ b/src/components/transformation/create/index.tsx
@@ -33,6 +33,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useSet } from 'react-use';
 import {
     useTransformationCreate_language,
+    useTransformationCreate_setCatalogName,
     useTransformationCreate_setName,
     useTransformationCreate_setPrefix,
 } from 'stores/TransformationCreate/hooks';
@@ -73,6 +74,7 @@ function TransformationCreate({ postWindowOpen }: Props) {
 
     const collections = useLiveSpecs('collection');
 
+    const setCatalogName = useTransformationCreate_setCatalogName();
     const setDerivationName = useTransformationCreate_setName();
     const setCatalogPrefix = useTransformationCreate_setPrefix();
     const language = useTransformationCreate_language();
@@ -131,6 +133,10 @@ function TransformationCreate({ postWindowOpen }: Props) {
                                     standardVariant
                                     size="medium"
                                     label={null}
+                                    onChange={(newName, errors) => {
+                                        setCatalogName(newName);
+                                        setEntityNameError(errors);
+                                    }}
                                     onNameChange={(newName, errors) => {
                                         setDerivationName(newName);
                                         setEntityNameError(errors);
@@ -250,6 +256,10 @@ function TransformationCreate({ postWindowOpen }: Props) {
                                     id: 'newTransform.collection.label',
                                 })}
                                 onChange={(newName, errors) => {
+                                    setCatalogName(newName);
+                                    setEntityNameError(errors);
+                                }}
+                                onNameChange={(newName, errors) => {
                                     setDerivationName(newName);
                                     setEntityNameError(errors);
                                 }}

--- a/src/stores/TransformationCreate/Store.ts
+++ b/src/stores/TransformationCreate/Store.ts
@@ -60,7 +60,17 @@ const getInitialState = (
                 state.catalogName = prefix ? `${prefix}${value}` : null;
             }),
             false,
-            'Transform Create Name Set'
+            'Transform Create Derivation Name Set'
+        );
+    },
+
+    setCatalogName: (value) => {
+        set(
+            produce((state: TransformCreateState) => {
+                state.catalogName = value;
+            }),
+            false,
+            'Transform Create Catalog Name Set'
         );
     },
 

--- a/src/stores/TransformationCreate/hooks.ts
+++ b/src/stores/TransformationCreate/hooks.ts
@@ -217,3 +217,13 @@ export const useTransformationCreate_catalogName = () => {
         TransformCreateState['catalogName']
     >(TransformCreateStoreNames.TRANSFORM_CREATE, (state) => state.catalogName);
 };
+
+export const useTransformationCreate_setCatalogName = () => {
+    return useLocalZustandStore<
+        TransformCreateState,
+        TransformCreateState['setCatalogName']
+    >(
+        TransformCreateStoreNames.TRANSFORM_CREATE,
+        (state) => state.setCatalogName
+    );
+};

--- a/src/stores/TransformationCreate/types.ts
+++ b/src/stores/TransformationCreate/types.ts
@@ -30,6 +30,7 @@ export interface TransformCreateState {
     setPrefix: (value: TransformCreateState['prefix']) => void;
 
     catalogName: string | null;
+    setCatalogName: (val: TransformCreateState['catalogName']) => void;
 
     // Transformation Config
     sourceCollections: string[];


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Store the complete value of `PrefixedName` in the `catalogName` transform create store property.

1. Store the value of the input component used in `PrefixedName` in the `name` transform create store property (which corresponds to the derivation name, a subset of the catalog name).

## Tests

_Describe the approach to testing._

