### PR TITLE
Better error handling for publishing

### DIFF
--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -98,10 +98,7 @@ function EntityCreateSave({
     // Resource Config Store
     const collections = useResourceConfig_collections();
 
-    const waitForPublishToFinish = (
-        logTokenVal: string,
-        draftIdVal: string
-    ) => {
+    const waitForPublishToFinish = (publicationId: string) => {
         updateFormStatus(status);
         setIncompatibleCollections([]);
 
@@ -109,10 +106,7 @@ function EntityCreateSave({
             supabaseClient
                 .from(TABLES.PUBLICATIONS)
                 .select(JOB_STATUS_COLUMNS)
-                .match({
-                    draft_id: draftIdVal,
-                    logs_token: logTokenVal,
-                }),
+                .eq('id', publicationId),
             async (payload: any) => {
                 const formStatus = dryRun
                     ? FormStatus.TESTED
@@ -242,7 +236,7 @@ function EntityCreateSave({
                     },
                 });
             } else {
-                waitForPublishToFinish(response.data[0].logs_token, draftId);
+                waitForPublishToFinish(response.data[0].id);
                 setFormState({
                     logToken: response.data[0].logs_token,
                     showLogs: true,

--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -236,11 +236,11 @@ function EntityCreateSave({
                     },
                 });
             } else {
-                waitForPublishToFinish(response.data[0].id);
                 setFormState({
                     logToken: response.data[0].logs_token,
                     showLogs: true,
                 });
+                waitForPublishToFinish(response.data[0].id);
             }
         } else {
             logRocketEvent('Entity:Create:Missing draftId');

--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -236,11 +236,11 @@ function EntityCreateSave({
                     },
                 });
             } else {
+                waitForPublishToFinish(response.data[0].id);
                 setFormState({
                     logToken: response.data[0].logs_token,
                     showLogs: true,
                 });
-                waitForPublishToFinish(response.data[0].id);
             }
         } else {
             logRocketEvent('Entity:Create:Missing draftId');

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -316,6 +316,7 @@ export const DEFAULT_POLLER_ERROR = {
 };
 
 // These columns are not always what you want... but okay for a "default" constant
+const JOB_STATUS_SUCCESS = ['emptyDraft', 'success'];
 export const JOB_STATUS_COLUMNS = `job_status, logs_token, id`;
 export const jobStatusPoller = (
     query: any,
@@ -350,7 +351,11 @@ export const jobStatusPoller = (
                             `Poller : response : ${response.job_status.type}`
                         );
 
-                        if (response.job_status.type === 'success') {
+                        if (
+                            JOB_STATUS_SUCCESS.includes(
+                                response.job_status.type
+                            )
+                        ) {
                             success(response);
                         } else {
                             failure(response);

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -365,17 +365,19 @@ export const jobStatusPoller = (
                 }
             },
             (error: any) => {
+                LogRocket.log('Poller : error : ', error);
+
                 const tryOnceMore =
                     attempts === 0 &&
                     typeof error?.message === 'string' &&
                     shouldTryAfterFailure(error.message);
 
                 if (tryOnceMore) {
-                    LogRocket.log('Poller : error : second attempt starting ');
+                    LogRocket.log('Poller : error : trying again');
                     attempts += 1;
                     pollerTimeout = window.setTimeout(makeApiCall, interval);
                 } else {
-                    LogRocket.log('Poller : error : ', error);
+                    LogRocket.log('Poller : error : returning failure');
                     timeoutCleanUp(pollerTimeout);
                     failure(handleFailure(JOB_STATUS_POLLER_ERROR));
                 }


### PR DESCRIPTION
## Issues

From Slack conversation

## Changes

Slack
- If there is a network issue then let the polled try one more time
- Add a little bit more logging for LogRocket
- Handle when the status could be `draftEmpty`
- Query for the publication based on the returned `id`

## Tests

Manually tested

Published and paused the debugged...
 - alter the `job_status` on the `publications` table
 - disable the url `localhost:5431/rest/v1/publications` in chrome (before and after inserting publication)

## Screenshots

N/A
