### PR TITLE
Reduce field selection debounce interval

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/useFieldSelection.ts
+++ b/src/components/editor/Bindings/FieldSelection/useFieldSelection.ts
@@ -29,13 +29,11 @@ function useFieldSelection(collectionName: string) {
     const draftId = useEditorStore_persistedDraftId();
     const mutateDraftSpecs = useEditorStore_queryResponse_mutate();
 
-    // TODO (field Selection): Determine a comfortable debounce interval. A second or less feels too quick
-    //   but five seconds feels too long.
     const debouncedUpdate = useRef(
         debounce(() => {
             setSelectionActive(false);
             setSelectionSaving(true);
-        }, 3000)
+        }, 500)
     );
 
     useEffect(() => {


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
#735 

## Changes

Reduce the field selection `debounce` interval to ensure the drafted specification is patched.

## Tests

Approaches to testing are as follows:

* Click a field selection action button and confirm that a competing call cannot be initiated that would result in the cancellation of patching the drafted specification.
