### PR TITLE
fix: Invoice sort order

### DIFF
--- a/src/components/tables/Billing/Rows.tsx
+++ b/src/components/tables/Billing/Rows.tsx
@@ -3,7 +3,6 @@ import { Invoice } from 'api/billing';
 import MonetaryValue from 'components/tables/cells/MonetaryValue';
 import DataVolume from 'components/tables/cells/billing/DataVolume';
 import TimeStamp from 'components/tables/cells/billing/TimeStamp';
-import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useBilling_setSelectedInvoice } from 'stores/Billing/hooks';
 import { InvoiceId, invoiceId } from 'utils/billing-utils';
@@ -56,26 +55,15 @@ function Row({ row, isSelected }: RowProps) {
 
 // TODO (billing): Remove pagination placeholder when the new RPC is available.
 function Rows({ data, selectedInvoice }: RowsProps) {
-    // The table should only show the four, most recent months of billing history.
-    // If the user has accrued more than four months worth of billing data, calculate
-    // the adjusted start index.
-    const startIndex = useMemo(
-        () => (data.length > 4 ? data.length - 4 : 0),
-        [data.length]
-    );
-
     return (
         <>
-            {data
-                .slice(startIndex, data.length)
-                .reverse()
-                .map((record, index) => (
-                    <Row
-                        row={record}
-                        key={index}
-                        isSelected={invoiceId(record) === selectedInvoice}
-                    />
-                ))}
+            {data.slice(0, 4).map((record, index) => (
+                <Row
+                    row={record}
+                    key={index}
+                    isSelected={invoiceId(record) === selectedInvoice}
+                />
+            ))}
         </>
     );
 }

--- a/src/stores/Billing/Store.ts
+++ b/src/stores/Billing/Store.ts
@@ -105,7 +105,7 @@ export const getInitialState = (
                                 record.date_end !== value[0].date_end
                         );
 
-                        evaluatedBillingHistory.push(value[0]);
+                        evaluatedBillingHistory.unshift(value[0]);
 
                         if (
                             !evaluatedBillingHistory.find(


### PR DESCRIPTION


## Changes

Invoices now come in order, so let's just pick the first 4 and not change the order.

## Tests

Manually tested

## Screenshots

**Old:**
<img width="294" alt="Screen Shot 2023-09-27 at 11 17 32" src="https://github.com/estuary/ui/assets/4368270/2562dbd1-bfb9-4583-b8a0-6d234fdb9233">

**New:**
<img width="292" alt="Screen Shot 2023-09-27 at 11 19 05" src="https://github.com/estuary/ui/assets/4368270/5574ebe4-f27c-4051-b29f-d8eb8c26cc4d">
