### PR TITLE
Field selection UX improvements 2

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -166,6 +166,8 @@ function FieldSelectionViewer({ collectionName }: Props) {
                     evaluatedFieldMetadata = selectedBinding.fields;
 
                     setRecommendFields(selectedBinding.fields.recommended);
+                } else {
+                    setRecommendFields(true);
                 }
 
                 if (evaluatedConstraints) {

--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -38,7 +38,11 @@ function Row({ row }: RowProps) {
                 <Typography>{row.ptr}</Typography>
             </TableCell>
 
-            <ChipListCell values={row.inference.types} stripPath={false} />
+            {row.inference?.types ? (
+                <ChipListCell values={row.inference.types} stripPath={false} />
+            ) : (
+                <TableCell />
+            )}
 
             {row.constraint ? (
                 <>


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/771

## Changes

The following features are included in this PR:
*   771
    * Set the `recommendFields` store property to `true` when initializing the field selection view and the `fields` stanza is not present in the binding configuration.
    
* Misc.
    * Check for the existence of inferred field types when rendering field selection table rows.

## Tests

Approaches to testing are as follows:

* 771
    * Executed the recreation steps listed in the originating [issue](https://github.com/estuary/ui/issues/771) and confirmed that the defective scenario cannot be reproduced.

* Misc.
    * Populated the field selection table for a binding whose schema contains a **single** field that cannot exist and confirmed that the table renders without error.
    * Populated the field selection table for a binding whose schema contains a **multiple** fields that cannot exist and confirmed that the table renders without error.

## Screenshots

_N/A_
