### PR TITLE
Switch to the `utc` object from Date-Fns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "estuary-ui",
             "version": "0.2.0-alpha",
             "dependencies": {
+                "@date-fns/utc": "^1.0.0",
                 "@dnd-kit/core": "^6.0.8",
                 "@dnd-kit/modifiers": "^6.0.1",
                 "@dnd-kit/sortable": "^7.0.2",
@@ -33,7 +34,6 @@
                 "ansicolor": "^1.1.100",
                 "data-plane-gateway": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
                 "date-fns": "^2.30.0",
-                "date-fns-tz": "^2.0.0",
                 "echarts": "^5.4.3",
                 "filter-obj": "^5.1.0",
                 "iconoir-react": "^6.9.0",
@@ -44,6 +44,7 @@
                 "logrocket": "^3.0.1",
                 "logrocket-react": "^5.0.1",
                 "lru-cache": "^9.1.2",
+                "luxon": "^3.4.3",
                 "madge": "^5.0.2",
                 "material-ui-popup-state": "^5.0.9",
                 "monaco-editor": "^0.34.1",
@@ -84,6 +85,7 @@
                 "@types/auth0-js": "^9.14.7",
                 "@types/lodash": "^4.14.191",
                 "@types/logrocket-react": "^3.0.0",
+                "@types/luxon": "^3.3.2",
                 "@types/react": "^17.0.52",
                 "@types/react-dom": "^17.0.18",
                 "@types/react-gtm-module": "^2.0.1",
@@ -2349,6 +2351,11 @@
                 "postcss": "^8.2",
                 "postcss-selector-parser": "^6.0.10"
             }
+        },
+        "node_modules/@date-fns/utc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-1.0.0.tgz",
+            "integrity": "sha512-NjV/AIlmOEhuuFJpQHOEeFl0mxVZIm77/JDSQqu/B43yL7gYDNUfH58I4sRkOCZty2gHoKQfmThtEY/DtTDhhQ=="
         },
         "node_modules/@date-io/core": {
             "version": "1.3.13",
@@ -5821,6 +5828,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-1.0.1.tgz",
             "integrity": "sha512-oPA0c5GzMKsWp/6p19OaujZQMzttluqVOI+989uHeciPAljPZvGEpZRbNO3Rr+jC/8jVLJdlMP9IHuyhKsASGA==",
+            "dev": true
+        },
+        "node_modules/@types/luxon": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.2.tgz",
+            "integrity": "sha512-l5cpE57br4BIjK+9BSkFBOsWtwv6J9bJpC7gdXIzZyI0vuKvNTk0wZZrkQxMGsUAuGW9+WMNWF2IJMD7br2yeQ==",
             "dev": true
         },
         "node_modules/@types/mime": {
@@ -9321,14 +9334,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/date-fns"
-            }
-        },
-        "node_modules/date-fns-tz": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
-            "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
-            "peerDependencies": {
-                "date-fns": ">=2.0.0"
             }
         },
         "node_modules/dayjs": {
@@ -18440,6 +18445,14 @@
             "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
             "engines": {
                 "node": "14 || >=16.14"
+            }
+        },
+        "node_modules/luxon": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+            "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/lz-string": {
@@ -29156,6 +29169,11 @@
             "dev": true,
             "requires": {}
         },
+        "@date-fns/utc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-1.0.0.tgz",
+            "integrity": "sha512-NjV/AIlmOEhuuFJpQHOEeFl0mxVZIm77/JDSQqu/B43yL7gYDNUfH58I4sRkOCZty2gHoKQfmThtEY/DtTDhhQ=="
+        },
         "@date-io/core": {
             "version": "1.3.13",
             "resolved": "https://registry.npmjs.org/@date-io/core/-/core-1.3.13.tgz",
@@ -31696,6 +31714,12 @@
                     "dev": true
                 }
             }
+        },
+        "@types/luxon": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.2.tgz",
+            "integrity": "sha512-l5cpE57br4BIjK+9BSkFBOsWtwv6J9bJpC7gdXIzZyI0vuKvNTk0wZZrkQxMGsUAuGW9+WMNWF2IJMD7br2yeQ==",
+            "dev": true
         },
         "@types/mime": {
             "version": "3.0.1",
@@ -34343,12 +34367,6 @@
             "requires": {
                 "@babel/runtime": "^7.21.0"
             }
-        },
-        "date-fns-tz": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
-            "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
-            "requires": {}
         },
         "dayjs": {
             "version": "1.11.7",
@@ -41175,6 +41193,11 @@
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
             "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ=="
+        },
+        "luxon": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+            "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg=="
         },
         "lz-string": {
             "version": "1.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
                 "logrocket": "^3.0.1",
                 "logrocket-react": "^5.0.1",
                 "lru-cache": "^9.1.2",
-                "luxon": "^3.4.3",
                 "madge": "^5.0.2",
                 "material-ui-popup-state": "^5.0.9",
                 "monaco-editor": "^0.34.1",
@@ -18451,6 +18450,8 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
             "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -41197,7 +41198,9 @@
         "luxon": {
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
-            "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg=="
+            "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
+            "optional": true,
+            "peer": true
         },
         "lz-string": {
             "version": "1.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,6 @@
                 "@types/auth0-js": "^9.14.7",
                 "@types/lodash": "^4.14.191",
                 "@types/logrocket-react": "^3.0.0",
-                "@types/luxon": "^3.3.2",
                 "@types/react": "^17.0.52",
                 "@types/react-dom": "^17.0.18",
                 "@types/react-gtm-module": "^2.0.1",
@@ -5827,12 +5826,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-1.0.1.tgz",
             "integrity": "sha512-oPA0c5GzMKsWp/6p19OaujZQMzttluqVOI+989uHeciPAljPZvGEpZRbNO3Rr+jC/8jVLJdlMP9IHuyhKsASGA==",
-            "dev": true
-        },
-        "node_modules/@types/luxon": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.2.tgz",
-            "integrity": "sha512-l5cpE57br4BIjK+9BSkFBOsWtwv6J9bJpC7gdXIzZyI0vuKvNTk0wZZrkQxMGsUAuGW9+WMNWF2IJMD7br2yeQ==",
             "dev": true
         },
         "node_modules/@types/mime": {
@@ -31715,12 +31708,6 @@
                     "dev": true
                 }
             }
-        },
-        "@types/luxon": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.2.tgz",
-            "integrity": "sha512-l5cpE57br4BIjK+9BSkFBOsWtwv6J9bJpC7gdXIzZyI0vuKvNTk0wZZrkQxMGsUAuGW9+WMNWF2IJMD7br2yeQ==",
-            "dev": true
         },
         "@types/mime": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
         "@types/auth0-js": "^9.14.7",
         "@types/lodash": "^4.14.191",
         "@types/logrocket-react": "^3.0.0",
-        "@types/luxon": "^3.3.2",
         "@types/react": "^17.0.52",
         "@types/react-dom": "^17.0.18",
         "@types/react-gtm-module": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "pre_commit": "npm run lint-staged; npm run depcheck"
     },
     "dependencies": {
+        "@date-fns/utc": "^1.0.0",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
@@ -51,7 +52,6 @@
         "ansicolor": "^1.1.100",
         "data-plane-gateway": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
         "date-fns": "^2.30.0",
-        "date-fns-tz": "^2.0.0",
         "echarts": "^5.4.3",
         "filter-obj": "^5.1.0",
         "iconoir-react": "^6.9.0",
@@ -62,6 +62,7 @@
         "logrocket": "^3.0.1",
         "logrocket-react": "^5.0.1",
         "lru-cache": "^9.1.2",
+        "luxon": "^3.4.3",
         "madge": "^5.0.2",
         "material-ui-popup-state": "^5.0.9",
         "monaco-editor": "^0.34.1",
@@ -102,6 +103,7 @@
         "@types/auth0-js": "^9.14.7",
         "@types/lodash": "^4.14.191",
         "@types/logrocket-react": "^3.0.0",
+        "@types/luxon": "^3.3.2",
         "@types/react": "^17.0.52",
         "@types/react-dom": "^17.0.18",
         "@types/react-gtm-module": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "logrocket": "^3.0.1",
         "logrocket-react": "^5.0.1",
         "lru-cache": "^9.1.2",
-        "luxon": "^3.4.3",
         "madge": "^5.0.2",
         "material-ui-popup-state": "^5.0.9",
         "monaco-editor": "^0.34.1",

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -86,8 +86,11 @@ const MATERIALIZATION_QUERY = `
     bytes_by:bytes_read_by_me
 `;
 
+const hourlyGrain = 'hourly';
+const dailyGrain = 'daily';
+const monthlyGrain = 'monthly';
+type Grains = typeof hourlyGrain | typeof dailyGrain | typeof monthlyGrain;
 type AllowedDates = Date | string | number;
-type Grains = 'hourly' | 'daily' | 'monthly';
 
 // Make sure that this matched the derivation closely
 //      Function : grainsFromTS
@@ -101,11 +104,11 @@ export const convertToUTC = (date: AllowedDates, grain: Grains) => {
     isoUTC.setUTCSeconds(0);
     isoUTC.setUTCMinutes(0);
 
-    if (grain === 'daily') {
+    if (grain === dailyGrain) {
         isoUTC.setUTCHours(0);
     }
 
-    if (grain === 'monthly') {
+    if (grain === monthlyGrain) {
         isoUTC.setUTCHours(0);
         isoUTC.setUTCDate(1);
     }
@@ -133,40 +136,40 @@ const getStatsByName = (names: string[], filter?: StatsFilter) => {
         // Day Range
         case 'today':
             queryBuilder = queryBuilder
-                .eq('ts', convertToUTC(today, 'daily'))
-                .eq('grain', 'daily');
+                .eq('ts', convertToUTC(today, dailyGrain))
+                .eq('grain', dailyGrain);
             break;
         case 'yesterday':
             queryBuilder = queryBuilder
-                .eq('ts', convertToUTC(yesterday, 'daily'))
-                .eq('grain', 'daily');
+                .eq('ts', convertToUTC(yesterday, dailyGrain))
+                .eq('grain', dailyGrain);
             break;
 
         // Week Range
         case 'thisWeek':
             queryBuilder = queryBuilder
-                .gt('ts', convertToUTC(startOfWeek(today), 'daily'))
-                .lte('ts', convertToUTC(endOfWeek(today), 'daily'))
-                .eq('grain', 'daily');
+                .gt('ts', convertToUTC(startOfWeek(today), dailyGrain))
+                .lte('ts', convertToUTC(endOfWeek(today), dailyGrain))
+                .eq('grain', dailyGrain);
             break;
         case 'lastWeek':
             queryBuilder = queryBuilder
-                .gt('ts', convertToUTC(startOfWeek(lastWeek), 'daily'))
-                .lte('ts', convertToUTC(endOfWeek(lastWeek), 'daily'))
-                .eq('grain', 'daily');
+                .gt('ts', convertToUTC(startOfWeek(lastWeek), dailyGrain))
+                .lte('ts', convertToUTC(endOfWeek(lastWeek), dailyGrain))
+                .eq('grain', dailyGrain);
             break;
 
         // Month Range
         case 'thisMonth':
             queryBuilder = queryBuilder
-                .eq('ts', convertToUTC(today, 'monthly'))
-                .eq('grain', 'monthly');
+                .eq('ts', convertToUTC(today, monthlyGrain))
+                .eq('grain', monthlyGrain);
 
             break;
         case 'lastMonth':
             queryBuilder = queryBuilder
-                .eq('ts', convertToUTC(lastMonth, 'monthly'))
-                .eq('grain', 'monthly');
+                .eq('ts', convertToUTC(lastMonth, monthlyGrain))
+                .eq('grain', monthlyGrain);
             break;
 
         default:
@@ -195,9 +198,9 @@ const getStatsForBilling = (tenants: string[], startDate: AllowedDates) => {
             flow_document
         `
         )
-        .eq('grain', 'monthly')
-        .gte('ts', convertToUTC(startDate, 'monthly'))
-        .lte('ts', convertToUTC(today, 'monthly'))
+        .eq('grain', monthlyGrain)
+        .gte('ts', convertToUTC(startDate, monthlyGrain))
+        .lte('ts', convertToUTC(today, monthlyGrain))
         .or(subjectRoleFilters)
         .order('ts', { ascending: false });
 };
@@ -211,8 +214,8 @@ const getStatsForDetails = (
     const current = new UTCDate();
     const past = duration ? sub(current, duration) : current;
 
-    const gt = convertToUTC(past, 'hourly');
-    const lte = convertToUTC(current, 'hourly');
+    const gt = convertToUTC(past, hourlyGrain);
+    const lte = convertToUTC(current, hourlyGrain);
 
     let query: string;
     switch (entityType) {
@@ -269,9 +272,9 @@ const getStatsForBillingHistoryTable = (
         `,
             { count: 'exact' }
         )
-        .eq('grain', 'monthly')
-        .gte('ts', convertToUTC(startMonth, 'monthly'))
-        .lte('ts', convertToUTC(today, 'monthly'))
+        .eq('grain', monthlyGrain)
+        .gte('ts', convertToUTC(startMonth, monthlyGrain))
+        .lte('ts', convertToUTC(today, monthlyGrain))
         .or(subjectRoleFilters);
 
     queryBuilder = defaultTableFilter<CatalogStats_Billing>(

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -1,5 +1,4 @@
 import { PostgrestFilterBuilder } from '@supabase/postgrest-js';
-import { DateTime } from 'luxon';
 import {
     endOfWeek,
     format,
@@ -92,17 +91,11 @@ type AllowedDates = Date | string | number;
 
 // This will format the date so that it just gets the month, day, year
 //  We do not need the full minute/hour/offset because the backend is not saving those
-export const formatToUTC = (date: AllowedDates, includeHour?: boolean) => {
-    // Convert date to UTC and then format it
-    const utcDate2 = format(
+export const formatToUTC = (date: AllowedDates, includeHour?: boolean) =>
+    format(
         new UTCDate(date),
         `yyyy-MM-dd${includeHour ? ' HH:00:00' : "' 00:00:00+00'"}`
     );
-
-    console.log('utcDate2 = ', utcDate2);
-
-    return utcDate2;
-};
 
 // TODO (stats) add support for which stats columns each entity wants
 //  Right now all tables run the same query even though they only need
@@ -115,29 +108,10 @@ const getStatsByName = (names: string[], filter?: StatsFilter) => {
         .in('catalog_name', names)
         .order('catalog_name');
 
-    const today = new Date();
+    const today = new UTCDate();
     const yesterday = subDays(today, 1);
     const lastWeek = subWeeks(today, 1);
     const lastMonth = subMonths(today, 1);
-
-    const today_utc = DateTime.utc();
-    const yesterday_utc = today_utc.minus({ days: 1 });
-    const lastWeek_utc = today_utc.minus({ weeks: 1 });
-    const lastMonth_utc = today_utc.minus({ months: 1 });
-
-    console.log('getStatsByName', {
-        today,
-        yesterday,
-        lastWeek,
-        lastMonth,
-    });
-
-    console.log('getStatsByName', {
-        today_utc,
-        yesterday_utc,
-        lastWeek_utc,
-        lastMonth_utc: lastMonth_utc.toISODate(),
-    });
 
     switch (filter) {
         // Day Range
@@ -218,11 +192,11 @@ const getStatsForDetails = (
     grain: string,
     duration?: Duration
 ) => {
-    const today = new Date();
-    const past = duration ? sub(today, duration) : today;
+    const current = new UTCDate();
+    const past = duration ? sub(current, duration) : current;
 
     const gt = formatToUTC(startOfHour(past), true);
-    const lte = formatToUTC(startOfHour(today), true);
+    const lte = formatToUTC(startOfHour(current), true);
 
     let query: string;
     switch (entityType) {

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -131,6 +131,7 @@ const getStatsByName = (names: string[], filter?: StatsFilter) => {
 
     const today = new Date();
 
+    // TODO (locale) allow users to have proper locale settings used for start and end of weeks
     // startOf/endOf functions can give some odd results so just forcing exactly
     //  what days we want to say are the start and end of a week based on the
     //  current day.

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -101,8 +101,6 @@ export const convertToUTC = (date: AllowedDates, grain: Grains) => {
     isoUTC.setUTCSeconds(0);
     isoUTC.setUTCMinutes(0);
 
-    // If hourly then we do none of the magic below
-
     if (grain === 'daily') {
         isoUTC.setUTCHours(0);
     }

--- a/src/components/tables/StorageMappings/Rows.tsx
+++ b/src/components/tables/StorageMappings/Rows.tsx
@@ -61,8 +61,8 @@ function Row({ row }: RowProps) {
                     <TableCell colSpan={4}>{row.catalog_prefix}</TableCell>
                     <TimeStamp time={row.updated_at} enableRelative />
                 </TableRow>
-                {row.spec.stores.map((store) => (
-                    <TableRow key={key}>
+                {row.spec.stores.map((store, index) => (
+                    <TableRow key={`${key}_${index}`}>
                         <TableCell />
                         <DataCells store={store} />
                         <TableCell />

--- a/src/components/tables/StorageMappings/Rows.tsx
+++ b/src/components/tables/StorageMappings/Rows.tsx
@@ -62,7 +62,7 @@ function Row({ row }: RowProps) {
                     <TimeStamp time={row.updated_at} enableRelative />
                 </TableRow>
                 {row.spec.stores.map((store, index) => (
-                    <TableRow key={`${key}_${index}`}>
+                    <TableRow key={`${key}_stores_${index}`}>
                         <TableCell />
                         <DataCells store={store} />
                         <TableCell />


### PR DESCRIPTION
## Issues

Fixes https://github.com/estuary/ui/issues/759

## Changes

- 759
    - Use the [utc](https://github.com/date-fns/utc) object for dates. Was originally concerned a bit as this is not mentioned in their docs when discussing timezone conversion. However, I can see how maybe they do not consider simply switching the local time to UTC as a "timezone conversion".
- Misc
    - Found a duplicated key while testing the app. Fixed it by adding a special key for when things are "nested"

## Tests

Manually tested
- Stats in table and on details page
- While testing logged the dates and compared to World Time Buddy

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/8ceb3961-29fc-4954-aeff-bee5c9a2143d)

Today
![image](https://github.com/estuary/ui/assets/270078/3e080482-c529-40ed-adbc-cb0fb2508d21)

Yesterday
![image](https://github.com/estuary/ui/assets/270078/f2219b87-5775-4453-92f6-53ec41ba9bdb)

This Week
![image](https://github.com/estuary/ui/assets/270078/1ca824fb-45ca-402a-97bd-ba240c4bc292)

Last Week
![image](https://github.com/estuary/ui/assets/270078/2f78fd75-e551-4bd4-b355-dd535526d1ed)

This Month
![image](https://github.com/estuary/ui/assets/270078/eb57b712-53fc-402c-b76e-7ecfbd4a469c)

Last Month
![image](https://github.com/estuary/ui/assets/270078/7cfa3487-d755-4fda-95e3-4df9b72bd2ff)

Detail Stats 6 hours
![image](https://github.com/estuary/ui/assets/270078/557d7313-24a4-45ff-a625-7b06259abc66)

Billing Table
![image](https://github.com/estuary/ui/assets/270078/16a5215b-59ab-48b7-8d91-164e6488f057)
