### PR TITLE
Expose capture auto discovery settings

### DIFF
--- a/src/components/capture/SchemaEvolution.tsx
+++ b/src/components/capture/SchemaEvolution.tsx
@@ -1,0 +1,138 @@
+import {
+    Checkbox,
+    FormControl,
+    FormControlLabel,
+    Stack,
+    Typography,
+} from '@mui/material';
+import { useEditorStore_queryResponse_draftSpecs } from 'components/editor/Store/hooks';
+import { useEffect, useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+import {
+    useEndpointConfig_addNewBindings,
+    useEndpointConfig_evolveIncompatibleCollections,
+    useEndpointConfig_setAddNewBindings,
+    useEndpointConfig_setEvolveIncompatibleCollections,
+    useEndpointConfig_setServerUpdateRequired,
+} from 'stores/EndpointConfig/hooks';
+import { useFormStateStore_isActive } from 'stores/FormState/hooks';
+
+interface Props {
+    readOnly?: boolean;
+}
+
+function SchemaEvolution({ readOnly }: Props) {
+    // Draft Editor Store
+    const draftSpecs = useEditorStore_queryResponse_draftSpecs();
+
+    // Endpoint Config Store
+    const addNewBindings = useEndpointConfig_addNewBindings();
+    const setAddNewBindings = useEndpointConfig_setAddNewBindings();
+
+    const evolveIncompatibleCollections =
+        useEndpointConfig_evolveIncompatibleCollections();
+    const setEvolveIncompatibleCollections =
+        useEndpointConfig_setEvolveIncompatibleCollections();
+
+    const setServerUpdateRequired = useEndpointConfig_setServerUpdateRequired();
+
+    // Form State Store
+    const formActive = useFormStateStore_isActive();
+
+    // Controlling if we need to show the generate button again
+    const schemaEvolutionSettingsUpdated = useMemo(() => {
+        if (draftSpecs.length > 0) {
+            if (Object.hasOwn(draftSpecs[0].spec, 'autoDiscover')) {
+                const schemaEvolutionSettings = draftSpecs[0].spec.autoDiscover;
+
+                const newBindingSettingExists = Object.hasOwn(
+                    schemaEvolutionSettings,
+                    'addNewBindings'
+                );
+
+                const evolutionSettingExists = Object.hasOwn(
+                    schemaEvolutionSettings,
+                    'evolveIncompatibleCollections'
+                );
+
+                if (newBindingSettingExists && !evolutionSettingExists) {
+                    return (
+                        schemaEvolutionSettings.addNewBindings !==
+                        addNewBindings
+                    );
+                } else if (evolutionSettingExists && !newBindingSettingExists) {
+                    return (
+                        schemaEvolutionSettings.evolveIncompatibleCollections !==
+                        evolveIncompatibleCollections
+                    );
+                } else if (newBindingSettingExists && evolutionSettingExists) {
+                    return (
+                        schemaEvolutionSettings.addNewBindings !==
+                            addNewBindings ||
+                        schemaEvolutionSettings.evolveIncompatibleCollections !==
+                            evolveIncompatibleCollections
+                    );
+                }
+
+                return addNewBindings || evolveIncompatibleCollections;
+            } else {
+                return addNewBindings || evolveIncompatibleCollections;
+            }
+        } else {
+            return false;
+        }
+    }, [addNewBindings, draftSpecs, evolveIncompatibleCollections]);
+
+    useEffect(() => {
+        setServerUpdateRequired(schemaEvolutionSettingsUpdated);
+    }, [setServerUpdateRequired, schemaEvolutionSettingsUpdated]);
+
+    return (
+        <Stack sx={{ mt: 3 }}>
+            <Typography sx={{ mb: 1, fontWeight: 500 }}>
+                <FormattedMessage id="workflows.schemaEvolution.header" />
+            </Typography>
+
+            <FormControl>
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            value={addNewBindings}
+                            checked={addNewBindings}
+                            disabled={readOnly ?? formActive}
+                            onChange={(_event, checked) => {
+                                setAddNewBindings(checked);
+                            }}
+                        />
+                    }
+                    label={
+                        <FormattedMessage id="workflows.schemaEvolution.label.addNewBindings" />
+                    }
+                />
+            </FormControl>
+
+            {addNewBindings ? (
+                <FormControl>
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                value={evolveIncompatibleCollections}
+                                checked={evolveIncompatibleCollections}
+                                disabled={readOnly ?? formActive}
+                                onChange={(_event, checked) => {
+                                    setEvolveIncompatibleCollections(checked);
+                                }}
+                            />
+                        }
+                        label={
+                            <FormattedMessage id="workflows.schemaEvolution.label.evolveIncompatibleCollection" />
+                        }
+                        sx={{ ml: 2 }}
+                    />
+                </FormControl>
+            ) : null}
+        </Stack>
+    );
+}
+
+export default SchemaEvolution;

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -34,6 +34,8 @@ import {
     useDetailsForm_setDraftedEntityName,
 } from 'stores/DetailsForm/hooks';
 import {
+    useEndpointConfig_addNewBindings,
+    useEndpointConfig_evolveIncompatibleCollections,
     useEndpointConfig_serverUpdateRequired,
     useEndpointConfigStore_encryptedEndpointConfig_data,
     useEndpointConfigStore_endpointConfig_data,
@@ -52,7 +54,7 @@ import {
     useResourceConfig_resourceConfig,
     useResourceConfig_resourceConfigErrorsExist,
 } from 'stores/ResourceConfig/hooks';
-import { Entity } from 'types';
+import { Entity, SchemaEvolutionSettings } from 'types';
 import { encryptEndpointConfig } from 'utils/sops-utils';
 import { modifyExistingCaptureDraftSpec } from 'utils/workflow-utils';
 
@@ -108,6 +110,9 @@ function useDiscoverCapture(
     const serverUpdateRequired = useEndpointConfig_serverUpdateRequired();
     const setPreviousEndpointConfig =
         useEndpointConfigStore_setPreviousEndpointConfig();
+    const addNewBindings = useEndpointConfig_addNewBindings();
+    const evolveIncompatibleCollections =
+        useEndpointConfig_evolveIncompatibleCollections();
 
     // Resource Config Store
     const resourceConfig = useResourceConfig_resourceConfig();
@@ -307,13 +312,21 @@ function useDiscoverCapture(
                             ? existingDraftSpecResponse.data[0]
                             : null;
 
+                    const schemaEvolutionSettings:
+                        | SchemaEvolutionSettings
+                        | undefined =
+                        entityType === 'capture'
+                            ? { addNewBindings, evolveIncompatibleCollections }
+                            : undefined;
+
                     const draftSpecsResponse =
                         await modifyExistingCaptureDraftSpec(
                             persistedDraftId,
                             imagePath,
                             encryptedEndpointConfig.data,
                             resourceConfig,
-                            existingTaskData
+                            existingTaskData,
+                            schemaEvolutionSettings
                         );
 
                     if (draftSpecsResponse.error) {
@@ -373,6 +386,9 @@ function useDiscoverCapture(
             setPreviousEndpointConfig,
             setDraftId,
             postGenerateMutate,
+            addNewBindings,
+            evolveIncompatibleCollections,
+            entityType,
         ]
     );
 

--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -1,4 +1,5 @@
 import { Box, useTheme } from '@mui/material';
+import SchemaEvolution from 'components/capture/SchemaEvolution';
 import { useEditorStore_id } from 'components/editor/Store/hooks';
 import AlertBox from 'components/shared/AlertBox';
 import EndpointConfigForm from 'components/shared/Entity/EndpointConfig/Form';
@@ -196,6 +197,8 @@ function EndpointConfig({
                     ) : null}
 
                     <EndpointConfigForm readOnly={readOnly} />
+
+                    <SchemaEvolution />
                 </ErrorBoundryWrapper>
             </WrapperWithHeader>
         );

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -897,6 +897,10 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.collectionSelector.schemaInference.alert.patchService.message.docLink': `contact support`,
     'workflows.collectionSelector.schemaInference.alert.patchService.message.docPath': `mailto:support@estuary.dev`,
     'workflows.collectionSelector.schemaInference.cta.continue': `Apply Inferred Schema`,
+
+    'workflows.schemaEvolution.header': `Schema Evolution`,
+    'workflows.schemaEvolution.label.addNewBindings': `Update collection schema as source changes`,
+    'workflows.schemaEvolution.label.evolveIncompatibleCollection': `Include breaking changes (will cause reversion and backfill)`,
 };
 
 const ShardStatus: ResolvedIntlConfig['messages'] = {

--- a/src/stores/EndpointConfig/hooks.ts
+++ b/src/stores/EndpointConfig/hooks.ts
@@ -218,3 +218,42 @@ export const useEndpointConfig_setEndpointCanBeEmpty = () => {
         EndpointConfigState['setEndpointCanBeEmpty']
     >(getStoreName(entityType), (state) => state.setEndpointCanBeEmpty);
 };
+
+export const useEndpointConfig_addNewBindings = () => {
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        EndpointConfigState,
+        EndpointConfigState['addNewBindings']
+    >(getStoreName(entityType), (state) => state.addNewBindings);
+};
+
+export const useEndpointConfig_setAddNewBindings = () => {
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        EndpointConfigState,
+        EndpointConfigState['setAddNewBindings']
+    >(getStoreName(entityType), (state) => state.setAddNewBindings);
+};
+
+export const useEndpointConfig_evolveIncompatibleCollections = () => {
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        EndpointConfigState,
+        EndpointConfigState['evolveIncompatibleCollections']
+    >(getStoreName(entityType), (state) => state.evolveIncompatibleCollections);
+};
+
+export const useEndpointConfig_setEvolveIncompatibleCollections = () => {
+    const entityType = useEntityType();
+
+    return useZustandStore<
+        EndpointConfigState,
+        EndpointConfigState['setEvolveIncompatibleCollections']
+    >(
+        getStoreName(entityType),
+        (state) => state.setEvolveIncompatibleCollections
+    );
+};

--- a/src/stores/EndpointConfig/types.ts
+++ b/src/stores/EndpointConfig/types.ts
@@ -50,6 +50,15 @@ export interface EndpointConfigState
         workflow: EntityWorkflow | null
     ) => Promise<void>;
 
+    // Schema Evolution
+    addNewBindings: boolean;
+    setAddNewBindings: (value: EndpointConfigState['addNewBindings']) => void;
+
+    evolveIncompatibleCollections: boolean;
+    setEvolveIncompatibleCollections: (
+        value: EndpointConfigState['evolveIncompatibleCollections']
+    ) => void;
+
     // Misc.
     stateChanged: () => boolean;
     resetState: () => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -327,3 +327,8 @@ export interface InferSchemaPropertyForRender
     extends InferSchemaResponseProperty {
     allowedToBeKey: boolean;
 }
+
+export interface SchemaEvolutionSettings {
+    addNewBindings: boolean;
+    evolveIncompatibleCollections: boolean;
+}


### PR DESCRIPTION
## Changes

The following features are included in this PR:

1. Allow the `autoDiscover` property of a capture specification to be set in the _Endpoint Config_ section of capture workflows.

## Tests

_Describe the approach to testing._

## Issues

_Please list out any related issues (Here so issue is not auto closed by PR)_

## Content

_Were there any changes to [content](https://github.com/estuary/ui/tree/main/src/lang) that you need to get reviewed?_

## Screenshots

_If applicable - please include some screenshots of the new UI_
