### PR TITLE
Quick fix for incorrect entity name when pasted in

### DIFF
--- a/src/components/collection/Selector/List.tsx
+++ b/src/components/collection/Selector/List.tsx
@@ -44,7 +44,7 @@ function CollectionSelectorList({
     height,
     renderCell,
 }: Props) {
-    const onSelectTimeOut = useRef<number | null>(null);
+    const hackyTimeout = useRef<number | null>(null);
     const intl = useIntl();
     const collectionsLabel = useConstant(
         () =>
@@ -98,7 +98,7 @@ function CollectionSelectorList({
     ];
 
     useUnmount(() => {
-        if (onSelectTimeOut.current) clearTimeout(onSelectTimeOut.current);
+        if (hackyTimeout.current) clearTimeout(hackyTimeout.current);
     });
 
     return (
@@ -124,11 +124,9 @@ function CollectionSelectorList({
                               //  different binding VERY quickly it could cause the updates
                               //  to go into the wrong form.
                               setCurrentCollection(null);
-                              onSelectTimeOut.current = window.setTimeout(
-                                  () => {
-                                      setCurrentCollection(params.row.name);
-                                  }
-                              );
+                              hackyTimeout.current = window.setTimeout(() => {
+                                  setCurrentCollection(params.row.name);
+                              });
                           }
                         : undefined
                 }

--- a/src/components/collection/Selector/List.tsx
+++ b/src/components/collection/Selector/List.tsx
@@ -118,8 +118,8 @@ function CollectionSelectorList({
                 onRowClick={
                     selectionEnabled
                         ? (params: any) => {
-                              // This is hacky but it works. It clears out the
-                              //  current collection before switching.
+                              // TODO (JSONForms) This is hacky but it works.
+                              // It clears out the current collection before switching.
                               //  If a user is typing quickly in a form and then selects a
                               //  different binding VERY quickly it could cause the updates
                               //  to go into the wrong form.

--- a/src/forms/renderers/CatalogName/index.tsx
+++ b/src/forms/renderers/CatalogName/index.tsx
@@ -35,8 +35,9 @@ import { withJsonFormsOneOfEnumProps } from '@jsonforms/react';
 import PrefixedName from 'components/inputs/PrefixedName';
 import { PrefixedName_Change } from 'components/inputs/PrefixedName/types';
 import { useEntityWorkflow_Editing } from 'context/Workflow';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useIntl } from 'react-intl';
+import { useUnmount } from 'react-use';
 import { useDetailsForm_setCustomErrors } from 'stores/DetailsForm/hooks';
 import { generateCustomError } from 'stores/extensions/CustomErrors';
 
@@ -56,31 +57,44 @@ const CatalogNameTypeRenderer = ({
     uischema,
 }: ControlProps & OwnPropsOfEnum & WithOptionLabel) => {
     const intl = useIntl();
+    const hackyTimeout = useRef<number | null>(null);
 
     const isEdit = useEntityWorkflow_Editing();
     const setCustomErrors = useDetailsForm_setCustomErrors();
 
     const updateFunction = useCallback<PrefixedName_Change>(
         (prefixedName, errorString) => {
-            const customErrors = [];
-
-            // Just replace all specific errors with a simple "invalid" error
-            if (errorString) {
-                customErrors.push(
-                    generateCustomError(
-                        path,
-                        intl.formatMessage({
-                            id: 'entityCreate.endpointConfig.entityNameInvalid',
-                        })
-                    )
-                );
-            }
-
-            setCustomErrors(customErrors);
             handleChange(path, prefixedName);
+
+            // TODO (JSONForms) This is hacky but it works.
+            //  setting custom errors right away can cause re-renders that will
+            //  mess up populating the correct catalog name
+            hackyTimeout.current = window.setTimeout(() => {
+                const customErrors = [];
+
+                // Just replace all specific errors with a simple "invalid" error
+                if (errorString) {
+                    customErrors.push(
+                        generateCustomError(
+                            path,
+                            intl.formatMessage({
+                                id: 'entityCreate.endpointConfig.entityNameInvalid',
+                            })
+                        )
+                    );
+                }
+
+                setCustomErrors(customErrors);
+            });
         },
         [handleChange, intl, path, setCustomErrors]
     );
+
+    useUnmount(() => {
+        if (hackyTimeout.current) {
+            clearTimeout(hackyTimeout.current);
+        }
+    });
 
     return (
         <PrefixedName

--- a/src/forms/renderers/ConnectorSelect/AutoComplete.tsx
+++ b/src/forms/renderers/ConnectorSelect/AutoComplete.tsx
@@ -34,7 +34,7 @@ import {
 import ConnectorInput from 'forms/renderers/ConnectorSelect/Input';
 import ConnectorOption from 'forms/renderers/ConnectorSelect/Option';
 import merge from 'lodash/merge';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 
 export interface WithOptionLabel {
     getOptionLabel?(option: EnumOption): string;
@@ -72,10 +72,13 @@ export const ConnectorAutoComplete = (
 
     const appliedUiSchemaOptions = merge({}, config, uischema.options);
     const [inputValue, setInputValue] = React.useState('');
-    const currentOption =
-        options?.find((option) => {
-            return areOptionsEqual(option.value, data);
-        }) ?? null;
+    const currentOption = useMemo(
+        () =>
+            options?.find((option) => {
+                return areOptionsEqual(option.value, data);
+            }) ?? null,
+        [data, options]
+    );
 
     return (
         <Autocomplete


### PR DESCRIPTION
## Changes

1. Wrap the custom error setting in a timeout. We can properly handle this later. This is the same root issue as the current collection issue. Since we are setting both the name AND custom errors a re-render fires with the custom error setting and that messes up the name setting.

## Tests

Capture create: paste in name, type in name, type and then change name

## Issues

Prod issue reported in Slack

## Content

N/A

## Screenshots

N/A
