### PR TITLE
Update materialization field selection link to documentation

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -254,7 +254,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
                             <FormattedMessage id="fieldSelection.header" />
                         </Typography>
 
-                        <ExternalLink link="https://docs.estuary.dev/concepts/materialization/#projected-fields">
+                        <ExternalLink link="https://docs.estuary.dev/guides/customize-materialization-fields/">
                             <FormattedMessage id="terms.documentation" />
                         </ExternalLink>
                     </Stack>


### PR DESCRIPTION
## Changes

Update the link to documentation in the _Field Selection_ section of materialization workflows.

## Tests

Approaches to testing are as follows:

* Click the _Docs_ button in the _Field Selection_ section of the materialization create workflow and confirm that it opens the desired URL in a new tab.

* Click the _Docs_ button in the _Field Selection_ section of the materialization edit workflow and confirm that it opens the desired URL in a new tab.

## Issues

The issues directly below are completely resolved by this PR:
#717 