### PR TITLE
Fix hourly graphs for timezones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "data-plane-gateway": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
                 "date-fns": "^2.30.0",
                 "date-fns-tz": "^2.0.0",
-                "echarts": "^5.4.2",
+                "echarts": "^5.4.3",
                 "filter-obj": "^5.1.0",
                 "iconoir-react": "^6.9.0",
                 "immer": "^9.0.21",
@@ -10010,12 +10010,12 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
         "node_modules/echarts": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.2.tgz",
-            "integrity": "sha512-2W3vw3oI2tWJdyAz+b8DuWS0nfXtSDqlDmqgin/lfzbkB01cuMEN66KWBlmur3YMp5nEDEEt5s23pllnAzB4EA==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
+            "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
             "dependencies": {
                 "tslib": "2.3.0",
-                "zrender": "5.4.3"
+                "zrender": "5.4.4"
             }
         },
         "node_modules/echarts/node_modules/tslib": {
@@ -27591,9 +27591,9 @@
             }
         },
         "node_modules/zrender": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.3.tgz",
-            "integrity": "sha512-DRUM4ZLnoaT0PBVvGBDO9oWIDBKFdAVieNWxWwK0niYzJCMwGchRk21/hsE+RKkIveH3XHCyvXcJDkgLVvfizQ==",
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
+            "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
             "dependencies": {
                 "tslib": "2.3.0"
             }
@@ -34817,12 +34817,12 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
         "echarts": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.2.tgz",
-            "integrity": "sha512-2W3vw3oI2tWJdyAz+b8DuWS0nfXtSDqlDmqgin/lfzbkB01cuMEN66KWBlmur3YMp5nEDEEt5s23pllnAzB4EA==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
+            "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
             "requires": {
                 "tslib": "2.3.0",
-                "zrender": "5.4.3"
+                "zrender": "5.4.4"
             },
             "dependencies": {
                 "tslib": {
@@ -47880,9 +47880,9 @@
             "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
         },
         "zrender": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.3.tgz",
-            "integrity": "sha512-DRUM4ZLnoaT0PBVvGBDO9oWIDBKFdAVieNWxWwK0niYzJCMwGchRk21/hsE+RKkIveH3XHCyvXcJDkgLVvfizQ==",
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
+            "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
             "requires": {
                 "tslib": "2.3.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9247,7 +9247,7 @@
         "node_modules/data-plane-gateway": {
             "version": "0.0.0",
             "resolved": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-Wt1YVbNtB+6iZwJy9QCuL+d4dlaDB6nJ3GknD9f2YM3Mrl5umHkqd4HfWSCok+KzIlWhamfBO+OXeNuO0DDQCQ==",
+            "integrity": "sha512-9IWuCPjKUJbgAIYi6mqQsrcrQhvKOUzszS7/CPB4xBeW6/Jg1KkIlCcMsmn8IkDddf3yCTmMfYdHlGoEagNowQ==",
             "license": "MIT"
         },
         "node_modules/data-urls": {
@@ -34249,7 +34249,7 @@
         },
         "data-plane-gateway": {
             "version": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-Wt1YVbNtB+6iZwJy9QCuL+d4dlaDB6nJ3GknD9f2YM3Mrl5umHkqd4HfWSCok+KzIlWhamfBO+OXeNuO0DDQCQ=="
+            "integrity": "sha512-9IWuCPjKUJbgAIYi6mqQsrcrQhvKOUzszS7/CPB4xBeW6/Jg1KkIlCcMsmn8IkDddf3yCTmMfYdHlGoEagNowQ=="
         },
         "data-urls": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "data-plane-gateway": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
-        "echarts": "^5.4.2",
+        "echarts": "^5.4.3",
         "filter-obj": "^5.1.0",
         "iconoir-react": "^6.9.0",
         "immer": "^9.0.21",

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -220,7 +220,7 @@ const getStatsForDetails = (
         .eq('grain', grain)
         .gt('ts', gt)
         .lte('ts', lte)
-        .order('ts', { ascending: false });
+        .order('ts', { ascending: true });
 };
 
 // TODO (billing): Enable pagination when a database table containing historic billing data is available.

--- a/src/components/graphs/DataByHourGraph/index.tsx
+++ b/src/components/graphs/DataByHourGraph/index.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@mui/material';
 import { defaultOutlineColor, eChartsColors } from 'context/Theme';
-import { eachHourOfInterval, subHours } from 'date-fns';
+import { eachHourOfInterval, parseISO, startOfHour, subHours } from 'date-fns';
 import { EChartsOption } from 'echarts';
 import { BarChart } from 'echarts/charts';
 import {
@@ -68,7 +68,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
 
         // Format the full date so that hours from one day don't show for another day
         return listOfHours.map((date) => {
-            return intl.formatDate(date, formatDateSettings);
+            return intl.formatDate(startOfHour(date), formatDateSettings);
         });
     }, [intl, range]);
 
@@ -216,7 +216,10 @@ function DataByHourGraph({ range, stats = [] }: Props) {
 
         stats.forEach((stat) => {
             // Format to time
-            const formattedTime = intl.formatDate(stat.ts, formatDateSettings);
+            const formattedTime = intl.formatDate(
+                startOfHour(parseISO(stat.ts)),
+                formatDateSettings
+            );
 
             // Total up docs. Mainly for collections that are derivations
             //  eventually we might split this data up into multiple lines

--- a/src/components/graphs/DataByHourGraph/index.tsx
+++ b/src/components/graphs/DataByHourGraph/index.tsx
@@ -143,6 +143,9 @@ function DataByHourGraph({ range, stats = [] }: Props) {
             markLine: {
                 data: [{ type: 'max', name: 'Max' }],
                 label: {
+                    backgroundColor: eChartsColors[0],
+                    color: 'white',
+                    padding: 3,
                     position: 'start',
                     formatter: ({ value }: any) => {
                         return formatter(value, 'bytes');
@@ -164,6 +167,10 @@ function DataByHourGraph({ range, stats = [] }: Props) {
             markLine: {
                 data: [{ type: 'max', name: 'Max' }],
                 label: {
+                    backgroundColor: eChartsColors[1],
+                    color: 'black',
+                    padding: 3,
+
                     position: 'end',
                     formatter: ({ value }: any) => {
                         return formatter(value, 'docs');

--- a/src/components/graphs/DataByHourGraph/index.tsx
+++ b/src/components/graphs/DataByHourGraph/index.tsx
@@ -102,7 +102,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
         );
     }, [intl, stats]);
 
-    // Create a dataset the groups things based on time
+    // Create a dataset
     const scopedDataSet = useMemo(() => {
         const response: Data[] = stats.map((stat) => {
             // Total up docs. Mainly for collections that are derivations
@@ -117,7 +117,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
             return {
                 docs: totalDocs,
                 bytes: totalBytes,
-                timestamp: stat.ts, //new Date(stat.ts)
+                timestamp: stat.ts,
             };
         });
 

--- a/src/components/graphs/DataByHourGraph/index.tsx
+++ b/src/components/graphs/DataByHourGraph/index.tsx
@@ -24,10 +24,17 @@ import useLegendConfig from '../useLegendConfig';
 import useTooltipConfig from '../useTooltipConfig';
 
 interface Props {
+    id: string;
     range: DataByHourRange;
     stats: CatalogStats_Details[] | undefined;
     createdAt?: string;
 }
+
+// These are keys that are used all over. Not typing them as Echarts typing within
+//  dataset complained when I tried
+const TIME = 'timestamp';
+const DOCS = 'docs';
+const BYTES = 'bytes';
 
 const formatTimeSettings: FormatDateOptions = {
     hour: '2-digit',
@@ -41,7 +48,7 @@ const defaultDataFormat = (value: any) => {
     });
 };
 
-function DataByHourGraph({ range, stats = [] }: Props) {
+function DataByHourGraph({ id, range, stats = [] }: Props) {
     const intl = useIntl();
     const theme = useTheme();
     const legendConfig = useLegendConfig();
@@ -64,7 +71,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
                 MarkLineComponent,
             ]);
 
-            const chartDom = document.getElementById('data-by-hour');
+            const chartDom = document.getElementById(id);
 
             if (chartDom) {
                 const chart = echarts.init(chartDom);
@@ -78,7 +85,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
                 });
             }
         }
-    }, [myChart]);
+    }, [id, myChart]);
 
     // Update the "last updated" string shown as an xAxis label
     useEffect(() => {
@@ -109,9 +116,9 @@ function DataByHourGraph({ range, stats = [] }: Props) {
                 : stat.bytes_by;
 
             return {
-                docs: totalDocs,
-                bytes: totalBytes,
-                timestamp: stat.ts,
+                [DOCS]: totalDocs,
+                [BYTES]: totalBytes,
+                [TIME]: stat.ts,
             };
         });
     }, [stats]);
@@ -127,7 +134,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
                 });
             }
 
-            if (dimension === 'docs') {
+            if (dimension === DOCS) {
                 return readable(value, 2, false);
             }
 
@@ -137,8 +144,8 @@ function DataByHourGraph({ range, stats = [] }: Props) {
         const bytesSeries: EChartsOption['series'] = {
             barMinHeight: 1,
             encode: {
-                x: 'timestamp',
-                y: 'bytes',
+                x: TIME,
+                y: BYTES,
             },
             markLine: {
                 data: [{ type: 'max', name: 'Max' }],
@@ -147,9 +154,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
                     color: 'white',
                     padding: 3,
                     position: 'start',
-                    formatter: ({ value }: any) => {
-                        return formatter(value, 'bytes');
-                    },
+                    formatter: ({ value }: any) => formatter(value, BYTES),
                 },
                 symbolSize: 0,
             },
@@ -161,8 +166,8 @@ function DataByHourGraph({ range, stats = [] }: Props) {
         const docsSeries: EChartsOption['series'] = {
             barMinHeight: 1,
             encode: {
-                x: 'timestamp',
-                y: 'docs',
+                x: TIME,
+                y: DOCS,
             },
             markLine: {
                 data: [{ type: 'max', name: 'Max' }],
@@ -172,9 +177,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
                     padding: 3,
 
                     position: 'end',
-                    formatter: ({ value }: any) => {
-                        return formatter(value, 'docs');
-                    },
+                    formatter: ({ value }: any) => formatter(value, DOCS),
                 },
                 symbolSize: 0,
             },
@@ -191,7 +194,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
             useUTC: true,
             // Setting dataset here because setting in a stand alone set option cause the chart to go blank
             dataset: {
-                dimensions: ['timestamp', 'bytes', 'docs'],
+                dimensions: [TIME, BYTES, DOCS],
                 source: scopedDataSet,
             },
             textStyle: {
@@ -324,7 +327,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
         tooltipConfig,
     ]);
 
-    return <div id="data-by-hour" style={{ height: 350 }} />;
+    return <div id={id} style={{ height: 350 }} />;
 }
 
 export default DataByHourGraph;

--- a/src/components/graphs/DataByHourGraph/index.tsx
+++ b/src/components/graphs/DataByHourGraph/index.tsx
@@ -29,12 +29,6 @@ interface Props {
     createdAt?: string;
 }
 
-interface Data {
-    docs?: number;
-    bytes?: number;
-    timestamp?: string; //Date;
-}
-
 const formatTimeSettings: FormatDateOptions = {
     hour: '2-digit',
     minute: '2-digit',
@@ -104,7 +98,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
 
     // Create a dataset
     const scopedDataSet = useMemo(() => {
-        const response: Data[] = stats.map((stat) => {
+        return stats.map((stat) => {
             // Total up docs. Mainly for collections that are derivations
             //  eventually we might split this data up into multiple lines
             const totalDocs = stat.docs_to
@@ -120,8 +114,6 @@ function DataByHourGraph({ range, stats = [] }: Props) {
                 timestamp: stat.ts,
             };
         });
-
-        return response;
     }, [stats]);
 
     // Set the main bulk of the options for the chart
@@ -184,8 +176,7 @@ function DataByHourGraph({ range, stats = [] }: Props) {
             yAxisIndex: 1,
         };
 
-        // TODO (typing) EChartsOption is the type but removed due to it complaining about the dataset typing
-        const option: any = {
+        const option: EChartsOption = {
             animation: false,
             darkMode: theme.palette.mode === 'dark',
             legend: legendConfig,

--- a/src/components/shared/Entity/Details/Usage.tsx
+++ b/src/components/shared/Entity/Details/Usage.tsx
@@ -30,7 +30,11 @@ function Usage({ catalogName }: Props) {
             ) : error ? (
                 <Error error={error} />
             ) : (
-                <DataByHourGraph stats={stats} range={range} />
+                <DataByHourGraph
+                    id="data-by-hour_entity-details"
+                    stats={stats}
+                    range={range}
+                />
             )}
         </CardWrapper>
     );


### PR DESCRIPTION
## Changes

The hourly chart now uses the dataset approach and uses the timestamp the server returns as the main category. It is always stored, sorted, etc. in GMT and only formatted when displayed to the user.

Update the markline label to not clash

## Tests

Tested with timezones in New York, India, Australia

## Issues

Quick fix for https://github.com/estuary/ui/issues/697

## Content

_Were there any changes to [content](https://github.com/estuary/ui/tree/main/src/lang) that you need to get reviewed?_

## Screenshots

We will now display all the data we have. If some is missing nothing will show. This enables us to later more easily add a slider
![image](https://github.com/estuary/ui/assets/270078/3fc70d10-75ea-4a98-8e3f-19bbd9d5c3be)

Full six hours
![image](https://github.com/estuary/ui/assets/270078/5855c4a9-4d9a-4c33-af01-4749602489c5)

Kolkuta, India
![image](https://github.com/estuary/ui/assets/270078/2d1af01b-7b9d-4fca-9918-81c126c57233)

Broken Hill, Australia
![image](https://github.com/estuary/ui/assets/270078/bfdcdee9-1594-4e93-95e4-b02bac1c4a46)


Updated the markline to not clash as bad
![image](https://github.com/estuary/ui/assets/270078/ac42bc53-223f-41ba-a710-f6e1204962f3)

![image](https://github.com/estuary/ui/assets/270078/78b914c9-bed0-4f45-b39f-6c5914499f8a)
