### PR TITLE
Enable table filtering by compound values

### DIFF
--- a/src/api/combinedGrantsExt.ts
+++ b/src/api/combinedGrantsExt.ts
@@ -34,7 +34,7 @@ const getGrants = (
         ['subject_role', 'object_role'],
         searchQuery,
         sorting,
-        pagination
+        { pagination }
     );
 
     return queryBuilder;
@@ -69,7 +69,7 @@ const getGrants_Users = (
         ['user_full_name', 'user_email', 'object_role'],
         searchQuery,
         sorting,
-        pagination
+        { pagination }
     );
 
     return queryBuilder;
@@ -103,4 +103,4 @@ export const getAuthRoles = async (capability: string) => {
         .throwOnError();
 };
 
-export { getGrantsForAuthToken, getGrants, getGrants_Users, getGrantsForUser };
+export { getGrants, getGrants_Users, getGrantsForAuthToken, getGrantsForUser };

--- a/src/api/connectors.ts
+++ b/src/api/connectors.ts
@@ -1,15 +1,15 @@
 import {
-    ConnectorWithTagDetailQuery,
     CONNECTOR_WITH_TAG_QUERY,
+    ConnectorWithTagDetailQuery,
 } from 'hooks/useConnectorWithTagDetail';
 import {
     CONNECTOR_NAME,
+    SortingProps,
+    TABLES,
     defaultTableFilter,
     handleFailure,
     handleSuccess,
-    SortingProps,
     supabaseClient,
-    TABLES,
 } from 'services/supabase';
 
 // Table-specific queries
@@ -29,7 +29,7 @@ const getConnectors = (
         [CONNECTOR_NAME],
         searchQuery,
         sorting,
-        pagination
+        { pagination }
     );
 
     return queryBuilder;

--- a/src/api/directives.ts
+++ b/src/api/directives.ts
@@ -16,8 +16,8 @@ import {
     AppliedDirective,
     Directive,
     GrantDirective,
-    GrantDirectiveSpec,
     GrantDirective_AccessLinks,
+    GrantDirectiveSpec,
     JoinedAppliedDirective,
     Schema,
 } from 'types';
@@ -177,7 +177,7 @@ const getDirectivesByType = (
         ['catalog_prefix', `spec->>capability`, `spec->>grantedPrefix`],
         searchQuery,
         sorting,
-        pagination
+        { pagination }
     );
 
     return queryBuilder;
@@ -196,7 +196,7 @@ export {
     exchangeBearerToken,
     generateGrantDirective,
     getAppliedDirectives,
-    getDirectivesByType,
     getDirectiveByToken,
+    getDirectivesByType,
     submitDirective,
 };

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -80,7 +80,7 @@ const getLiveSpecs_captures = (
 
     queryBuilder = defaultTableFilter<CaptureQuery>(
         queryBuilder,
-        ['catalog_name', QUERY_PARAM_CONNECTOR_TITLE, 'test'],
+        ['catalog_name', QUERY_PARAM_CONNECTOR_TITLE],
         searchQuery,
         sorting,
         { pagination, compoundSearchParams: ['writes_to'] }

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -80,10 +80,10 @@ const getLiveSpecs_captures = (
 
     queryBuilder = defaultTableFilter<CaptureQuery>(
         queryBuilder,
-        ['catalog_name', QUERY_PARAM_CONNECTOR_TITLE],
+        ['catalog_name', QUERY_PARAM_CONNECTOR_TITLE, 'test'],
         searchQuery,
         sorting,
-        pagination
+        { pagination, compoundSearchParams: ['writes_to'] }
     ).eq('spec_type', 'capture');
 
     return queryBuilder;
@@ -105,7 +105,7 @@ const getLiveSpecs_materializations = (
         ['catalog_name', QUERY_PARAM_CONNECTOR_TITLE],
         searchQuery,
         sorting,
-        pagination
+        { pagination, compoundSearchParams: ['reads_from'] }
     ).eq('spec_type', 'materialization');
 
     return queryBuilder;
@@ -127,7 +127,7 @@ const getLiveSpecs_collections = (
         ['catalog_name'],
         searchQuery,
         sorting,
-        pagination
+        { pagination }
     ).eq('spec_type', 'collection');
 
     return queryBuilder;
@@ -166,7 +166,7 @@ const getLiveSpecs_collectionsSelector = (
         ['catalog_name'],
         searchQuery,
         sorting,
-        pagination
+        { pagination }
     ).eq('spec_type', specType);
 
     return queryBuilder;
@@ -371,9 +371,9 @@ export {
     getLiveSpecs_captures,
     getLiveSpecs_collections,
     getLiveSpecs_collectionsSelector,
+    getLiveSpecs_detailsForm,
     getLiveSpecs_existingTasks,
     getLiveSpecs_materializations,
-    getLiveSpecs_detailsForm,
     getLiveSpecsByCatalogName,
     getLiveSpecsByCatalogNames,
     getLiveSpecsByConnectorId,

--- a/src/api/storageMappings.ts
+++ b/src/api/storageMappings.ts
@@ -28,7 +28,7 @@ const getStorageMappings = (
         ['catalog_prefix'],
         searchQuery,
         sorting,
-        pagination
+        { pagination }
     );
 
     return queryBuilder;
@@ -49,4 +49,4 @@ const getStorageMapping = (catalog_prefix: string) => {
     return queryBuilder;
 };
 
-export { getStorageMappings, getStorageMapping };
+export { getStorageMapping, getStorageMappings };

--- a/src/components/connectors/ConnectorTiles.tsx
+++ b/src/components/connectors/ConnectorTiles.tsx
@@ -8,8 +8,8 @@ import {
     useMediaQuery,
     useTheme,
 } from '@mui/material';
-import ConnectorCard from 'components/connectors/card';
 import ConnectorToolbar from 'components/connectors/ConnectorToolbar';
+import ConnectorCard from 'components/connectors/card';
 import useEntityCreateNavigate from 'components/shared/Entity/hooks/useEntityCreateNavigate';
 import {
     semiTransparentBackground,
@@ -17,8 +17,8 @@ import {
 } from 'context/Theme';
 import { useQuery, useSelect } from 'hooks/supabase-swr';
 import {
-    ConnectorWithTagDetailQuery,
     CONNECTOR_WITH_TAG_QUERY,
+    ConnectorWithTagDetailQuery,
 } from 'hooks/useConnectorWithTagDetail';
 import { AddSquare } from 'iconoir-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -26,8 +26,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import {
     CONNECTOR_NAME,
     CONNECTOR_RECOMMENDED,
-    defaultTableFilter,
     TABLES,
+    defaultTableFilter,
 } from 'services/supabase';
 import {
     BaseComponentProps,
@@ -129,8 +129,12 @@ function ConnectorTiles({
                             direction: sortDirection,
                         },
                     ],
-                    undefined,
-                    { column: 'connector_tags.protocol', value: protocol }
+                    {
+                        protocol: {
+                            column: 'connector_tags.protocol',
+                            value: protocol,
+                        },
+                    }
                 );
             },
         },

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -130,25 +130,16 @@ export const defaultTableFilter = <Data>(
         const { pagination, protocol, compoundSearchParams } = options;
 
         if (searchQuery) {
-            const queryElements = searchQuery
-                .split(',')
-                .map((el) => el.trim())
-                .filter((el) => hasLength(el));
-
             const scalarFilter = scalarSearchParams
                 .map((param) => {
-                    return queryElements
-                        .map((el) => `${param}.ilike.*${el}*`)
-                        .join(',');
+                    return `${param}.ilike.*${searchQuery}*`;
                 })
                 .join(',');
 
             const compoundFilter = compoundSearchParams
                 ? compoundSearchParams
                       .map((param) => {
-                          return `${String(param)}.cs.{${queryElements.join(
-                              ','
-                          )}}`;
+                          return `${String(param)}.cs.{${searchQuery}}`;
                       })
                       .join(',')
                 : '';


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/{issue_number}

## Changes

The following features are included in this PR:

*   _Pending_
    *   Enable table filtering by a Supabase column that contains compound values.

## Tests

Approaches to testing are as follows:

* _Pending_
    *   Enter the full name of a collection that is bound to at least one capture in the capture table search bar and observe that the table contains all captures that write to that collection.

    *   Enter characters in the capture table search bar and observe that the existing filtering behavior is still intact.

    *   Enter the full name of a collection that is bound to at least one materialization in the materialization table search bar and observe that the table contains all materializations that read from that collection.

    *   Enter characters in the materialization table search bar and observe that the existing filtering behavior is still intact.

## Screenshots

**Materializations Table | Default**

<img width="928" alt="pr_screenshot-772-compound_table_filter-materialization-default" src="https://github.com/estuary/ui/assets/77648584/fc31a453-d2b0-44dc-8991-102d6f5a69e2">

<br />
<br />

**Materializations Table | Filter by Collection**

<img width="930" alt="pr_screenshot-772-compound_table_filter-materialization-collection_filter" src="https://github.com/estuary/ui/assets/77648584/f67a48b2-0c41-47aa-8bf6-df9616bf0ca0">

<br />
<br />

**Materializations Table | Filter by Catalog or Connector Name**

<img width="926" alt="pr_screenshot-772-compound_table_filter-materialization-catalog_filter" src="https://github.com/estuary/ui/assets/77648584/b5b9213e-7836-43cc-98ad-b89143d04b32">

<br />
<br />

**Captures Table | Default**

<img width="928" alt="pr_screenshot-772-compound_table_filter-capture-default" src="https://github.com/estuary/ui/assets/77648584/685a21d4-17e7-4691-b3e2-ac6e1f2f2c71">

<br />
<br />

**Captures Table | Filter by Collection**

<img width="930" alt="pr_screenshot-772-compound_table_filter-capture-collection_filter" src="https://github.com/estuary/ui/assets/77648584/89af915b-af7c-4bf0-97ef-0bb6248c03d7">

<br />
<br />

**Captures Table | Filter by Catalog or Connector Name**

<img width="929" alt="pr_screenshot-772-compound_table_filter-capture-catalog_filter" src="https://github.com/estuary/ui/assets/77648584/d0f2d725-c367-4443-99b6-3bb38ccdbc00">
