### PR TITLE
prod: update draft ID fallback chain in editor store hydrator

### DIFF
--- a/src/components/editor/Store/hooks.ts
+++ b/src/components/editor/Store/hooks.ts
@@ -519,13 +519,22 @@ export const useHydrateEditorState = (
 ) => {
     const draftIdInURL = useGlobalSearchParams(GlobalSearchParams.DRAFT_ID);
 
-    const draftId = useEditorStore_persistedDraftId({ localScope });
+    const draftId = useEditorStore_id({ localScope });
+    const persistedDraftId = useEditorStore_persistedDraftId({ localScope });
     const setQueryResponse = useEditorStore_setQueryResponse({ localScope });
 
-    const response = useDraftSpecs(draftId ?? draftIdInURL, {
-        specType,
-        catalogName,
-    });
+    // This fallback chain of draft IDs is required because of how the global editor store
+    // differs in keeping record of the draft ID from its local counterpart. Notable component
+    // call-outs include: the collection tab of the binding selector relies on the draft ID
+    // stored in the 'id' property of the local editor store state; the capture auto-discovery settings
+    // rely on the draft ID stored in the 'persistedDraftId' property of the global editor store state.
+    const response = useDraftSpecs(
+        draftId ?? persistedDraftId ?? draftIdInURL,
+        {
+            specType,
+            catalogName,
+        }
+    );
 
     useEffect(() => {
         if (!response.isValidating) {


### PR DESCRIPTION
## Changes

Update the draft ID fallback chain in the editor store hydrator to increase the likelihood that a defined draft ID is selected from the state.

## Tests

_Describe the approach to testing._

## Screenshots

**Capture Create**

<img width="1083" alt="pr_screenshot-725-draft_ID_fallback_chain-capture_create" src="https://github.com/estuary/ui/assets/77648584/99d0755b-37da-4900-b5ac-8a307f520d12">

<br />
<br />

**Materialization Create**

<img width="1083" alt="pr_screenshot-725-draft_ID_fallback_chain-materialization_create" src="https://github.com/estuary/ui/assets/77648584/5f59bba6-fcaf-4a44-af92-63229707a1ca">
