### PR TITLE
prod: reinitialize field selections using the patched draft spec

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -19,6 +19,7 @@ import {
 } from 'components/editor/Bindings/FieldSelection/types';
 import useFieldSelection from 'components/editor/Bindings/FieldSelection/useFieldSelection';
 import {
+    useBindingsEditorStore_initializeSelections,
     useBindingsEditorStore_recommendFields,
     useBindingsEditorStore_selectionSaving,
     useBindingsEditorStore_setRecommendFields,
@@ -106,6 +107,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
     const recommendFields = useBindingsEditorStore_recommendFields();
     const setRecommendFields = useBindingsEditorStore_setRecommendFields();
 
+    const initializeSelections = useBindingsEditorStore_initializeSelections();
     const setSingleSelection = useBindingsEditorStore_setSingleSelection();
 
     const selectionSaving = useBindingsEditorStore_selectionSaving();
@@ -185,10 +187,11 @@ function FieldSelectionViewer({ collectionName }: Props) {
                         evaluatedFieldMetadata
                     );
 
-                    compositeProjections.forEach(({ field, selectionType }) =>
-                        setSingleSelection(field, selectionType, true)
+                    const selections = compositeProjections.map(
+                        ({ field, selectionType }) => ({ field, selectionType })
                     );
 
+                    initializeSelections(selections);
                     setData(compositeProjections);
                 } else {
                     setData(null);
@@ -200,11 +203,11 @@ function FieldSelectionViewer({ collectionName }: Props) {
             setData(null);
         }
     }, [
-        setData,
-        setRecommendFields,
-        setSingleSelection,
         collectionName,
         draftSpecs,
+        initializeSelections,
+        setData,
+        setRecommendFields,
     ]);
 
     const toggleRecommendFields = useCallback(

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -411,14 +411,28 @@ const getInitialState = (
         );
     },
 
-    setSingleSelection: (field, selectionType, initOnly) => {
+    initializeSelections: (selections) => {
+        set(
+            produce((state: BindingsEditorState) => {
+                state.selections = {};
+
+                selections.forEach(({ field, selectionType }) => {
+                    state.selections[field] = selectionType;
+                });
+            }),
+            false,
+            'Selections Initialized'
+        );
+    },
+
+    setSingleSelection: (field, selectionType) => {
         set(
             produce((state: BindingsEditorState) => {
                 const { selectionSaving } = get();
 
                 state.selections[field] = selectionType;
 
-                if (!selectionSaving && !initOnly) {
+                if (!selectionSaving) {
                     state.selectionSaving = true;
                 }
             }),

--- a/src/components/editor/Bindings/Store/hooks.ts
+++ b/src/components/editor/Bindings/Store/hooks.ts
@@ -290,6 +290,13 @@ export const useBindingsEditorStore_selections = () => {
     >(BindingsEditorStoreNames.GENERAL, (state) => state.selections);
 };
 
+export const useBindingsEditorStore_initializeSelections = () => {
+    return useZustandStore<
+        BindingsEditorState,
+        BindingsEditorState['initializeSelections']
+    >(BindingsEditorStoreNames.GENERAL, (state) => state.initializeSelections);
+};
+
 export const useBindingsEditorStore_setSingleSelection = () => {
     return useZustandStore<
         BindingsEditorState,

--- a/src/components/editor/Bindings/Store/types.ts
+++ b/src/components/editor/Bindings/Store/types.ts
@@ -86,10 +86,15 @@ export interface BindingsEditorState {
     setRecommendFields: (value: BindingsEditorState['recommendFields']) => void;
 
     selections: { [field: string]: FieldSelectionType | null };
+    initializeSelections: (
+        selection: {
+            field: string;
+            selectionType: FieldSelectionType | null;
+        }[]
+    ) => void;
     setSingleSelection: (
         field: string,
-        selectionType: FieldSelectionType | null,
-        initOnly?: boolean
+        selectionType: FieldSelectionType | null
     ) => void;
 
     selectionSaving: boolean;


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/762

## Changes

The following features are included in this PR:
*   762
    *   Reinitialize the field selections for the selected binding using the relevant `fields` stanza of the patched, drafted specification.

## Tests

Approaches to testing are as follows:

* Executed the recreation steps listed in the originating issue and confirmed that the defective scenario cannot be reproduced.

## Screenshots

_N/A_
