### PR TITLE
New bindings editor: UX 1

### DIFF
--- a/src/components/collection/Selector/Table/Hydrator.tsx
+++ b/src/components/collection/Selector/Table/Hydrator.tsx
@@ -10,25 +10,10 @@ import TableHydrator from 'stores/Tables/Hydrator';
 import { MAX_BINDINGS } from 'utils/workflow-utils';
 import { useStore } from 'zustand';
 import Rows from './Rows';
+import { catalogNameColumn, publishedColumn, tableColumns } from './shared';
 
 const selectableTableStoreName = SelectTableStoreNames.COLLECTION_SELECTOR;
 const tableRowsPerPage = [10, 50, 100, MAX_BINDINGS];
-const catalogNameColumn = 'catalog_name';
-const publishedColumn = 'updated_at';
-export const tableColumns = [
-    {
-        field: null,
-        headerIntlKey: '',
-    },
-    {
-        field: catalogNameColumn,
-        headerIntlKey: 'entityTable.data.userFullName',
-    },
-    {
-        field: publishedColumn,
-        headerIntlKey: 'entityTable.data.lastPublished',
-    },
-];
 
 interface Props {
     selectedCollections: string[];

--- a/src/components/collection/Selector/Table/Hydrator.tsx
+++ b/src/components/collection/Selector/Table/Hydrator.tsx
@@ -14,6 +14,7 @@ import Rows from './Rows';
 const selectableTableStoreName = SelectTableStoreNames.COLLECTION_SELECTOR;
 const tableRowsPerPage = [10, 50, 100, MAX_BINDINGS];
 const catalogNameColumn = 'catalog_name';
+const publishedColumn = 'updated_at';
 export const tableColumns = [
     {
         field: null,
@@ -24,7 +25,7 @@ export const tableColumns = [
         headerIntlKey: 'entityTable.data.userFullName',
     },
     {
-        field: 'updated_at',
+        field: publishedColumn,
         headerIntlKey: 'entityTable.data.lastPublished',
     },
 ];
@@ -46,7 +47,7 @@ function Hydrator({ selectedCollections }: Props) {
         setSortDirection,
         columnToSort,
         setColumnToSort,
-    } = useTableState('csl', catalogNameColumn, 'desc', tableRowsPerPage[0]);
+    } = useTableState('csl', publishedColumn, 'desc', tableRowsPerPage[0]);
 
     const query = useMemo(() => {
         return getLiveSpecs_collectionsSelector(pagination, searchQuery, [

--- a/src/components/collection/Selector/Table/Rows.tsx
+++ b/src/components/collection/Selector/Table/Rows.tsx
@@ -48,7 +48,13 @@ function Row({ row, setRow }: RowProps) {
                 isSelected={isSelected}
                 name={row.catalog_name}
             />
-            <TableCell>{row.catalog_name}</TableCell>
+            <TableCell
+                sx={{
+                    wordBreak: 'break-all',
+                }}
+            >
+                {row.catalog_name}
+            </TableCell>
             <TimeStamp time={row.updated_at} />
         </TableRow>
     );

--- a/src/components/collection/Selector/Table/Rows.tsx
+++ b/src/components/collection/Selector/Table/Rows.tsx
@@ -5,6 +5,7 @@ import { getEntityTableRowSx } from 'context/Theme';
 import invariableStores from 'context/Zustand/invariableStores';
 
 import { useStore } from 'zustand';
+import { catalogNameColumn, publishedColumn } from './shared';
 
 interface RowProps {
     row: any;
@@ -21,7 +22,7 @@ function Row({ row, setRow }: RowProps) {
     const disabled = useStore(
         invariableStores['Collections-Selector-Table'],
         (state) => {
-            return state.disabledRows.includes(row.catalog_name);
+            return state.disabledRows.includes(row[catalogNameColumn]);
         }
     );
 
@@ -39,23 +40,23 @@ function Row({ row, setRow }: RowProps) {
             onClick={
                 disabled
                     ? undefined
-                    : () => setRow(row.id, row.catalog_name, !isSelected)
+                    : () => setRow(row.id, row[catalogNameColumn], !isSelected)
             }
             sx={getEntityTableRowSx(theme, disabled)}
         >
             <RowSelect
                 disabled={disabled}
                 isSelected={isSelected}
-                name={row.catalog_name}
+                name={row[catalogNameColumn]}
             />
             <TableCell
                 sx={{
                     wordBreak: 'break-all',
                 }}
             >
-                {row.catalog_name}
+                {row[catalogNameColumn]}
             </TableCell>
-            <TimeStamp time={row.updated_at} />
+            <TimeStamp time={row[publishedColumn]} />
         </TableRow>
     );
 }

--- a/src/components/collection/Selector/Table/shared.ts
+++ b/src/components/collection/Selector/Table/shared.ts
@@ -1,0 +1,16 @@
+export const catalogNameColumn = 'catalog_name';
+export const publishedColumn = 'updated_at';
+export const tableColumns = [
+    {
+        field: null,
+        headerIntlKey: '',
+    },
+    {
+        field: catalogNameColumn,
+        headerIntlKey: 'entityTable.data.userFullName',
+    },
+    {
+        field: publishedColumn,
+        headerIntlKey: 'entityTable.data.lastPublished',
+    },
+];


### PR DESCRIPTION
## Changes

1. Sort the collections by published date like we do today
2. Wrap the entity names so the table does not scroll

## Tests

Manually tested materialization create

## Issues

Noticed during production validation

## Content

N/A

## Screenshots

Default table state when an entity name is long
![image](https://github.com/estuary/ui/assets/270078/50b8b9e0-fdec-457a-be14-e4bbea7ea4ea)

Default table state when all entity names are short
![image](https://github.com/estuary/ui/assets/270078/771477bd-9134-423f-9fdb-7fb818f38d48)

