### PR TITLE
Updating `deploy` memory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,8 @@ jobs:
     # Deployment steps undertaken on a merge to `main`.
     deploy:
         name: Deploy
+        env:
+            NODE_OPTIONS: '--max_old_space_size=4096'
         needs: quality
         runs-on: ubuntu-latest
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
We are getting heap memory issues during the `deploy` action. Looking for some quick solutions I found this [Stack Overflow](https://stackoverflow.com/questions/73272019/github-actions-reached-heap-limit-allocation-failed) answer that links to this [Github Issue](https://github.com/actions/runner-images/issues/70#issuecomment-1191708172)