### PR TITLE
Need to default shuffle to any for transforms

### DIFF
--- a/src/components/transformation/create/generateTransformSpec.ts
+++ b/src/components/transformation/create/generateTransformSpec.ts
@@ -19,6 +19,7 @@ const generateSqlTemplate = (
 
         return {
             name: `${baseName}`,
+            shuffle: 'any',
             source,
             lambda: `${entityName}.lambda.${baseName}.sql`,
         };
@@ -47,6 +48,7 @@ const generateTsTemplate = (
 
         return {
             name: `${baseName}`,
+            shuffle: 'any',
             source,
         };
     });


### PR DESCRIPTION
## Changes

1. Add `shuffle: any` to the transformations

## Tests

Manually update the specs on Gitpod in prod to see if setting shuffle to `any` would let the files get generated and it did

## Issues

Issue from Slack

## Content

N/A

## Screenshots

N/A
