### PR TITLE
feature: Fetch billing historicals and display them on the billing page

### DIFF
--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -69,6 +69,16 @@ export interface BillingRecord {
     subtotal: number;
 }
 
+const billingHistoricalQuery = [
+    'billed_prefix:tenant',
+    'billed_month',
+    'report->processed_data_gb',
+    'report->recurring_fee',
+    'report->task_usage_hours',
+    'report->line_items',
+    'report->subtotal',
+].join(', ');
+
 export const getBillingRecord = (
     billed_prefix: string,
     month: string | Date
@@ -86,17 +96,7 @@ export const getBillingRecord = (
     ) {
         return supabaseClient
             .from<BillingRecord>(TABLES.BILLING_HISTORICALS)
-            .select(
-                [
-                    'billed_prefix:tenant',
-                    'billed_month',
-                    'report->processed_data_gb',
-                    'report->recurring_fee',
-                    'report->task_usage_hours',
-                    'report->line_items',
-                    'report->subtotal',
-                ].join(', ')
-            )
+            .select(billingHistoricalQuery)
             .filter('tenant', 'eq', billed_prefix)
             .filter('billed_month', 'eq', formattedMonth)
             .throwOnError()
@@ -118,6 +118,8 @@ function isSingleResponse<T>(
     return arg.body !== null;
 }
 
+// TODO (billing) need to make this so it does not cause multipl calls
+//  and instead just builds up a single query that matches all months
 export const getBillingHistory = async (
     tenant: string,
     dateRange: string[]

--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -56,6 +56,10 @@ interface InvoiceLineItem {
 }
 
 export interface BillingRecord {
+    // In `billing_historicals` this is called tenant
+    // and so needs to be included here in order to
+    // filter by tenant
+    tenant?: string;
     billed_prefix: string;
     billed_month: string; // Timestamp
     processed_data_gb: number | null;
@@ -84,7 +88,7 @@ export const getBillingRecord = (
             .from<BillingRecord>(TABLES.BILLING_HISTORICALS)
             .select(
                 [
-                    'billed_prefix',
+                    'billed_prefix:tenant',
                     'billed_month',
                     'report->processed_data_gb',
                     'report->recurring_fee',
@@ -93,7 +97,7 @@ export const getBillingRecord = (
                     'report->subtotal',
                 ].join(', ')
             )
-            .filter('billed_prefix', 'eq', billed_prefix)
+            .filter('tenant', 'eq', billed_prefix)
             .filter('billed_month', 'eq', formattedMonth)
             .throwOnError()
             .maybeSingle();

--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -1,10 +1,14 @@
-import { PostgrestSingleResponse } from '@supabase/postgrest-js';
-import { format } from 'date-fns';
+import {
+    PostgrestMaybeSingleResponse,
+    PostgrestSingleResponse,
+} from '@supabase/postgrest-js';
+import { format, isBefore, parse, startOfMonth } from 'date-fns';
 import {
     FUNCTIONS,
     invokeSupabase,
     RPCS,
     supabaseClient,
+    TABLES,
 } from 'services/supabase';
 
 const OPERATIONS = {
@@ -51,9 +55,7 @@ interface InvoiceLineItem {
     subtotal: number;
 }
 
-export interface BillingRecord {
-    billed_prefix: string;
-    billed_month: string; // Timestamp
+export interface BillingReport {
     processed_data_gb: number | null;
     recurring_fee: number;
     task_usage_hours: number | null;
@@ -61,32 +63,102 @@ export interface BillingRecord {
     subtotal: number;
 }
 
+export interface BillingHistoricals {
+    billed_prefix: string;
+    billed_month: string; // Timestamp
+    report: BillingReport;
+}
+
+export interface BillingRecord extends BillingReport {
+    billed_prefix: string;
+    billed_month: string; // Timestamp
+}
+
 export const getBillingRecord = (
     billed_prefix: string,
     month: string | Date
-) => {
+): PromiseLike<PostgrestMaybeSingleResponse<BillingRecord>> => {
+    const fmt = "yyyy-MM-dd' 00:00:00+00'";
     const formattedMonth: string =
-        typeof month === 'string'
-            ? month
-            : format(month, "yyyy-MM-dd' 00:00:00+00'");
+        typeof month === 'string' ? month : format(month, fmt);
 
-    return supabaseClient
-        .rpc<BillingRecord>(RPCS.BILLING_REPORT, {
-            billed_prefix,
-            billed_month: formattedMonth,
-        })
-        .throwOnError()
-        .single();
+    // If we're asking for a previous month, look up billing_historicals
+    if (
+        isBefore(
+            startOfMonth(parse(formattedMonth, fmt, new Date())),
+            startOfMonth(new Date())
+        )
+    ) {
+        const req = supabaseClient
+            .from<BillingHistoricals>(TABLES.BILLING_HISTORICALS)
+            .select('billed_prefix, billed_month, report')
+            .filter('billed_prefix', 'eq', billed_prefix)
+            .filter('billed_month', 'eq', formattedMonth);
+
+        const url = (req as any).url;
+
+        const prom: PromiseLike<PostgrestMaybeSingleResponse<BillingRecord>> =
+            req.then((response) => {
+                if (response.body && response.body.length > 0) {
+                    if (response.body.length > 1) {
+                        throw new Error(
+                            `Found multiple billing historical records where at most one was expected. prefix: ${billed_prefix}, month: ${formattedMonth}`
+                        );
+                    }
+                    const modified_body: BillingRecord = {
+                        billed_month: response.body[0].billed_month,
+                        billed_prefix: response.body[0].billed_prefix,
+                        ...response.body[0].report,
+                    };
+                    return {
+                        ...response,
+                        body: modified_body,
+                        data: modified_body,
+                        url,
+                    };
+                } else {
+                    return {
+                        ...response,
+                        body: null,
+                        data: null,
+                        url,
+                    };
+                }
+            });
+
+        // Hack alert: `useSelectNew` actually expects to be passed a
+        // PostgrestFilterBuilder which has a protected `url: URL` field
+        // which `useSelectNew` uses as the key for SWR purposes. If we `.map()`
+        // the promise-like object returned by the Supabase SDK, we lose that
+        // hidden URL field in the process, breaking SWR.
+        // So... for the moment, this hacks it back into existence.
+        (prom as any).url = url;
+        return prom;
+    } else {
+        return supabaseClient
+            .rpc<BillingRecord>(RPCS.BILLING_REPORT, {
+                billed_prefix,
+                billed_month: formattedMonth,
+            })
+            .throwOnError()
+            .single();
+    }
 };
+
+function isSingleResponse<T>(
+    arg: PostgrestMaybeSingleResponse<T>
+): arg is PostgrestSingleResponse<T> {
+    return arg.body !== null;
+}
 
 export const getBillingHistory = async (
     tenant: string,
     dateRange: string[]
 ): Promise<PostgrestSingleResponse<BillingRecord>[]> => {
-    const promises: PromiseLike<PostgrestSingleResponse<BillingRecord>>[] =
+    const promises: PromiseLike<PostgrestMaybeSingleResponse<BillingRecord>>[] =
         dateRange.map((date) => getBillingRecord(tenant, date));
 
-    const res = await Promise.all(promises);
+    const resolved = await Promise.all(promises);
 
-    return res;
+    return resolved.filter(isSingleResponse);
 };

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1,5 +1,5 @@
 import { PostgrestError, PostgrestFilterBuilder } from '@supabase/postgrest-js';
-import { User, createClient } from '@supabase/supabase-js';
+import { createClient, User } from '@supabase/supabase-js';
 import { ToPostgrestFilterBuilder } from 'hooks/supabase-swr';
 import { forEach, isEmpty } from 'lodash';
 import LogRocket from 'logrocket';
@@ -36,6 +36,7 @@ export const DEFAULT_FILTER = '__unknown__';
 
 export enum TABLES {
     APPLIED_DIRECTIVES = 'applied_directives',
+    BILLING_HISTORICALS = 'billing_historicals',
     CATALOG_STATS = 'catalog_stats',
     COMBINED_GRANTS_EXT = 'combined_grants_ext',
     CONNECTOR_TAGS = 'connector_tags',


### PR DESCRIPTION
## Changes

Transparently pull data from the new [`billing_historicals` table](https://github.com/estuary/flow/pull/1163) when fetching billing data for previous months. One interesting side-effect is that the data for the graphs of `Data Volume by Month` and `Task Hours by Month` will also be frozen and fetched from `billing_historicals`. I... think this is fine, just observing that it'll become possible to manually edit those values for prior months. We probably shouldn't do that though?

We also decided to not implement the ability to view line-items in the UI yet, as it's entirely possible/likely that until we finish cleaning up this data, line-items from prior months may still be wrong, even if the total cost is correct.

## Screenshots
August is "live" data, June and July are `billing_historicals`

![Screen Shot 2023-08-28 at 16 48 10](https://github.com/estuary/ui/assets/4368270/aad15a62-656f-42b9-a61f-14982766dba9)

![Screen Shot 2023-08-28 at 16 52 43](https://github.com/estuary/ui/assets/4368270/5d284a1c-62e1-49be-ad89-7f18d5fddab6)


**Note:**
Do not merge before https://github.com/estuary/flow/pull/1163 is live.