### PR TITLE
Supporting when bindings are full bindings and not just the name

### DIFF
--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -35,6 +35,7 @@ import {
 } from 'stores/ResourceConfig/hooks';
 import { ResourceConfigDictionary } from 'stores/ResourceConfig/types';
 import { Schema } from 'types';
+import { getCollectionName, getCollectionNameProp } from 'utils/workflow-utils';
 
 interface Props {
     draftSpecs: DraftSpecQuery[];
@@ -99,13 +100,12 @@ function BindingsMultiEditor({
     const resourceConfigUpdated = useMemo(() => {
         let queriedResourceConfig: ResourceConfigDictionary = {};
 
-        const collectionNameProp =
-            entityType === 'materialization' ? 'source' : 'target';
+        const collectionNameProp = getCollectionNameProp(entityType);
 
         draftSpecs[0]?.spec.bindings.forEach((binding: any) => {
             queriedResourceConfig = {
                 ...queriedResourceConfig,
-                [binding[collectionNameProp]]: {
+                [getCollectionName(binding[collectionNameProp])]: {
                     data: binding.resource,
                     errors: [],
                 },

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -21,6 +21,7 @@ import { ResourceConfigStoreNames } from 'stores/names';
 import { Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
 import { devtoolsOptions } from 'utils/store-utils';
+import { getCollectionName } from 'utils/workflow-utils';
 import { create, StoreApi } from 'zustand';
 import { devtools, NamedSet } from 'zustand/middleware';
 import { ResourceConfigDictionary, ResourceConfigState } from './types';
@@ -189,7 +190,7 @@ const getInitialState = (
                     entityType === 'materialization' ? 'source' : 'target';
 
                 value.forEach((binding: any) => {
-                    collections.push(binding[queryProp]);
+                    collections.push(getCollectionName(binding[queryProp]));
                 });
 
                 state.collections = collections;
@@ -585,10 +586,13 @@ const getInitialState = (
                 ]);
 
                 sortedBindings.forEach((binding: any) =>
-                    setResourceConfig(binding[collectionNameProp], {
-                        data: binding.resource,
-                        errors: [],
-                    })
+                    setResourceConfig(
+                        getCollectionName(binding[collectionNameProp]),
+                        {
+                            data: binding.resource,
+                            errors: [],
+                        }
+                    )
                 );
 
                 preFillCollections(sortedBindings, entityType);

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -21,7 +21,7 @@ import { ResourceConfigStoreNames } from 'stores/names';
 import { Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
 import { devtoolsOptions } from 'utils/store-utils';
-import { getCollectionName } from 'utils/workflow-utils';
+import { getCollectionName, getCollectionNameProp } from 'utils/workflow-utils';
 import { create, StoreApi } from 'zustand';
 import { devtools, NamedSet } from 'zustand/middleware';
 import { ResourceConfigDictionary, ResourceConfigState } from './types';
@@ -186,8 +186,7 @@ const getInitialState = (
             produce((state: ResourceConfigState) => {
                 const collections: string[] = [];
 
-                const queryProp =
-                    entityType === 'materialization' ? 'source' : 'target';
+                const queryProp = getCollectionNameProp(entityType);
 
                 value.forEach((binding: any) => {
                     collections.push(getCollectionName(binding[queryProp]));

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -10,6 +10,16 @@ import { EntityWithCreateWorkflow, Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
 import { ConnectorConfig } from '../../flow_deps/flow';
 
+export const getCollectionName = (binding: any) => {
+    const root = Object.hasOwn(binding, 'source')
+        ? binding.source
+        : Object.hasOwn(binding, 'target')
+        ? binding.target
+        : binding;
+
+    return Object.hasOwn(root, 'name') ? root.name : root;
+};
+
 // TODO (typing): Narrow the return type for this function.
 export const generateTaskSpec = (
     entityType: EntityWithCreateWorkflow,
@@ -36,7 +46,7 @@ export const generateTaskSpec = (
             const resourceConfig = resourceConfigs[collectionName].data;
 
             const existingBindingIndex = draftSpec.bindings.findIndex(
-                (binding: any) => binding[collectionNameProp] === collectionName
+                (binding: any) => getCollectionName(binding) === collectionName
             );
 
             if (existingBindingIndex > -1) {
@@ -54,11 +64,11 @@ export const generateTaskSpec = (
         });
 
         if (hasLength(draftSpec.bindings)) {
-            const filteredBindings = draftSpec.bindings.filter((binding: any) =>
-                boundCollectionNames.includes(binding[collectionNameProp])
+            draftSpec.bindings = draftSpec.bindings.filter((binding: any) =>
+                boundCollectionNames.includes(
+                    getCollectionName(binding[collectionNameProp])
+                )
             );
-
-            draftSpec.bindings = filteredBindings;
         }
     } else {
         draftSpec.bindings = [];

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -11,13 +11,18 @@ import { hasLength } from 'utils/misc-utils';
 import { ConnectorConfig } from '../../flow_deps/flow';
 
 export const getCollectionName = (binding: any) => {
-    const root = Object.hasOwn(binding, 'source')
+    // First see if we've already been passed a scoped binding
+    //  or if we need to find the proper scope ourselves.
+    const scopedBinding = Object.hasOwn(binding, 'source')
         ? binding.source
         : Object.hasOwn(binding, 'target')
         ? binding.target
         : binding;
 
-    return Object.hasOwn(root, 'name') ? root.name : root;
+    // Check if we're dealing with a FullSource or just a string
+    return Object.hasOwn(scopedBinding, 'name')
+        ? scopedBinding.name
+        : scopedBinding;
 };
 
 // TODO (typing): Narrow the return type for this function.

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -6,9 +6,13 @@ import { DraftSpecQuery } from 'hooks/useDraftSpecs';
 import { isEmpty } from 'lodash';
 import { CallSupabaseResponse } from 'services/supabase';
 import { ResourceConfigDictionary } from 'stores/ResourceConfig/types';
-import { EntityWithCreateWorkflow, Schema } from 'types';
+import { Entity, EntityWithCreateWorkflow, Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
 import { ConnectorConfig } from '../../flow_deps/flow';
+
+export const getCollectionNameProp = (entityType: Entity) => {
+    return entityType === 'materialization' ? 'source' : 'target';
+};
 
 export const getCollectionName = (binding: any) => {
     // First see if we've already been passed a scoped binding
@@ -42,8 +46,7 @@ export const generateTaskSpec = (
     draftSpec.endpoint.connector = connectorConfig;
 
     if (resourceConfigs) {
-        const collectionNameProp =
-            entityType === 'capture' ? 'target' : 'source';
+        const collectionNameProp = getCollectionNameProp(entityType);
 
         const boundCollectionNames = Object.keys(resourceConfigs);
 


### PR DESCRIPTION
## Changes

Add support for Materialization bindings to handle both string and `FullSource`

## Tests

Materialization create
Materialization edit
Capture create
Capture edit

## Issues

Helps https://github.com/estuary/ui/issues/677

## Content

N/A

## Screenshots

_If applicable - please include some screenshots of the new UI_
