### PR TITLE
Rediscover capture when previously disabled collections are enabled

### DIFF
--- a/src/components/capture/GenerateButton.tsx
+++ b/src/components/capture/GenerateButton.tsx
@@ -9,6 +9,7 @@ import {
 } from 'stores/DetailsForm/hooks';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
+import { useResourceConfig_rediscoveryRequired } from 'stores/ResourceConfig/hooks';
 import { Entity } from 'types';
 import useDiscoverCapture from './useDiscoverCapture';
 
@@ -28,10 +29,15 @@ function CaptureGenerateButton({
     postGenerateMutate,
     createWorkflowMetadata,
 }: Props) {
+    const rediscoveryRequired = useResourceConfig_rediscoveryRequired();
+
     const { generateCatalog, isSaving, formActive } = useDiscoverCapture(
         entityType,
         postGenerateMutate,
-        { initiateDiscovery: createWorkflowMetadata?.initiateDiscovery }
+        {
+            initiateDiscovery: createWorkflowMetadata?.initiateDiscovery,
+            initiateRediscovery: rediscoveryRequired,
+        }
     );
 
     // Details Form Store

--- a/src/components/capture/useDiscoverStartSubscription.ts
+++ b/src/components/capture/useDiscoverStartSubscription.ts
@@ -21,7 +21,6 @@ import {
 } from 'stores/EndpointConfig/hooks';
 import { useFormStateStore_setFormState } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
-import { useResourceConfig_setRediscoveryRequired } from 'stores/ResourceConfig/hooks';
 import { Entity } from 'types';
 
 const trackEvent = (payload: any) => {
@@ -53,8 +52,6 @@ function useDiscoverStartSubscription(
     const setServerUpdateRequired = useEndpointConfig_setServerUpdateRequired();
     const setPreviousEndpointConfig =
         useEndpointConfigStore_setPreviousEndpointConfig();
-
-    const setRediscoveryRequired = useResourceConfig_setRediscoveryRequired();
 
     const storeDiscoveredCollections = useStoreDiscoveredCaptures();
 
@@ -115,8 +112,6 @@ function useDiscoverStartSubscription(
                     //      https://github.com/estuary/ui/pull/650#pullrequestreview-1466195898
                     setServerUpdateRequired(false);
 
-                    setRediscoveryRequired(false);
-
                     trackEvent(payload);
                 },
                 (payload: any) => {
@@ -143,7 +138,6 @@ function useDiscoverStartSubscription(
             setDraftedEntityName,
             setFormState,
             setPreviousEndpointConfig,
-            setRediscoveryRequired,
             setServerUpdateRequired,
             storeDiscoveredCollections,
             supabaseClient,

--- a/src/components/materialization/GenerateButton.tsx
+++ b/src/components/materialization/GenerateButton.tsx
@@ -43,6 +43,7 @@ import {
 } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
 import {
+    useResourceConfig_resetRediscoverySettings,
     useResourceConfig_resourceConfig,
     useResourceConfig_resourceConfigErrorsExist,
 } from 'stores/ResourceConfig/hooks';
@@ -97,6 +98,8 @@ function MaterializeGenerateButton({ disabled, mutateDraftSpecs }: Props) {
     const resourceConfig = useResourceConfig_resourceConfig();
     const resourceConfigHasErrors =
         useResourceConfig_resourceConfigErrorsExist();
+    const resetRediscoverySettings =
+        useResourceConfig_resetRediscoverySettings();
 
     // Source Capture Store
     const sourceCapture = useStore(
@@ -245,6 +248,11 @@ function MaterializeGenerateButton({ disabled, mutateDraftSpecs }: Props) {
             setFormState({
                 status: FormStatus.GENERATED,
             });
+
+            // Materializations do not use this setting but still letting it get populated to keep
+            //  the stores simpler. Also, I could easily see us needing to know what collections
+            //  were enabled during an edit in materializations.
+            resetRediscoverySettings();
 
             return mutateDraftSpecs();
         }

--- a/src/components/materialization/GenerateButton.tsx
+++ b/src/components/materialization/GenerateButton.tsx
@@ -71,35 +71,26 @@ function MaterializeGenerateButton({ disabled, mutateDraftSpecs }: Props) {
 
     // Draft Editor Store
     const isSaving = useEditorStore_isSaving();
-
     const resetEditorState = useEditorStore_resetState();
-
     const setDraftId = useEditorStore_setId();
-
     const persistedDraftId = useEditorStore_persistedDraftId();
     const setPersistedDraftId = useEditorStore_setPersistedDraftId();
 
     // Endpoint Config Store
     const endpointSchema = useEndpointConfigStore_endpointSchema();
-
     const endpointConfigData = useEndpointConfigStore_endpointConfig_data();
-
     const serverEndpointConfigData =
         useEndpointConfigStore_encryptedEndpointConfig_data();
     const setEncryptedEndpointConfig =
         useEndpointConfigStore_setEncryptedEndpointConfig();
-
     const setPreviousEndpointConfig =
         useEndpointConfigStore_setPreviousEndpointConfig();
-
     const endpointConfigHasErrors = useEndpointConfigStore_errorsExist();
     const serverUpdateRequired = useEndpointConfig_serverUpdateRequired();
 
     // Form State Store
     const formActive = useFormStateStore_isActive();
-
     const setFormState = useFormStateStore_setFormState();
-
     const updateFormStatus = useFormStateStore_updateStatus();
 
     // Resource Config Store

--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -4,17 +4,19 @@ import {
     getDraftSpecsBySpecTypeReduced,
 } from 'api/draftSpecs';
 import { createPublication } from 'api/publications';
+import useDiscoverCapture from 'components/capture/useDiscoverCapture';
 import { useBindingsEditorStore_setIncompatibleCollections } from 'components/editor/Bindings/Store/hooks';
 import {
     useEditorStore_id,
-    useEditorStore_isSaving,
     useEditorStore_queryResponse_mutate,
     useEditorStore_setDiscoveredDraftId,
     useEditorStore_setPubId,
 } from 'components/editor/Store/hooks';
 import { buttonSx } from 'components/shared/Entity/Header';
 import useEntityWorkflowHelpers from 'components/shared/Entity/hooks/useEntityWorkflowHelpers';
+import { useEntityType } from 'context/EntityContext';
 import { useClient } from 'hooks/supabase-swr';
+import { noop } from 'lodash';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { CustomEvents, logRocketEvent } from 'services/logrocket';
 import {
@@ -25,7 +27,6 @@ import {
 } from 'services/supabase';
 import { useDetailsForm_details_description } from 'stores/DetailsForm/hooks';
 import {
-    useFormStateStore_isActive,
     useFormStateStore_messagePrefix,
     useFormStateStore_setFormState,
     useFormStateStore_updateStatus,
@@ -34,7 +35,10 @@ import { FormStatus } from 'stores/FormState/types';
 import useNotificationStore, {
     notificationStoreSelectors,
 } from 'stores/NotificationStore';
-import { useResourceConfig_collections } from 'stores/ResourceConfig/hooks';
+import {
+    useResourceConfig_collections,
+    useResourceConfig_collectionsRequiringRediscovery,
+} from 'stores/ResourceConfig/hooks';
 import { hasLength } from 'utils/misc-utils';
 
 interface Props {
@@ -67,36 +71,39 @@ function EntityCreateSave({
     const intl = useIntl();
     const supabaseClient = useClient();
     const { closeLogs } = useEntityWorkflowHelpers();
+    const entityType = useEntityType();
 
     const status = dryRun ? FormStatus.TESTING : FormStatus.SAVING;
+
+    const { generateCatalog, isSaving, formActive } = useDiscoverCapture(
+        entityType,
+        noop,
+        { initiateRediscovery: true }
+    );
 
     // Draft Editor Store
     const draftId = useEditorStore_id();
     const setPubId = useEditorStore_setPubId();
-    const isSaving = useEditorStore_isSaving();
 
     const setDiscoveredDraftId = useEditorStore_setDiscoveredDraftId();
     const mutateDraftSpecs = useEditorStore_queryResponse_mutate();
 
-    // Details Form Store
     const entityDescription = useDetailsForm_details_description();
 
     const setIncompatibleCollections =
         useBindingsEditorStore_setIncompatibleCollections();
 
-    // Form State Store
     const messagePrefix = useFormStateStore_messagePrefix();
     const setFormState = useFormStateStore_setFormState();
     const updateFormStatus = useFormStateStore_updateStatus();
-    const formActive = useFormStateStore_isActive();
 
-    // Notification Store
     const showNotification = useNotificationStore(
         notificationStoreSelectors.showNotification
     );
 
-    // Resource Config Store
     const collections = useResourceConfig_collections();
+    const collectionsRequiringRediscovery =
+        useResourceConfig_collectionsRequiringRediscovery();
 
     const waitForPublishToFinish = (
         logTokenVal: string,
@@ -184,6 +191,16 @@ function EntityCreateSave({
         updateFormStatus(status);
 
         if (draftId) {
+            if (
+                entityType === 'capture' &&
+                hasLength(collectionsRequiringRediscovery)
+            ) {
+                console.log('Need to run a discover before we save');
+                const foo = await generateCatalog(event);
+
+                console.log('foo', foo);
+            }
+
             // If there are bound collections then we need to potentially handle clean up
             if (collections && collections.length > 0) {
                 const draftSpecResponse = await getDraftSpecsBySpecTypeReduced(

--- a/src/components/shared/Entity/Actions/SaveButton.tsx
+++ b/src/components/shared/Entity/Actions/SaveButton.tsx
@@ -13,13 +13,6 @@ import {
     useFormStateStore_status,
 } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
-import {
-    useResourceConfig_collections,
-    useResourceConfig_discoveredCollections,
-} from 'stores/ResourceConfig/hooks';
-import { useMemo } from 'react';
-import { hasLength } from 'utils/misc-utils';
-import { isEqual } from 'lodash';
 
 interface Props {
     logEvent:
@@ -46,30 +39,6 @@ function EntitySaveButton({ disabled, taskNames, logEvent }: Props) {
     const showLogs = useFormStateStore_showLogs();
     const logToken = useFormStateStore_logToken();
     const formStatus = useFormStateStore_status();
-
-    const collections = useResourceConfig_collections();
-    const discoveredCollections = useResourceConfig_discoveredCollections();
-
-    useMemo(() => {
-        if (entityType === 'capture') {
-            const collectionsExist = hasLength(collections);
-            const discoveredCollectionsExist = hasLength(discoveredCollections);
-            const collectionsAndDiscoveredMatch = isEqual(
-                collections,
-                discoveredCollections
-            );
-
-            console.log('checking collections', {
-                collectionsExist,
-                discoveredCollectionsExist,
-                collectionsAndDiscoveredMatch,
-            });
-
-            return collectionsAndDiscoveredMatch;
-        } else {
-            return null;
-        }
-    }, [collections, discoveredCollections, entityType]);
 
     return (
         <>

--- a/src/components/shared/Entity/Actions/SaveButton.tsx
+++ b/src/components/shared/Entity/Actions/SaveButton.tsx
@@ -13,6 +13,13 @@ import {
     useFormStateStore_status,
 } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
+import {
+    useResourceConfig_collections,
+    useResourceConfig_discoveredCollections,
+} from 'stores/ResourceConfig/hooks';
+import { useMemo } from 'react';
+import { hasLength } from 'utils/misc-utils';
+import { isEqual } from 'lodash';
 
 interface Props {
     logEvent:
@@ -36,11 +43,33 @@ function EntitySaveButton({ disabled, taskNames, logEvent }: Props) {
 
     // Form State Store
     const messagePrefix = useFormStateStore_messagePrefix();
-
     const showLogs = useFormStateStore_showLogs();
     const logToken = useFormStateStore_logToken();
-
     const formStatus = useFormStateStore_status();
+
+    const collections = useResourceConfig_collections();
+    const discoveredCollections = useResourceConfig_discoveredCollections();
+
+    useMemo(() => {
+        if (entityType === 'capture') {
+            const collectionsExist = hasLength(collections);
+            const discoveredCollectionsExist = hasLength(discoveredCollections);
+            const collectionsAndDiscoveredMatch = isEqual(
+                collections,
+                discoveredCollections
+            );
+
+            console.log('checking collections', {
+                collectionsExist,
+                discoveredCollectionsExist,
+                collectionsAndDiscoveredMatch,
+            });
+
+            return collectionsAndDiscoveredMatch;
+        } else {
+            return null;
+        }
+    }, [collections, discoveredCollections, entityType]);
 
     return (
         <>

--- a/src/hooks/useServerUpdateRequiredMonitor.ts
+++ b/src/hooks/useServerUpdateRequiredMonitor.ts
@@ -50,8 +50,11 @@ const useServerUpdateRequiredMonitor = (draftSpecs: DraftSpecQuery[]) => {
                     //     setRediscoveryRequired(true);
                     // }
 
+                    const { previouslyDisabled, ...restOfConfig } =
+                        resourceConfig[collectionName];
+
                     // See if anything has changed
-                    return !isEqual(resourceConfig[collectionName], {
+                    return !isEqual(restOfConfig, {
                         ...disableProp,
                         data: resource,
                         errors: [],

--- a/src/hooks/useServerUpdateRequiredMonitor.ts
+++ b/src/hooks/useServerUpdateRequiredMonitor.ts
@@ -16,9 +16,6 @@ import {
 const useServerUpdateRequiredMonitor = (draftSpecs: DraftSpecQuery[]) => {
     const entityType = useEntityType();
 
-    // TODO (enabled rediscovery)
-    // Need to fetch if we're in edit or not
-
     const resourceConfig = useResourceConfig_resourceConfig();
     const setServerUpdateRequired = useResourceConfig_setServerUpdateRequired();
 
@@ -43,12 +40,6 @@ const useServerUpdateRequiredMonitor = (draftSpecs: DraftSpecQuery[]) => {
                     //Pull out resource as that is moved into `data`
                     const { resource, disable } = binding;
                     const disableProp = getDisableProps(disable);
-
-                    // TODO (enabled rediscovery)
-                    // If we're enabling something then make sure we know to rediscover
-                    // if (disable && !resourceConfig[collectionName].disable) {
-                    //     setRediscoveryRequired(true);
-                    // }
 
                     const { previouslyDisabled, ...restOfConfig } =
                         resourceConfig[collectionName];

--- a/src/hooks/useServerUpdateRequiredMonitor.ts
+++ b/src/hooks/useServerUpdateRequiredMonitor.ts
@@ -41,6 +41,7 @@ const useServerUpdateRequiredMonitor = (draftSpecs: DraftSpecQuery[]) => {
                     const { resource, disable } = binding;
                     const disableProp = getDisableProps(disable);
 
+                    // Make sure we remove the local only props before comparing
                     const { previouslyDisabled, ...restOfConfig } =
                         resourceConfig[collectionName];
 

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -336,13 +336,23 @@ const getInitialState = (
             produce((state: ResourceConfigState) => {
                 populateCollections(state, []);
 
-                state.rediscoveryRequired = false;
-                state.collectionsRequiringRediscovery = [];
                 state.restrictedDiscoveredCollections = [];
                 state.resourceConfig = {};
+                state.resetRediscoverySettings();
             }),
             false,
             'Resource Config and Collections Reset'
+        );
+    },
+
+    resetRediscoverySettings: () => {
+        set(
+            produce((state: ResourceConfigState) => {
+                state.rediscoveryRequired = false;
+                state.collectionsRequiringRediscovery = [];
+            }),
+            false,
+            'Rediscovery Related Settings Reset'
         );
     },
 

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -120,7 +120,6 @@ const getInitialCollectionStateData = (): Pick<
 const getInitialMiscStoreData = (): Pick<
     ResourceConfigState,
     | 'discoveredCollections'
-    | 'previouslyDisabledCollections'
     | 'hydrated'
     | 'hydrationErrorsExist'
     | 'resourceConfig'
@@ -132,7 +131,6 @@ const getInitialMiscStoreData = (): Pick<
     | 'rediscoveryRequired'
 > => ({
     discoveredCollections: null,
-    previouslyDisabledCollections: [],
     hydrated: false,
     hydrationErrorsExist: false,
     resourceConfig: {},
@@ -219,7 +217,8 @@ const getInitialState = (
                 const collections = bindings.map((binding: any) => {
                     const [name, configVal] = getResourceConfig(binding);
                     state.resourceConfig[name] = configVal;
-
+                    state.resourceConfig[name].previouslyDisabled =
+                        configVal.disable === true;
                     return name;
                 });
 

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -642,14 +642,15 @@ const getInitialState = (
                     ? 'source'
                     : 'target';
 
-                // TODO (direct bindings) We can remove this when/if we move the UI
+                // TODO (direct bindings) We can remove the ordering when/if we move the UI
                 //   to using the bindings directly and save a lot of processing
-                const sortedBindings = orderBy(
-                    data[0].spec.bindings,
-                    ['disable', collectionNameProp],
-                    ['desc', 'asc']
+                prefillResourceConfig(
+                    orderBy(
+                        data[0].spec.bindings,
+                        ['disable', collectionNameProp],
+                        ['desc', 'asc']
+                    )
                 );
-                prefillResourceConfig(sortedBindings);
             }
         }
 

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -14,8 +14,8 @@ import {
     isEqual,
     map,
     omit,
+    orderBy,
     pick,
-    sortBy,
 } from 'lodash';
 import { createJSONFormDefaults } from 'services/ajv';
 import {
@@ -120,6 +120,7 @@ const getInitialCollectionStateData = (): Pick<
 const getInitialMiscStoreData = (): Pick<
     ResourceConfigState,
     | 'discoveredCollections'
+    | 'previouslyDisabledCollections'
     | 'hydrated'
     | 'hydrationErrorsExist'
     | 'resourceConfig'
@@ -131,6 +132,7 @@ const getInitialMiscStoreData = (): Pick<
     | 'rediscoveryRequired'
 > => ({
     discoveredCollections: null,
+    previouslyDisabledCollections: [],
     hydrated: false,
     hydrationErrorsExist: false,
     resourceConfig: {},
@@ -642,9 +644,11 @@ const getInitialState = (
 
                 // TODO (direct bindings) We can remove this when/if we move the UI
                 //   to using the bindings directly and save a lot of processing
-                const sortedBindings = sortBy(data[0].spec.bindings, [
-                    collectionNameProp,
-                ]);
+                const sortedBindings = orderBy(
+                    data[0].spec.bindings,
+                    ['disable', collectionNameProp],
+                    ['desc', 'asc']
+                );
                 prefillResourceConfig(sortedBindings);
             }
         }

--- a/src/stores/ResourceConfig/hooks.ts
+++ b/src/stores/ResourceConfig/hooks.ts
@@ -280,20 +280,13 @@ export const useResourceConfig_setServerUpdateRequired = () => {
     );
 };
 
-export const useResourceConfig_rediscoveryRequired = () => {
+export const useResourceConfig_collectionsRequiringRediscovery = () => {
     return useZustandStore<
         ResourceConfigState,
-        ResourceConfigState['rediscoveryRequired']
-    >(ResourceConfigStoreNames.GENERAL, (state) => state.rediscoveryRequired);
-};
-
-export const useResourceConfig_setRediscoveryRequired = () => {
-    return useZustandStore<
-        ResourceConfigState,
-        ResourceConfigState['setRediscoveryRequired']
+        ResourceConfigState['collectionsRequiringRediscovery']
     >(
         ResourceConfigStoreNames.GENERAL,
-        (state) => state.setRediscoveryRequired
+        (state) => state.collectionsRequiringRediscovery
     );
 };
 

--- a/src/stores/ResourceConfig/hooks.ts
+++ b/src/stores/ResourceConfig/hooks.ts
@@ -280,21 +280,21 @@ export const useResourceConfig_setServerUpdateRequired = () => {
     );
 };
 
-export const useResourceConfig_collectionsRequiringRediscovery = () => {
-    return useZustandStore<
-        ResourceConfigState,
-        ResourceConfigState['collectionsRequiringRediscovery']
-    >(
-        ResourceConfigStoreNames.GENERAL,
-        (state) => state.collectionsRequiringRediscovery
-    );
-};
-
 export const useResourceConfig_rediscoveryRequired = () => {
     return useZustandStore<
         ResourceConfigState,
         ResourceConfigState['rediscoveryRequired']
     >(ResourceConfigStoreNames.GENERAL, (state) => state.rediscoveryRequired);
+};
+
+export const useResourceConfig_resetRediscoverySettings = () => {
+    return useZustandStore<
+        ResourceConfigState,
+        ResourceConfigState['resetRediscoverySettings']
+    >(
+        ResourceConfigStoreNames.GENERAL,
+        (state) => state.resetRediscoverySettings
+    );
 };
 
 export const useResourceConfig_evaluateDiscoveredCollections = () => {

--- a/src/stores/ResourceConfig/hooks.ts
+++ b/src/stores/ResourceConfig/hooks.ts
@@ -290,6 +290,13 @@ export const useResourceConfig_collectionsRequiringRediscovery = () => {
     );
 };
 
+export const useResourceConfig_rediscoveryRequired = () => {
+    return useZustandStore<
+        ResourceConfigState,
+        ResourceConfigState['rediscoveryRequired']
+    >(ResourceConfigStoreNames.GENERAL, (state) => state.rediscoveryRequired);
+};
+
 export const useResourceConfig_evaluateDiscoveredCollections = () => {
     return useZustandStore<
         ResourceConfigState,

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -76,6 +76,7 @@ export interface ResourceConfigState extends StoreWithHydration {
     setServerUpdateRequired: (value: boolean) => void;
 
     collectionsRequiringRediscovery: string[];
+    rediscoveryRequired: boolean;
 
     evaluateDiscoveredCollections: (
         response: CallSupabaseResponse<any>

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -7,7 +7,7 @@ import { Entity, EntityWorkflow, JsonFormsData, Schema } from 'types';
 export interface ResourceConfig extends JsonFormsData {
     errors: any[];
     disable?: boolean;
-    previouslyDisabled?: boolean;
+    previouslyDisabled?: boolean; // Used to store if the binding was disabled last time we loaded in bindings
 }
 
 export interface ResourceConfigDictionary {
@@ -75,8 +75,7 @@ export interface ResourceConfigState extends StoreWithHydration {
     serverUpdateRequired: boolean;
     setServerUpdateRequired: (value: boolean) => void;
 
-    rediscoveryRequired: boolean;
-    setRediscoveryRequired: (value: boolean) => void;
+    collectionsRequiringRediscovery: string[];
 
     evaluateDiscoveredCollections: (
         response: CallSupabaseResponse<any>

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -77,6 +77,7 @@ export interface ResourceConfigState extends StoreWithHydration {
 
     collectionsRequiringRediscovery: string[];
     rediscoveryRequired: boolean;
+    resetRediscoverySettings: () => void;
 
     evaluateDiscoveredCollections: (
         response: CallSupabaseResponse<any>

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -7,6 +7,7 @@ import { Entity, EntityWorkflow, JsonFormsData, Schema } from 'types';
 export interface ResourceConfig extends JsonFormsData {
     errors: any[];
     disable?: boolean;
+    previouslyDisabled?: boolean;
 }
 
 export interface ResourceConfigDictionary {
@@ -37,8 +38,6 @@ export interface ResourceConfigState extends StoreWithHydration {
 
     discoveredCollections: string[] | null;
     setDiscoveredCollections: (value: DraftSpecQuery) => void;
-
-    previouslyDisabledCollections: string[];
 
     restrictedDiscoveredCollections: string[];
     setRestrictedDiscoveredCollections: (

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -38,6 +38,8 @@ export interface ResourceConfigState extends StoreWithHydration {
     discoveredCollections: string[] | null;
     setDiscoveredCollections: (value: DraftSpecQuery) => void;
 
+    previouslyDisabledCollections: string[];
+
     restrictedDiscoveredCollections: string[];
     setRestrictedDiscoveredCollections: (
         collection: string,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/789

## Changes

- 789
    - Keep track of what collections were disable during the last load/discover
    - Keep track of what collections were enabled and will require rediscovery
    - Keep track of when rediscovery is needed
    - Have the capture's generate button pass if rediscovery is needed

## Tests

Manually tested

- Capture create
- Capture edit

## Screenshots

Enabling a previously disabled
![image](https://github.com/estuary/ui/assets/270078/4c875e1b-fc48-415b-b66e-1bc034245936)

Disabling it again is recorded
![image](https://github.com/estuary/ui/assets/270078/08a7c9c7-f776-4858-9379-d9b41a9329f6)

When clicking next we run a discover
![image](https://github.com/estuary/ui/assets/270078/9f9679b9-808e-44e9-b67c-3f5e594323b1)

And show the "discover" loading bar
![image](https://github.com/estuary/ui/assets/270078/e965e21a-7211-47fe-abe6-46507926749c)
