### PR TITLE
Correct schema editing

### DIFF
--- a/src/components/collection/schema/Editor/index.tsx
+++ b/src/components/collection/schema/Editor/index.tsx
@@ -47,10 +47,8 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
         useBindingsEditorStore_populateInferSchemaResponse();
     const editModeEnabled = useBindingsEditorStore_editModeEnabled();
 
-    // TODO (draftSpecEditor) This causes some extra calls when using the infer schema
-    //  stuff. however, that is worth it because doing a deep compare breaks the editor
     useEffect(() => {
-        if (draftSpec && entityName) {
+        if (draftSpec?.spec && entityName) {
             // TODO (collection editor) when we allow collections to get updated
             //  from the details page we'll need to handle this for that.
 
@@ -69,7 +67,7 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
             setCollectionData({ spec: draftSpec.spec, belongsToDraft: true });
         }
     }, [
-        draftSpec,
+        draftSpec?.spec,
         entityType,
         entityName,
         populateInferSchemaResponse,

--- a/src/components/collection/schema/Editor/index.tsx
+++ b/src/components/collection/schema/Editor/index.tsx
@@ -1,6 +1,7 @@
 import { Grid, Stack, Typography } from '@mui/material';
 import {
     useBindingsEditorStore_editModeEnabled,
+    useBindingsEditorStore_inferSchemaResponseDoneProcessing,
     useBindingsEditorStore_populateInferSchemaResponse,
     useBindingsEditorStore_schemaUpdated,
     useBindingsEditorStore_setCollectionData,
@@ -15,6 +16,7 @@ import { FormattedMessage } from 'react-intl';
 import { useDeepCompareEffect, useUpdateEffect } from 'react-use';
 import { Schema } from 'types';
 import { getProperSchemaScope } from 'utils/schema-utils';
+import CollectionSchemaEditorSkeleton from './Skeleton';
 
 export interface Props {
     entityName?: string;
@@ -39,6 +41,8 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
 
     const setCollectionData = useBindingsEditorStore_setCollectionData();
 
+    const inferSchemaResponseDoneProcessing =
+        useBindingsEditorStore_inferSchemaResponseDoneProcessing();
     const populateInferSchemaResponse =
         useBindingsEditorStore_populateInferSchemaResponse();
     const editModeEnabled = useBindingsEditorStore_editModeEnabled();
@@ -97,6 +101,9 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
     );
 
     if (draftSpec && entityName) {
+        if (!inferSchemaResponseDoneProcessing) {
+            return <CollectionSchemaEditorSkeleton />;
+        }
         return (
             <Grid container>
                 {entityType === 'collection' ? null : (

--- a/src/components/collection/schema/Editor/index.tsx
+++ b/src/components/collection/schema/Editor/index.tsx
@@ -11,9 +11,9 @@ import KeyAutoComplete from 'components/schema/KeyAutoComplete';
 import PropertiesViewer from 'components/schema/PropertiesViewer';
 import { useEntityType } from 'context/EntityContext';
 import useDraftSpecEditor from 'hooks/useDraftSpecEditor';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useDeepCompareEffect, useUpdateEffect } from 'react-use';
+import { useUpdateEffect } from 'react-use';
 import { Schema } from 'types';
 import { getProperSchemaScope } from 'utils/schema-utils';
 import CollectionSchemaEditorSkeleton from './Skeleton';
@@ -47,9 +47,9 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
         useBindingsEditorStore_populateInferSchemaResponse();
     const editModeEnabled = useBindingsEditorStore_editModeEnabled();
 
-    // TODO (draftSpecEditor) should not return a new draftSpec causing this
-    // Need to use deep compare to make sure the draftSpec actually changed
-    useDeepCompareEffect(() => {
+    // TODO (draftSpecEditor) This causes some extra calls when using the infer schema
+    //  stuff. however, that is worth it because doing a deep compare breaks the editor
+    useEffect(() => {
         if (draftSpec && entityName) {
             // TODO (collection editor) when we allow collections to get updated
             //  from the details page we'll need to handle this for that.

--- a/src/components/editor/Bindings/SchemaEdit/Toggle.tsx
+++ b/src/components/editor/Bindings/SchemaEdit/Toggle.tsx
@@ -1,11 +1,13 @@
 import { Button } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
+import { useFormStateStore_isActive } from 'stores/FormState/hooks';
 import {
     useBindingsEditorStore_editModeEnabled,
     useBindingsEditorStore_setEditModeEnabled,
 } from '../Store/hooks';
 
 function SchemaEditToggle() {
+    const formActive = useFormStateStore_isActive();
     const editModeEnabled = useBindingsEditorStore_editModeEnabled();
     const setEditModeEnabled = useBindingsEditorStore_setEditModeEnabled();
 
@@ -14,7 +16,7 @@ function SchemaEditToggle() {
     };
 
     return (
-        <Button onClick={toggleEditMode}>
+        <Button onClick={toggleEditMode} disabled={formActive}>
             <FormattedMessage id={editModeEnabled ? 'cta.close' : 'cta.edit'} />
         </Button>
     );

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -468,9 +468,9 @@ const getInitialState = (
                 produce((state: BindingsEditorState) => {
                     state.inferSchemaResponseError = errorVal;
                     state.inferSchemaResponse = updatedVal;
-                    state.inferSchemaResponseDoneProcessing = true;
                     state.inferSchemaResponseEmpty = !hasResponse;
                     state.inferSchemaResponse_Keys = validKeys;
+                    state.inferSchemaResponseDoneProcessing = true;
                 }),
                 false,
                 'Infere Schema Populated'
@@ -479,7 +479,7 @@ const getInitialState = (
 
         set(
             produce((state: BindingsEditorState) => {
-                state.inferSchemaResponseDoneProcessing = true;
+                state.inferSchemaResponseDoneProcessing = false;
             }),
             false,
             'Resetting inferSchemaDoneProcessing flag'

--- a/src/components/editor/DraftSpec.tsx
+++ b/src/components/editor/DraftSpec.tsx
@@ -15,6 +15,8 @@ function DraftSpecEditor({
     editorHeight,
     entityName,
 }: Props) {
+    console.log('useDraftSpecEditor : called : DraftSpecEditor', entityName);
+
     const { draftSpec, isValidating, onChange, defaultValue } =
         useDraftSpecEditor(entityName, localZustandScope);
 

--- a/src/components/editor/DraftSpec.tsx
+++ b/src/components/editor/DraftSpec.tsx
@@ -15,8 +15,6 @@ function DraftSpecEditor({
     editorHeight,
     entityName,
 }: Props) {
-    console.log('useDraftSpecEditor : called : DraftSpecEditor', entityName);
-
     const { draftSpec, isValidating, onChange, defaultValue } =
         useDraftSpecEditor(entityName, localZustandScope);
 

--- a/src/hooks/useDraftSpecEditor.ts
+++ b/src/hooks/useDraftSpecEditor.ts
@@ -19,8 +19,14 @@ function useDraftSpecEditor(
     editorSchemaScope?: string
 ) {
     // Local State
+    // We store off a ref and a state so we can constantly do compares against
+    //  the ref and not cause re-renders. This makes sure we do not do extra updates
     const [draftSpec, setDraftSpec] = useState<DraftSpec>(null);
     const draftSpecRef = useRef<DraftSpec>(null);
+    const updateDraftSpec = useCallback((updatedValue: DraftSpec) => {
+        setDraftSpec(updatedValue);
+        draftSpecRef.current = updatedValue;
+    }, []);
 
     // Draft Editor Store
     const currentCatalog = useEditorStore_currentCatalog({
@@ -74,7 +80,7 @@ function useDraftSpecEditor(
                 }
 
                 // Update the local copy of the spec that is contained within the entire draft
-                setDraftSpec({
+                updateDraftSpec({
                     ...draftSpec,
                     spec: updatedSpec,
                 });
@@ -93,7 +99,7 @@ function useDraftSpecEditor(
                 return mutate();
             }
         },
-        [mutate, draftId, draftSpec]
+        [draftId, draftSpec, mutate, updateDraftSpec]
     );
 
     useEffect(() => {
@@ -107,8 +113,7 @@ function useDraftSpecEditor(
                     }
 
                     if (!isEqual(draftSpecRef.current, val)) {
-                        setDraftSpec(val);
-                        draftSpecRef.current = val;
+                        updateDraftSpec(val);
                         return true;
                     }
 
@@ -116,14 +121,13 @@ function useDraftSpecEditor(
                 });
             }
         }
-    }, [currentCatalog, draftSpecs, entityName, setSpecs]);
+    }, [currentCatalog, draftSpecs, entityName, setSpecs, updateDraftSpec]);
 
     useEffect(() => {
         if (currentCatalog && !isEqual(draftSpecRef.current, currentCatalog)) {
-            setDraftSpec(currentCatalog);
-            draftSpecRef.current = currentCatalog;
+            updateDraftSpec(currentCatalog);
         }
-    }, [currentCatalog]);
+    }, [currentCatalog, updateDraftSpec]);
 
     // TODO (sync editing) : turning off as right now this will show lots of "Out of sync" errors
     //    because we are comparing two JSON objects that are being stringified and that means the order


### PR DESCRIPTION
## Issues

Fixes https://github.com/estuary/ui/issues/747

## Changes

### 747
- Do NOT directly update the state object
- Used a ref so we can compare without causing renders
- Only update spec when things have actually changed

### Misc
- Show a loading page when the inferred schema is being processed
- Disable schema edit button while form is active

## Tests

Manually tested

## Content

N/A

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/ec445f14-e6d2-4a60-b19e-72780c884524)

