### PR TITLE
Add inferred and write schema `$ref` support for read schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@dnd-kit/utilities": "^3.2.1",
                 "@emotion/react": "^11.11.1",
                 "@emotion/styled": "^11.11.0",
-                "@estuary/flow-web": "^0.2.0",
+                "@estuary/flow-web": "^0.3.0",
                 "@jsonforms/core": "3.0.0",
                 "@jsonforms/material-renderers": "3.0.0",
                 "@jsonforms/react": "3.0.0",
@@ -2697,9 +2697,9 @@
             }
         },
         "node_modules/@estuary/flow-web": {
-            "version": "0.2.0",
-            "resolved": "https://npm.pkg.github.com/download/@estuary/flow-web/0.2.0/41c7e7e55dbd6c70a287b3ab6068816965b92336",
-            "integrity": "sha512-99qK/FLMMspwO1N3SwtBQbuHPByZxOOdBz4IdADQN/Tg1s1l1IwGwYrfAfNCow7zQMxv42FE2nRGehsdKInjAQ==",
+            "version": "0.3.0",
+            "resolved": "https://npm.pkg.github.com/download/@estuary/flow-web/0.3.0/41032e6ff2567d6a1a8d5bea73714a821da33c2b",
+            "integrity": "sha512-zZWOpFK3KMTuRSqA4h4AZCYNUtAbRLeFtp+xCanjMU+s0JaT+Zec3K9/pwOo/Hime0bg9TEOKBOVdcOwciLw8Q==",
             "license": "BSL"
         },
         "node_modules/@formatjs/ecma402-abstract": {
@@ -29425,9 +29425,9 @@
             }
         },
         "@estuary/flow-web": {
-            "version": "0.2.0",
-            "resolved": "https://npm.pkg.github.com/download/@estuary/flow-web/0.2.0/41c7e7e55dbd6c70a287b3ab6068816965b92336",
-            "integrity": "sha512-99qK/FLMMspwO1N3SwtBQbuHPByZxOOdBz4IdADQN/Tg1s1l1IwGwYrfAfNCow7zQMxv42FE2nRGehsdKInjAQ=="
+            "version": "0.3.0",
+            "resolved": "https://npm.pkg.github.com/download/@estuary/flow-web/0.3.0/41032e6ff2567d6a1a8d5bea73714a821da33c2b",
+            "integrity": "sha512-zZWOpFK3KMTuRSqA4h4AZCYNUtAbRLeFtp+xCanjMU+s0JaT+Zec3K9/pwOo/Hime0bg9TEOKBOVdcOwciLw8Q=="
         },
         "@formatjs/ecma402-abstract": {
             "version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@estuary/flow-web": "^0.2.0",
+        "@estuary/flow-web": "^0.3.0",
         "@jsonforms/core": "3.0.0",
         "@jsonforms/material-renderers": "3.0.0",
         "@jsonforms/react": "3.0.0",

--- a/src/api/inferred_schemas.ts
+++ b/src/api/inferred_schemas.ts
@@ -5,7 +5,8 @@ export const fetchInferredSchema = (collectionName: string) => {
     const queryBuilder = supabaseClient
         .from<InferredSchemas>(TABLES.INFERRED_SCHEMAS)
         .select(`schema`)
-        .eq('collection_name', collectionName);
+        .eq('collection_name', collectionName)
+        .maybeSingle();
 
     return queryBuilder;
 };

--- a/src/api/inferred_schemas.ts
+++ b/src/api/inferred_schemas.ts
@@ -1,4 +1,9 @@
-import { supabaseClient, TABLES } from 'services/supabase';
+import {
+    handleFailure,
+    handleSuccess,
+    supabaseClient,
+    TABLES,
+} from 'services/supabase';
 import { InferredSchemas } from 'types';
 
 export const fetchInferredSchema = (collectionName: string) => {
@@ -6,7 +11,8 @@ export const fetchInferredSchema = (collectionName: string) => {
         .from<InferredSchemas>(TABLES.INFERRED_SCHEMAS)
         .select(`schema`)
         .eq('collection_name', collectionName)
-        .maybeSingle();
+        .maybeSingle()
+        .then(handleSuccess<Pick<InferredSchemas, 'schema'>>, handleFailure);
 
     return queryBuilder;
 };

--- a/src/api/inferred_schemas.ts
+++ b/src/api/inferred_schemas.ts
@@ -1,0 +1,11 @@
+import { supabaseClient, TABLES } from 'services/supabase';
+import { InferredSchemas } from 'types';
+
+export const fetchInferredSchema = (collectionName: string) => {
+    const queryBuilder = supabaseClient
+        .from<InferredSchemas>(TABLES.INFERRED_SCHEMAS)
+        .select(`schema`)
+        .eq('collection_name', collectionName);
+
+    return queryBuilder;
+};

--- a/src/api/inferred_schemas.ts
+++ b/src/api/inferred_schemas.ts
@@ -11,8 +11,7 @@ export const fetchInferredSchema = (collectionName: string) => {
         .from<InferredSchemas>(TABLES.INFERRED_SCHEMAS)
         .select(`schema`)
         .eq('collection_name', collectionName)
-        .maybeSingle()
-        .then(handleSuccess<Pick<InferredSchemas, 'schema'>>, handleFailure);
+        .then(handleSuccess<Pick<InferredSchemas, 'schema'>[]>, handleFailure);
 
     return queryBuilder;
 };

--- a/src/components/collection/schema/Editor/index.tsx
+++ b/src/components/collection/schema/Editor/index.tsx
@@ -44,7 +44,7 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
     const editModeEnabled = useBindingsEditorStore_editModeEnabled();
 
     useEffect(() => {
-        if (draftSpec) {
+        if (draftSpec && entityName) {
             // TODO (collection editor) when we allow collections to get updated
             //  from the details page we'll need to handle this for that.
 
@@ -56,13 +56,19 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
 
             // Infer schema and pass in spec so the function can handle
             //  if there is a read/write or just plain schema
-            populateInferSchemaResponse(draftSpec.spec);
+            populateInferSchemaResponse(draftSpec.spec, entityName);
 
             // Need to keep the collection data updated so that the schema
             //  inference and CLI buttons work
             setCollectionData({ spec: draftSpec.spec, belongsToDraft: true });
         }
-    }, [draftSpec, entityType, populateInferSchemaResponse, setCollectionData]);
+    }, [
+        draftSpec,
+        entityType,
+        entityName,
+        populateInferSchemaResponse,
+        setCollectionData,
+    ]);
 
     useUpdateEffect(() => {
         // If the schema is updated via the scheme inference

--- a/src/components/collection/schema/Editor/index.tsx
+++ b/src/components/collection/schema/Editor/index.tsx
@@ -10,9 +10,9 @@ import KeyAutoComplete from 'components/schema/KeyAutoComplete';
 import PropertiesViewer from 'components/schema/PropertiesViewer';
 import { useEntityType } from 'context/EntityContext';
 import useDraftSpecEditor from 'hooks/useDraftSpecEditor';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useUpdateEffect } from 'react-use';
+import { useDeepCompareEffect, useUpdateEffect } from 'react-use';
 import { Schema } from 'types';
 import { getProperSchemaScope } from 'utils/schema-utils';
 
@@ -43,7 +43,9 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
         useBindingsEditorStore_populateInferSchemaResponse();
     const editModeEnabled = useBindingsEditorStore_editModeEnabled();
 
-    useEffect(() => {
+    // TODO (draftSpecEditor) should not return a new draftSpec causing this
+    // Need to use deep compare to make sure the draftSpec actually changed
+    useDeepCompareEffect(() => {
         if (draftSpec && entityName) {
             // TODO (collection editor) when we allow collections to get updated
             //  from the details page we'll need to handle this for that.

--- a/src/components/editor/Bindings/SchemaInference/Dialog/UpdateSchemaButton.tsx
+++ b/src/components/editor/Bindings/SchemaInference/Dialog/UpdateSchemaButton.tsx
@@ -2,6 +2,7 @@ import { Button } from '@mui/material';
 import {
     useBindingsEditorStore_applyInferredSchema,
     useBindingsEditorStore_collectionData,
+    useBindingsEditorStore_inferredSchemaApplicationErrored,
     useBindingsEditorStore_inferredSpec,
     useBindingsEditorStore_loadingInferredSchema,
 } from 'components/editor/Bindings/Store/hooks';
@@ -22,6 +23,8 @@ function UpdateSchemaButton({ setOpen }: Props) {
         useBindingsEditorStore_loadingInferredSchema();
     const applyInferredSchema = useBindingsEditorStore_applyInferredSchema();
     const collectionData = useBindingsEditorStore_collectionData();
+    const inferredSchemaApplicationErrored =
+        useBindingsEditorStore_inferredSchemaApplicationErrored();
 
     // Draft Editor Store
     const persistedDraftId = useEditorStore_persistedDraftId();
@@ -52,6 +55,10 @@ function UpdateSchemaButton({ setOpen }: Props) {
 
         applyInferredSchema(currentCollection, persistedDraftId, setOpen);
     };
+
+    if (inferredSchemaApplicationErrored) {
+        return null;
+    }
 
     return (
         <Button

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -120,10 +120,14 @@ const evaluateInferSchemaResponse = (dataVal: InferSchemaResponse[] | null) => {
 // Constants to handling inferred schema stuff. Taken from
 //  estuary/flow crates/validation/src/lib.rs and slightly changes for JS
 
-// eslint-disable-next-line no-useless-escape
-const REF_INFERRED_SCHEMA_PATTERN = /\"\$ref\":\"flow:\/\/inferred-schema\"/;
-// eslint-disable-next-line no-useless-escape
-const REF_WRITE_SCHEMA_PATTERN = /\"\$ref\":\"flow:\/\/write-schema\"/;
+const REF_INFERRED_SCHEMA_PATTERN = new RegExp(
+    // eslint-disable-next-line no-useless-escape
+    /\"\$ref\": \"flow:\/\/inferred-schema\"/
+);
+const REF_WRITE_SCHEMA_PATTERN = new RegExp(
+    // eslint-disable-next-line no-useless-escape
+    /\"\$ref\": \"flow:\/\/write-schema\"/
+);
 const WRITE_SCHEMA_REF = 'flow://write-schema';
 const INFERRED_SCHEMA_REF = 'flow://inferred-schema';
 

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -510,9 +510,11 @@ const getInitialState = (
         try {
             // Should only impact the read schema
             if (usingReadSchema) {
+                // We MUST make this call before calling `infer` below
+                //  This will inline the write/inferred schema in the `$defs` if needed
                 schemasToTest[0] = await updateReadSchema(
                     schemasToTest[0],
-                    spec.writeSchema,
+                    spec.writeSchema ?? {},
                     entityName
                 );
             }

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -125,7 +125,9 @@ const updateReadSchema = async (
 ) => {
     // Try fetching the inferred schema... possible TODO handle errors better
     const inferredSchemaResponse = await fetchInferredSchema(entityName);
-    const inferred = inferredSchemaResponse.data?.schema ?? {};
+    const inferred = inferredSchemaResponse.data?.[0]?.schema
+        ? inferredSchemaResponse.data[0].schema
+        : {};
 
     let response;
     try {

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -125,9 +125,7 @@ const updateReadSchema = async (
 ) => {
     // Try fetching the inferred schema... possible TODO handle errors better
     const inferredSchemaResponse = await fetchInferredSchema(entityName);
-    const inferred = inferredSchemaResponse.data?.[0]
-        ? inferredSchemaResponse.data[0]
-        : {};
+    const inferred = inferredSchemaResponse.data?.schema ?? {};
 
     let response;
     try {

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -11,7 +11,7 @@ import { CollectionData } from 'components/editor/Bindings/types';
 import produce from 'immer';
 import { forEach, intersection, isEmpty, isPlainObject, union } from 'lodash';
 import { Dispatch, SetStateAction } from 'react';
-import { logRocketConsole } from 'services/logrocket';
+import { logRocketEvent } from 'services/logrocket';
 import { CallSupabaseResponse } from 'services/supabase';
 import { BindingsEditorStoreNames } from 'stores/names';
 import {
@@ -138,7 +138,7 @@ const updateReadSchema = async (
         //  component will show an error... though not the most useful one.
         // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
     } catch (e: any) {
-        logRocketConsole('extend_read_bundle:failed', e);
+        logRocketEvent('extend_read_bundle:failed', e);
         response = {};
     }
     return response;

--- a/src/components/editor/Bindings/Store/types.ts
+++ b/src/components/editor/Bindings/Store/types.ts
@@ -69,7 +69,10 @@ export interface BindingsEditorState {
     inferSchemaResponseError: string | null;
     inferSchemaResponseDoneProcessing: boolean;
     inferSchemaResponseEmpty: boolean;
-    populateInferSchemaResponse: (value?: any) => void;
+    populateInferSchemaResponse: (
+        value: any | undefined,
+        entityName: string
+    ) => void;
 
     // Schema Evolution
     incompatibleCollections: IncompatibleCollections[];

--- a/src/components/shared/Entity/Details/Spec.tsx
+++ b/src/components/shared/Entity/Details/Spec.tsx
@@ -10,11 +10,15 @@ import ReadOnly from 'components/schema/KeyAutoComplete/ReadOnly';
 import PropertiesViewer from 'components/schema/PropertiesViewer';
 import ExternalLink from 'components/shared/ExternalLink';
 import { useEntityType } from 'context/EntityContext';
+import useGlobalSearchParams, {
+    GlobalSearchParams,
+} from 'hooks/searchParams/useGlobalSearchParams';
 import { useEffect, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 function Spec() {
     const entityType = useEntityType();
+    const catalogName = useGlobalSearchParams(GlobalSearchParams.CATALOG_NAME);
 
     const currentCatalog = useEditorStore_currentCatalog({
         localScope: true,
@@ -30,13 +34,19 @@ function Spec() {
 
     useEffect(() => {
         if (entityType === 'collection' && currentCatalog) {
-            populateInferSchemaResponse(currentCatalog.spec);
+            populateInferSchemaResponse(currentCatalog.spec, catalogName);
         }
 
         return () => {
             resetState();
         };
-    }, [currentCatalog, entityType, populateInferSchemaResponse, resetState]);
+    }, [
+        catalogName,
+        currentCatalog,
+        entityType,
+        populateInferSchemaResponse,
+        resetState,
+    ]);
 
     const docsLink = useMemo(() => {
         switch (entityType) {

--- a/src/hooks/useDraftSpecEditor.ts
+++ b/src/hooks/useDraftSpecEditor.ts
@@ -132,6 +132,7 @@ function useDraftSpecEditor(
     //     };
     // });
 
+    // TODO (draftSpecEditor) need to better handle returning so we are not causing extra renders
     return {
         onChange: processEditorValue,
         draftSpec,

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -50,6 +50,7 @@ export enum TABLES {
     DRAFTS = 'drafts',
     DRAFTS_EXT = 'drafts_ext',
     EVOLUTIONS = 'evolutions',
+    INFERRED_SCHEMAS = 'inferred_schemas',
     LIVE_SPEC_FLOW = 'live_spec_flow',
     LIVE_SPECS = 'live_specs',
     LIVE_SPECS_EXT = 'live_specs_ext',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -212,6 +212,14 @@ export interface UserGrants {
     detail: string | null;
 }
 
+// InferredSchemaFlowDocument {}
+
+export interface InferredSchemas {
+    collection_name: string;
+    schema: Schema;
+    flow_document: any; //InferredSchemaFlowDocument
+}
+
 export interface Grants {
     capability: string;
     object_role: string;


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/740

## Changes

### 740
- Pass the entity name into the population method so we can fetch the inferred schema if needed
- Handle adding in `$defs` for the `write` and `inferred` schemas referenced in the `read` schema

## Tests

Manually tested by messing with the schema in the database to force the scenarios I wanted.

## Content

N/A

## Screenshots

