### PR TITLE
PROD: forgot to set disabled

### DIFF
--- a/src/stores/ShardDetail/Store.ts
+++ b/src/stores/ShardDetail/Store.ts
@@ -80,6 +80,7 @@ const getEverythingForDictionary = (
     const response: TaskShardDetails = {
         id: spec.id,
         color: defaultStatusColor,
+        disabled: spec.disable,
         messageId: ShardStatusMessageIds.NONE,
         errors: [],
         warnings: [],

--- a/src/stores/ShardDetail/Store.ts
+++ b/src/stores/ShardDetail/Store.ts
@@ -80,7 +80,7 @@ const getEverythingForDictionary = (
     const response: TaskShardDetails = {
         id: spec.id,
         color: defaultStatusColor,
-        disabled: spec.disable,
+        disabled: Boolean(spec.disable),
         messageId: ShardStatusMessageIds.NONE,
         errors: [],
         warnings: [],


### PR DESCRIPTION
Fixing prod issue where the `disabled` state on shards was not getting set.