### PR TITLE
Display complete billing history for all tenants in table

### DIFF
--- a/src/components/tables/Billing/Rows.tsx
+++ b/src/components/tables/Billing/Rows.tsx
@@ -3,6 +3,7 @@ import { BillingRecord } from 'api/billing';
 import DataVolume from 'components/tables/cells/billing/DataVolume';
 import TimeStamp from 'components/tables/cells/billing/TimeStamp';
 import MonetaryValue from 'components/tables/cells/MonetaryValue';
+import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 interface RowProps {
@@ -36,14 +37,20 @@ function Row({ row }: RowProps) {
 
 // TODO (billing): Remove pagination placeholder when the new RPC is available.
 function Rows({ data }: RowsProps) {
+    // The table should only show the four, most recent months of billing history.
+    // If the user has accrued more than four months worth of billing data, truncate
+    // the data.
+    const processedData = useMemo(
+        () =>
+            data.length > 4 ? data.slice(data.length - 4, data.length) : data,
+        [data]
+    );
+
     return (
         <>
-            {data
-                .slice(data.length - 4, data.length)
-                .reverse()
-                .map((record, index) => (
-                    <Row row={record} key={index} />
-                ))}
+            {[...processedData].reverse().map((record, index) => (
+                <Row row={record} key={index} />
+            ))}
         </>
     );
 }

--- a/src/components/tables/Billing/Rows.tsx
+++ b/src/components/tables/Billing/Rows.tsx
@@ -38,19 +38,21 @@ function Row({ row }: RowProps) {
 // TODO (billing): Remove pagination placeholder when the new RPC is available.
 function Rows({ data }: RowsProps) {
     // The table should only show the four, most recent months of billing history.
-    // If the user has accrued more than four months worth of billing data, truncate
-    // the data.
-    const processedData = useMemo(
-        () =>
-            data.length > 4 ? data.slice(data.length - 4, data.length) : data,
-        [data]
+    // If the user has accrued more than four months worth of billing data, calculate
+    // the adjusted start index.
+    const startIndex = useMemo(
+        () => (data.length > 4 ? data.length - 4 : 0),
+        [data.length]
     );
 
     return (
         <>
-            {[...processedData].reverse().map((record, index) => (
-                <Row row={record} key={index} />
-            ))}
+            {data
+                .slice(startIndex, data.length)
+                .reverse()
+                .map((record, index) => (
+                    <Row row={record} key={index} />
+                ))}
         </>
     );
 }


### PR DESCRIPTION
## Changes

The billing history table on the _Billing_ page should display the four, most recent billing records. This PR corrects the defect preventing tenants that have existed for less than four billing cycles from seeing all available records reflected in the table.

## Tests

Approaches to testing are as follows:

1. Validate that all available billing records appear on the billing history table for an account that has existed for less than four billing cycles.

1. Validate that all available billing records appear on the billing history table for an account that has existed for four billing cycles.

1. Validate that all available billing records appear on the billing history table for an account that has existed for more than four billing cycles.

## Issues

_Please list out any related issues (Here so issue is not auto closed by PR)_
