### PR TITLE
Enable schema evolution in materialization edit workflow

### DIFF
--- a/src/components/shared/Entity/Actions/SchemaEvolution.tsx
+++ b/src/components/shared/Entity/Actions/SchemaEvolution.tsx
@@ -18,10 +18,10 @@ import { FormattedMessage } from 'react-intl';
 import { logRocketEvent } from 'services/logrocket';
 import {
     DEFAULT_POLLER_ERROR,
-    jobStatusPoller,
     JOB_STATUS_COLUMNS,
     JOB_STATUS_POLLER_ERROR,
     TABLES,
+    jobStatusPoller,
 } from 'services/supabase';
 import {
     useFormStateStore_isActive,
@@ -154,8 +154,8 @@ function SchemaEvolution({ onFailure }: Props) {
         }
     };
 
-    // Only show in edit mode and for captures
-    if (!editingEntity || entityType !== 'capture') {
+    // Only show in edit mode
+    if (!editingEntity) {
         return null;
     }
     return (

--- a/src/components/shared/Entity/IncompatibleCollections/CollectionsList.tsx
+++ b/src/components/shared/Entity/IncompatibleCollections/CollectionsList.tsx
@@ -66,7 +66,12 @@ function CollectionsList() {
         return {
             val: <CollectionAction incompatibleCollection={ic} />,
             title: (
-                <Typography sx={{ fontWeight: 600 }}>
+                <Typography
+                    sx={{
+                        fontWeight: 500,
+                        color: (theme) => theme.palette.text.secondary,
+                    }}
+                >
                     {ic.collection}
                 </Typography>
             ),

--- a/src/components/shared/Entity/IncompatibleCollections/index.tsx
+++ b/src/components/shared/Entity/IncompatibleCollections/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Collapse, Stack, Typography } from '@mui/material';
+import { Box, Collapse, Divider, Stack, Typography } from '@mui/material';
 import { useBindingsEditorStore_incompatibleCollections } from 'components/editor/Bindings/Store/hooks';
 import AlertBox from 'components/shared/AlertBox';
 import { FormattedMessage } from 'react-intl';
@@ -23,12 +23,17 @@ function IncompatibleCollections() {
                 short
                 severity="warning"
                 title={
-                    <Typography variant="h5" component="span">
+                    <Typography
+                        component="span"
+                        sx={{ fontSize: 18, fontWeight: 500 }}
+                    >
                         <FormattedMessage id="entityEvolution.error.title" />
                     </Typography>
                 }
             >
-                <Stack spacing={2}>
+                <Stack spacing={1}>
+                    <Divider flexItem />
+
                     <Box>
                         <Typography>
                             <FormattedMessage id="entityEvolution.error.message" />


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Display the Apply CTA in the incompatible collections alert (a.k.a., schema evolutions alert) shown in the materialization edit workflow.

1. Update the typographic styling and layout of the incompatible collections alert (a.k.a., schema evolutions alert) so that it aligns with the draft error alert.

## Tests

_Describe the approach to testing._

## Issues

The issues directly below are completely resolved by this PR:
#694

## Screenshots

**Updated Alert Styling**

<img width="1201" alt="updated_schema_evolution_alert" src="https://github.com/estuary/ui/assets/77648584/6fd36b13-a421-4542-b877-d52e4fec9785">
