### PR TITLE
Checking what payment provider tenant is using before warning payment methods

### DIFF
--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -144,7 +144,10 @@ export const getPaymentMethodsForTenants = async (
     let count = 0;
 
     tenants.some((tenantDetail) => {
-        if (tenantDetail.pays_externally || !tenantDetail.trial_start) {
+        if (
+            tenantDetail.payment_provider === 'external' ||
+            !tenantDetail.trial_start
+        ) {
             promises.push(
                 new Promise((resolve) => {
                     resolve({

--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -145,12 +145,22 @@ export const getPaymentMethodsForTenants = async (
 
     tenants.some((tenantDetail) => {
         if (tenantDetail.pays_externally) {
-            return count;
+            promises.push(
+                new Promise((resolve) => {
+                    resolve({
+                        data: {
+                            tenant: tenantDetail.tenant,
+                            paysExternally: true,
+                        },
+                    });
+                })
+            );
+        } else {
+            promises.push(
+                limiter(() => getTenantPaymentMethods(tenantDetail.tenant))
+            );
         }
 
-        promises.push(
-            limiter(() => getTenantPaymentMethods(tenantDetail.tenant))
-        );
         count += 1;
         return count >= MAX_TENANTS;
     });

--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -144,13 +144,13 @@ export const getPaymentMethodsForTenants = async (
     let count = 0;
 
     tenants.some((tenantDetail) => {
-        if (tenantDetail.pays_externally) {
+        if (tenantDetail.pays_externally || !tenantDetail.trial_start) {
             promises.push(
                 new Promise((resolve) => {
                     resolve({
                         data: {
                             tenant: tenantDetail.tenant,
-                            paysExternally: true,
+                            skipPaymentMethod: true,
                         },
                     });
                 })

--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -144,6 +144,10 @@ export const getPaymentMethodsForTenants = async (
     let count = 0;
 
     tenants.some((tenantDetail) => {
+        if (tenantDetail.pays_externally) {
+            return count;
+        }
+
         promises.push(
             limiter(() => getTenantPaymentMethods(tenantDetail.tenant))
         );

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -1,7 +1,13 @@
 import { supabaseClient, TABLES } from 'services/supabase';
 import { Tenants } from 'types';
 
-const COLUMNS = ['tasks_quota', 'collections_quota', 'tenant', 'trial_start'];
+const COLUMNS = [
+    'collections_quota',
+    'pays_externally',
+    'tasks_quota',
+    'tenant',
+    'trial_start',
+];
 
 const getTenantDetails = () => {
     return supabaseClient

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -3,7 +3,7 @@ import { Tenants } from 'types';
 
 const COLUMNS = [
     'collections_quota',
-    'pays_externally',
+    'payment_provider',
     'tasks_quota',
     'tenant',
     'trial_start',

--- a/src/components/admin/Billing/AddPaymentMethod.tsx
+++ b/src/components/admin/Billing/AddPaymentMethod.tsx
@@ -26,7 +26,7 @@ function AddPaymentMethod({
     stripePromise,
     tenant,
 }: Props) {
-    const enableButton =
+    const enable =
         setupIntentSecret !== INTENT_SECRET_LOADING &&
         setupIntentSecret !== INTENT_SECRET_ERROR;
 
@@ -35,7 +35,7 @@ function AddPaymentMethod({
             <Box>
                 <LoadingButton
                     loadingPosition="start"
-                    disabled={!enableButton}
+                    disabled={!enable}
                     loading={setupIntentSecret === INTENT_SECRET_LOADING}
                     onClick={() => setOpen(true)}
                     startIcon={<Plus style={{ fontSize: 15 }} />}
@@ -58,7 +58,7 @@ function AddPaymentMethod({
                 <DialogTitle>
                     <FormattedMessage id="admin.billing.addPaymentMethods.title" />
                 </DialogTitle>
-                {enableButton ? (
+                {enable ? (
                     <Elements
                         stripe={stripePromise}
                         options={{

--- a/src/components/admin/Billing/AddPaymentMethod.tsx
+++ b/src/components/admin/Billing/AddPaymentMethod.tsx
@@ -58,7 +58,7 @@ function AddPaymentMethod({
                 <DialogTitle>
                     <FormattedMessage id="admin.billing.addPaymentMethods.title" />
                 </DialogTitle>
-                {setupIntentSecret ? (
+                {enableButton ? (
                     <Elements
                         stripe={stripePromise}
                         options={{

--- a/src/hooks/billing/useTenantMissingPaymentMethodWarning.tsx
+++ b/src/hooks/billing/useTenantMissingPaymentMethodWarning.tsx
@@ -99,6 +99,11 @@ function useTenantMissingPaymentMethodWarning() {
                     }
                 );
 
+                // We skip those tenants with their payments handled outside of our provider
+                if (paymentMethodForTenant.paysExternally) {
+                    return false;
+                }
+
                 // We check the methods list and see if one exists. We are not checking if a primary card is set
                 //   at this time (Q4 2023) but that might change based on experience.
                 const hasPaymentMethod =

--- a/src/hooks/billing/useTenantMissingPaymentMethodWarning.tsx
+++ b/src/hooks/billing/useTenantMissingPaymentMethodWarning.tsx
@@ -88,19 +88,24 @@ function useTenantMissingPaymentMethodWarning() {
 
         // We have tenant in trial and now need to go through all the payment methods and see if any are missing
         if (paymentMethods.responses.length > 0) {
-            // Go through each tenant to try to find the payment methods
-            tenantsInTrial.some((tenantInTrial) => {
-                const currentTenant = tenantInTrial.tenant;
+            //  Step through the responses we have to see if the tenant is missing details
+            //      we do not step through the tenants so if any calls to fetch payment methods
+            //      failed we do not show a warning accidently
+            paymentMethods.responses.some((paymentMethodForTenant) => {
+                const currentTenant = paymentMethodForTenant.tenant;
 
-                // Find the payment method for this tenant
-                const paymentMethodForTenant = paymentMethods.responses.find(
-                    (paymentMethod) => {
-                        return currentTenant === paymentMethod.tenant;
+                const tenantInTrial = tenantsInTrial.find(
+                    (tenantInTrialCurr) => {
+                        return tenantInTrialCurr.tenant === currentTenant;
                     }
                 );
 
+                // We can skip if there are no tenant details found
                 // We skip those not in a trial OR have payment methods outside our provider
-                if (paymentMethodForTenant?.skipPaymentMethod) {
+                if (
+                    !tenantInTrial ||
+                    paymentMethodForTenant?.skipPaymentMethod
+                ) {
                     return false;
                 }
 

--- a/src/hooks/billing/useTenantMissingPaymentMethodWarning.tsx
+++ b/src/hooks/billing/useTenantMissingPaymentMethodWarning.tsx
@@ -99,8 +99,8 @@ function useTenantMissingPaymentMethodWarning() {
                     }
                 );
 
-                // We skip those tenants with their payments handled outside of our provider
-                if (paymentMethodForTenant.paysExternally) {
+                // We skip those not in a trial OR have payment methods outside our provider
+                if (paymentMethodForTenant?.skipPaymentMethod) {
                     return false;
                 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -145,13 +145,14 @@ export interface StorageMappings {
 }
 
 export interface Tenants {
-    id: string;
-    tasks_quota: number;
     collections_quota: number;
+    created_at: string;
     detail: string;
+    id: string;
+    pays_externally: boolean;
+    tasks_quota: number;
     tenant: string;
     trial_start: string;
-    created_at: string;
     updated_at: string;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,12 +144,14 @@ export interface StorageMappings {
     updated_at: string;
 }
 
+export type TenantPaymentProviders = 'external' | 'stripe';
+
 export interface Tenants {
     collections_quota: number;
     created_at: string;
     detail: string;
     id: string;
-    pays_externally: boolean;
+    payment_provider: TenantPaymentProviders;
     tasks_quota: number;
     tenant: string;
     trial_start: string;


### PR DESCRIPTION
Adding the types for that
Checking the new column to see if we need to fetch payment methods

## Issues

https://github.com/estuary/ui/issues/784

## Changes

784
- Added a new column to fetch from `tenants`
- Skip the call for payment methods for tenants that pay externally

Misc
- Stop fetching payment methods if there is no trial started
- Replaced checking all `tenants` with checking all `payment methods` so we do not scare users

## Tests

Manually tested
- Added the column manually and tested against it

## Screenshots
N/A

All external means no calls to billing to get payment methods
![image](https://github.com/estuary/ui/assets/270078/0038b9d2-9bd0-4bd9-94c9-c1913588dfce)
![image](https://github.com/estuary/ui/assets/270078/c3abbc71-3253-4ccb-ae7c-4f7d3ac17df5)

2 in stripe means two calls
![image](https://github.com/estuary/ui/assets/270078/c41184b0-b085-4b95-9184-3c4ea1fe3b22)
![image](https://github.com/estuary/ui/assets/270078/ae4ceeab-f14c-4c86-a10e-5becaa6e90d7)
![image](https://github.com/estuary/ui/assets/270078/0dd5e22e-5fb4-4d52-8061-3f39e6f503bc)

2 in stripe but not in trial means no calls
![image](https://github.com/estuary/ui/assets/270078/f7c7b03e-c2dd-4921-9e71-49e2162722b4)
![image](https://github.com/estuary/ui/assets/270078/0c6b5f06-f29a-48e6-bb5d-56683125c990)
