### PR TITLE
PROD: Update advanced editor when draft changes

### DIFF
--- a/src/components/capture/Create/index.tsx
+++ b/src/components/capture/Create/index.tsx
@@ -6,6 +6,7 @@ import {
     useEditorStore_id,
     useEditorStore_persistedDraftId,
     useEditorStore_pubId,
+    useEditorStore_queryResponse_mutate,
     useEditorStore_resetState,
     useEditorStore_setId,
 } from 'components/editor/Store/hooks';
@@ -17,7 +18,7 @@ import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import useDraftSpecs from 'hooks/useDraftSpecs';
 import usePageTitle from 'hooks/usePageTitle';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 import {
@@ -68,6 +69,7 @@ function CaptureCreate() {
 
     // Endpoint Config Store
     const resetEndpointConfigState = useEndpointConfigStore_reset();
+    const mutate_advancedEditor = useEditorStore_queryResponse_mutate();
 
     // Form State Store
     const setFormState = useFormStateStore_setFormState();
@@ -81,6 +83,13 @@ function CaptureCreate() {
 
     const { mutate: mutateDraftSpecs, ...draftSpecsMetadata } =
         useDraftSpecs(persistedDraftId);
+
+    const updateDraftSpecs = useCallback(async () => {
+        await mutateDraftSpecs();
+        if (mutate_advancedEditor) {
+            await mutate_advancedEditor();
+        }
+    }, [mutateDraftSpecs, mutate_advancedEditor]);
 
     // Reset the catalog if the connector changes
     useEffect(() => {
@@ -169,7 +178,7 @@ function CaptureCreate() {
                                         entityType={entityType}
                                         disabled={!hasConnectors}
                                         callFailed={helpers.callFailed}
-                                        postGenerateMutate={mutateDraftSpecs}
+                                        postGenerateMutate={updateDraftSpecs}
                                         createWorkflowMetadata={{
                                             initiateDiscovery,
                                             setInitiateDiscovery,

--- a/src/components/capture/Edit.tsx
+++ b/src/components/capture/Edit.tsx
@@ -7,6 +7,7 @@ import {
     useEditorStore_id,
     useEditorStore_persistedDraftId,
     useEditorStore_pubId,
+    useEditorStore_queryResponse_mutate,
     useEditorStore_resetState,
 } from 'components/editor/Store/hooks';
 import EntitySaveButton from 'components/shared/Entity/Actions/SaveButton';
@@ -21,7 +22,7 @@ import { useClient } from 'hooks/supabase-swr';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import useDraftSpecs from 'hooks/useDraftSpecs';
 import usePageTitle from 'hooks/usePageTitle';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 import { useDetailsForm_resetState } from 'stores/DetailsForm/hooks';
@@ -71,6 +72,7 @@ function CaptureEdit() {
 
     // Endpoint Config Store
     const resetEndpointConfigState = useEndpointConfigStore_reset();
+    const mutate_advancedEditor = useEditorStore_queryResponse_mutate();
 
     // Form State Store
     const setFormState = useFormStateStore_setFormState();
@@ -84,6 +86,13 @@ function CaptureEdit() {
         persistedDraftId,
         { lastPubId }
     );
+
+    const updateDraftSpecs = useCallback(async () => {
+        await mutateDraftSpecs();
+        if (mutate_advancedEditor) {
+            await mutate_advancedEditor();
+        }
+    }, [mutateDraftSpecs, mutate_advancedEditor]);
 
     const taskNames = useMemo(
         () =>
@@ -177,7 +186,7 @@ function CaptureEdit() {
                                             disabled={!hasConnectors}
                                             callFailed={helpers.callFailed}
                                             postGenerateMutate={
-                                                mutateDraftSpecs
+                                                updateDraftSpecs
                                             }
                                         />
                                     }

--- a/src/components/materialization/Create/index.tsx
+++ b/src/components/materialization/Create/index.tsx
@@ -3,6 +3,7 @@ import { useBindingsEditorStore_resetState } from 'components/editor/Bindings/St
 import {
     useEditorStore_id,
     useEditorStore_persistedDraftId,
+    useEditorStore_queryResponse_mutate,
     useEditorStore_resetState,
     useEditorStore_setId,
 } from 'components/editor/Store/hooks';
@@ -14,7 +15,7 @@ import EntityToolbar from 'components/shared/Entity/Header';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import useDraftSpecs from 'hooks/useDraftSpecs';
 import usePageTitle from 'hooks/usePageTitle';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 import {
@@ -57,9 +58,9 @@ function MaterializationCreate() {
     // Draft Editor Store
     const draftId = useEditorStore_id();
     const setDraftId = useEditorStore_setId();
-
     const persistedDraftId = useEditorStore_persistedDraftId();
     const resetEditorStore = useEditorStore_resetState();
+    const mutate_advancedEditor = useEditorStore_queryResponse_mutate();
 
     // Endpoint Config Store
     const resetEndpointConfigState = useEndpointConfigStore_reset();
@@ -74,6 +75,13 @@ function MaterializationCreate() {
 
     const { mutate: mutateDraftSpecs, ...draftSpecsMetadata } =
         useDraftSpecs(persistedDraftId);
+
+    const updateDraftSpecs = useCallback(async () => {
+        await mutateDraftSpecs();
+        if (mutate_advancedEditor) {
+            await mutate_advancedEditor();
+        }
+    }, [mutateDraftSpecs, mutate_advancedEditor]);
 
     const taskNames = useMemo(
         () =>
@@ -139,7 +147,7 @@ function MaterializationCreate() {
                                     <MaterializeGenerateButton
                                         disabled={!hasConnectors}
                                         callFailed={helpers.callFailed}
-                                        mutateDraftSpecs={mutateDraftSpecs}
+                                        mutateDraftSpecs={updateDraftSpecs}
                                     />
                                 }
                                 TestButton={

--- a/src/components/materialization/Edit.tsx
+++ b/src/components/materialization/Edit.tsx
@@ -4,6 +4,7 @@ import { useBindingsEditorStore_resetState } from 'components/editor/Bindings/St
 import {
     useEditorStore_id,
     useEditorStore_persistedDraftId,
+    useEditorStore_queryResponse_mutate,
     useEditorStore_resetState,
 } from 'components/editor/Store/hooks';
 import MaterializeGenerateButton from 'components/materialization/GenerateButton';
@@ -19,7 +20,7 @@ import { useClient } from 'hooks/supabase-swr';
 import useConnectorWithTagDetail from 'hooks/useConnectorWithTagDetail';
 import useDraftSpecs from 'hooks/useDraftSpecs';
 import usePageTitle from 'hooks/usePageTitle';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CustomEvents } from 'services/logrocket';
 import { useDetailsForm_resetState } from 'stores/DetailsForm/hooks';
@@ -57,9 +58,9 @@ function MaterializationEdit() {
 
     // Draft Editor Store
     const draftId = useEditorStore_id();
-
     const persistedDraftId = useEditorStore_persistedDraftId();
     const resetEditorStore = useEditorStore_resetState();
+    const mutate_advancedEditor = useEditorStore_queryResponse_mutate();
 
     // Endpoint Config Store
     const resetEndpointConfigState = useEndpointConfigStore_reset();
@@ -76,6 +77,13 @@ function MaterializationEdit() {
         persistedDraftId,
         { lastPubId }
     );
+
+    const updateDraftSpecs = useCallback(async () => {
+        await mutateDraftSpecs();
+        if (mutate_advancedEditor) {
+            await mutate_advancedEditor();
+        }
+    }, [mutateDraftSpecs, mutate_advancedEditor]);
 
     const taskNames = useMemo(
         () =>
@@ -155,7 +163,7 @@ function MaterializationEdit() {
                                         <MaterializeGenerateButton
                                             disabled={!hasConnectors}
                                             callFailed={helpers.callFailed}
-                                            mutateDraftSpecs={mutateDraftSpecs}
+                                            mutateDraftSpecs={updateDraftSpecs}
                                         />
                                     }
                                     TestButton={


### PR DESCRIPTION
## Changes

1. Call the editor mutate (if there) when drafts are mutated
     - In the future we could move this into the draft spec hook but wanted to reduce potential impact of the fix 

## Tests

Manually tested create/edit for Capture and Materializations to make sure the editor got updated.

## Issues

Prod issue found during call

## Content

N/A

## Screenshots

N/A