### PR TITLE
Start getting LogRocket ready for proxy use

### DIFF
--- a/.env
+++ b/.env
@@ -30,7 +30,8 @@ REACT_APP_OSANO_HIDE_WIDGET_CLASS=estuary-logged-in
 
 # LogRocket settings
 # If this is not set then it defaults to the normal Log Rocket URL
-# REACT_APP_LOGROCKET_SERVER_URL=https://???????.estuary.dev
+# REACT_APP_LOGROCKET_CDN_URL=https://sessions.estuary.dev/cdn
+# REACT_APP_LOGROCKET_SERVER_URL=https://sessions.estuary.dev/ingest
 REACT_APP_LOGROCKET_ENABLED=true
 REACT_APP_LOGROCKET_APP_ID=tue20y/estuarytest
 REACT_APP_LOGROCKET_SANITIZE_REQUESTS=true

--- a/.env
+++ b/.env
@@ -29,6 +29,9 @@ REACT_APP_OSANO_PATH=https://cmp.osano.com/16CPXbTOi1sXx4D3/aaa8ccd6-4dbe-43d2-b
 REACT_APP_OSANO_HIDE_WIDGET_CLASS=estuary-logged-in
 
 # LogRocket settings
+# If this is not set then it defaults to the normal Log Rocket URL
+# REACT_APP_LOGROCKET_SERVER_URL=https://???????.estuary.dev
+REACT_APP_LOGROCKET_ENABLED=true
 REACT_APP_LOGROCKET_APP_ID=tue20y/estuarytest
 REACT_APP_LOGROCKET_SANITIZE_REQUESTS=true
 REACT_APP_LOGROCKET_SANITIZE_RESPONSES=true

--- a/.env.development.local
+++ b/.env.development.local
@@ -22,7 +22,12 @@ REACT_APP_ENCRYPTION_URL=http://localhost:8765/v1/encrypt-config
 # Osano setting blank to turn it off for locals
 REACT_APP_OSANO_PATH=
 
+# LogRocket settings
+# If you enable this your setting local data will go to production LogRocket
+REACT_APP_LOGROCKET_ENABLED=false
+
 REACT_APP_DOCS_ORIGIN=http://localhost:3001
+
 # If you want to run like in prod you'll need this line as well as update the doc url in your DB
 #REACT_APP_DOCS_IFRAME_STRING_INCLUDE=localhost
 

--- a/public/index.html
+++ b/public/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
     <head>
         <% if ( process.env.REACT_APP_LOGROCKET_ENABLED &&
-        process.env.REACT_APP_LOGROCKET_SERVER_URL) { %>
+        process.env.REACT_APP_LOGROCKET_CDN_URL) { %>
         <!-- Need to set this !BEFORE! any loading of scripts is started -->
         <script>
-            window._lrAsyncScript = '%REACT_APP_LOGROCKET_SERVER_URL%';
+            window._lrAsyncScript = '%REACT_APP_LOGROCKET_CDN_URL%';
         </script>
         <% } %> <% if ( process.env.REACT_APP_OSANO_PATH) { %>
         <!-- Make sure this loads quick -->

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
-        <% if ( process.env.REACT_APP_OSANO_PATH) { %>
+        <% if ( process.env.REACT_APP_LOGROCKET_ENABLED &&
+        process.env.REACT_APP_LOGROCKET_SERVER_URL) { %>
+        <!-- Need to set this !BEFORE! any loading of scripts is started -->
+        <script>
+            window._lrAsyncScript = '%REACT_APP_LOGROCKET_SERVER_URL%';
+        </script>
+        <% } %> <% if ( process.env.REACT_APP_OSANO_PATH) { %>
         <!-- Make sure this loads quick -->
         <script src="%REACT_APP_OSANO_PATH%"></script>
 

--- a/src/services/logrocket.ts
+++ b/src/services/logrocket.ts
@@ -4,11 +4,7 @@ import { isEmpty } from 'lodash';
 import LogRocket from 'logrocket';
 import setupLogRocketReact from 'logrocket-react';
 import { getUserDetails } from 'services/supabase';
-import {
-    getAppVersion,
-    getLogRocketSettings,
-    isProduction,
-} from 'utils/env-utils';
+import { getAppVersion, getLogRocketSettings } from 'utils/env-utils';
 
 // Based on node_modules/logrocket/dist/types.d.ts
 interface IUserTraits {
@@ -20,6 +16,7 @@ interface Settings {
     release: any;
     dom: any;
     network?: any;
+    serverURL?: any;
 }
 
 type ParsedBody = [{ [k: string]: any }] | { [k: string]: any } | undefined;
@@ -170,7 +167,7 @@ const maskContent = (requestResponse: any) => {
 // More info about the dom settings
 //  https://docs.logrocket.com/reference/dom
 export const initLogRocket = () => {
-    if (isProduction && logRocketSettings.appID) {
+    if (logRocketSettings?.appID) {
         const settings: Settings = {
             release: getAppVersion(),
             dom: {
@@ -178,6 +175,10 @@ export const initLogRocket = () => {
                 textSanitizer: logRocketSettings.sanitize.text,
             },
         };
+
+        if (logRocketSettings.serverURL) {
+            settings.serverURL = logRocketSettings.serverURL;
+        }
 
         if (
             logRocketSettings.sanitize.response ||
@@ -203,11 +204,7 @@ export const initLogRocket = () => {
 };
 
 export const identifyUser = (user: User) => {
-    if (
-        isProduction &&
-        logRocketSettings.idUser.enabled &&
-        logRocketSettings.appID
-    ) {
+    if (logRocketSettings?.idUser.enabled && logRocketSettings.appID) {
         const traits = {} as IUserTraits;
         const userDetails = getUserDetails(user);
 

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -64,6 +64,7 @@ export const getUrls = () => {
 
 type Settings = {
     appID: string | null;
+    serverURL: string | null;
     idUser: {
         enabled: boolean;
         includeName: boolean;
@@ -76,29 +77,35 @@ type Settings = {
         text: boolean;
     };
 };
-export const getLogRocketSettings = (): Settings => {
-    const settings: Settings = {
-        appID: process.env.REACT_APP_LOGROCKET_APP_ID ?? null,
-        idUser: {
-            enabled: process.env.REACT_APP_LOGROCKET_ID_USER === ENABLED,
-            includeName:
-                process.env.REACT_APP_LOGROCKET_ID_USER_INCLUDE_NAME ===
-                ENABLED,
-            includeEmail:
-                process.env.REACT_APP_LOGROCKET_ID_USER_INCLUDE_EMAIL ===
-                ENABLED,
-        },
-        sanitize: {
-            inputs: process.env.REACT_APP_LOGROCKET_SANITIZE_INPUTS === ENABLED,
-            request:
-                process.env.REACT_APP_LOGROCKET_SANITIZE_REQUESTS === ENABLED,
-            response:
-                process.env.REACT_APP_LOGROCKET_SANITIZE_RESPONSES === ENABLED,
-            text: process.env.REACT_APP_LOGROCKET_SANITIZE_TEXT === ENABLED,
-        },
-    };
+export const getLogRocketSettings = (): Settings | null => {
+    if (process.env.REACT_APP_LOGROCKET_ENABLED === ENABLED) {
+        return {
+            appID: process.env.REACT_APP_LOGROCKET_APP_ID ?? null,
+            serverURL: process.env.REACT_APP_LOGROCKET_SERVER_URL ?? null,
+            idUser: {
+                enabled: process.env.REACT_APP_LOGROCKET_ID_USER === ENABLED,
+                includeName:
+                    process.env.REACT_APP_LOGROCKET_ID_USER_INCLUDE_NAME ===
+                    ENABLED,
+                includeEmail:
+                    process.env.REACT_APP_LOGROCKET_ID_USER_INCLUDE_EMAIL ===
+                    ENABLED,
+            },
+            sanitize: {
+                inputs:
+                    process.env.REACT_APP_LOGROCKET_SANITIZE_INPUTS === ENABLED,
+                request:
+                    process.env.REACT_APP_LOGROCKET_SANITIZE_REQUESTS ===
+                    ENABLED,
+                response:
+                    process.env.REACT_APP_LOGROCKET_SANITIZE_RESPONSES ===
+                    ENABLED,
+                text: process.env.REACT_APP_LOGROCKET_SANITIZE_TEXT === ENABLED,
+            },
+        };
+    }
 
-    return settings;
+    return null;
 };
 
 export const getEncryptionSettings = () => {


### PR DESCRIPTION
## Issues

- Contributes to https://github.com/estuary/ops/issues/383 

## Changes

- Adding `.env` setting to enable/disable LogRocket instead of keying off Production.
- Add in support for LogRocket to be started up with a proxy use
- Add in commented out URLs for a new proxy 

## Tests

- Testing the proxy locally and it worked. However, due to CORs issues I was unable to test it end to end. Also, this does not implement the actual proxy... so tested that the old path still worked and sent data to LogRocket

## Content

N/A

## Screenshots

N/A

