### PR TITLE
Trigger billing loading states when selected tenant changes

### DIFF
--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -129,7 +129,7 @@ const getStatsForBilling = (tenants: string[], startDate: string) => {
         )
         .eq('grain', 'monthly')
         .gte('ts', formatToGMT(startDate))
-        .lt('ts', formatToGMT(today))
+        .lte('ts', formatToGMT(today))
         .or(subjectRoleFilters)
         .order('ts', { ascending: false });
 };
@@ -166,7 +166,7 @@ const getStatsForBillingHistoryTable = (
         )
         .eq('grain', 'monthly')
         .gte('ts', formatToGMT(startMonth))
-        .lt('ts', formatToGMT(today))
+        .lte('ts', formatToGMT(today))
         .or(subjectRoleFilters);
 
     queryBuilder = defaultTableFilter<CatalogStats_Billing>(
@@ -180,4 +180,4 @@ const getStatsForBillingHistoryTable = (
     return queryBuilder;
 };
 
-export { getStatsForBilling, getStatsForBillingHistoryTable, getStatsByName };
+export { getStatsByName, getStatsForBilling, getStatsForBillingHistoryTable };

--- a/src/components/admin/Billing/TenantOptions.tsx
+++ b/src/components/admin/Billing/TenantOptions.tsx
@@ -4,7 +4,10 @@ import { useTenantDetails } from 'context/fetcher/Tenant';
 import { useZustandStore } from 'context/Zustand/provider';
 import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
-import { useBilling_setSelectedTenant } from 'stores/Billing/hooks';
+import {
+    useBilling_resetState,
+    useBilling_setSelectedTenant,
+} from 'stores/Billing/hooks';
 import { SelectTableStoreNames } from 'stores/names';
 import {
     useBillingTable_setHydrated,
@@ -22,6 +25,7 @@ function TenantOptions() {
 
     // Billing Store
     const setSelectedTenant = useBilling_setSelectedTenant();
+    const resetBillingState = useBilling_resetState();
 
     // Billing Select Table Store
     const setHydrated = useBillingTable_setHydrated();
@@ -46,6 +50,7 @@ function TenantOptions() {
             options={tenants.map(({ tenant }) => tenant)}
             defaultValue={tenants[0].tenant}
             changeHandler={(_event, value) => {
+                resetBillingState();
                 setSelectedTenant(value);
 
                 resetBillingSelectTableState();

--- a/src/stores/Billing/Store.ts
+++ b/src/stores/Billing/Store.ts
@@ -73,6 +73,9 @@ export const getInitialState = (
         updateBillingHistory: (value) => {
             set(
                 produce((state: BillingState) => {
+                    // This action is used to update the record of the active billing cycle at a regular interval.
+                    // Since the selected tenant is subject to vary, the billed prefix of the record input must be
+                    // validated against the selected tenant before altering the billing history.
                     if (
                         value[0].max_concurrent_tasks > 0 &&
                         value[0].billed_prefix === state.selectedTenant

--- a/src/stores/Billing/Store.ts
+++ b/src/stores/Billing/Store.ts
@@ -73,7 +73,10 @@ export const getInitialState = (
         updateBillingHistory: (value) => {
             set(
                 produce((state: BillingState) => {
-                    if (value[0].max_concurrent_tasks > 0) {
+                    if (
+                        value[0].max_concurrent_tasks > 0 &&
+                        value[0].billed_prefix === state.selectedTenant
+                    ) {
                         const { billingHistory } = get();
 
                         const evaluatedBillingHistory = billingHistory.filter(


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Present the loading states for components on the _Billing_ page when the selected tenant changes.

1. Adjust the billing-related catalog stats queries so that data is fetched when a new billing cycle begins.

## Tests

Approaches to testing are as follows:

* Validate that the components on the _Billing_ page enter a loading state when the page is initially loaded.

* Validate that the components on the _Billing_ page enter a loading state when the selected tenant changes.

**NOTE:** I am unable to generate catalog stats locally. The second scenario needs to be tested with at least one account that has catalog stats before this PR can be merged.

## Screenshots

_If applicable - please include some screenshots of the new UI_
