### PR TITLE
Allowing the binding filter to be cleared

### DIFF
--- a/src/components/collection/Selector/List/Header/Name.tsx
+++ b/src/components/collection/Selector/List/Header/Name.tsx
@@ -1,4 +1,5 @@
 import { TextField } from '@mui/material';
+import ClearInput from 'components/shared/Input/Clear';
 import { useIntl } from 'react-intl';
 
 interface Props {
@@ -30,6 +31,14 @@ function CollectionSelectorHeaderName({
             size="small"
             variant="outlined"
             value={inputValue}
+            InputProps={{
+                endAdornment: (
+                    <ClearInput
+                        show={Boolean(!disabled && inputValue)}
+                        onClear={onChange}
+                    />
+                ),
+            }}
             onChange={(event) => {
                 onChange(event.target.value);
             }}

--- a/src/components/shared/Input/Clear.tsx
+++ b/src/components/shared/Input/Clear.tsx
@@ -1,0 +1,39 @@
+import { Close } from '@mui/icons-material';
+import { IconButton, InputAdornment } from '@mui/material';
+import { useIntl } from 'react-intl';
+
+interface Props {
+    onClear: (emptyValue: string) => void;
+    show?: boolean;
+}
+
+function ClearInput({ onClear, show }: Props) {
+    const intl = useIntl();
+
+    return (
+        <InputAdornment
+            position="end"
+            style={{
+                display: show ? 'flex' : 'none',
+                position: 'absolute',
+                right: 0,
+            }}
+        >
+            <IconButton
+                aria-label={intl.formatMessage({
+                    id: 'jsonForms.clearInput',
+                })}
+                onClick={() => onClear('')}
+                size="large"
+            >
+                <Close
+                    style={{
+                        borderRadius: '50%',
+                    }}
+                />
+            </IconButton>
+        </InputAdornment>
+    );
+}
+
+export default ClearInput;

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -1300,6 +1300,10 @@ const Notifications: ResolvedIntlConfig['messages'] = {
     'notifications.paymentMethods.missing.trialPast.instructions': `Please {cta} to continue using Estuary Flow.`,
 };
 
+const JsonForms: ResolvedIntlConfig['messages'] = {
+    'jsonForms.clearInput': `Clear input field`,
+};
+
 const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...CommonMessages,
     ...CTAs,
@@ -1361,6 +1365,7 @@ const enUSMessages: ResolvedIntlConfig['messages'] = {
     ...NotBeforeNotAfter,
     ...Notifications,
     ...Fetchers,
+    ...JsonForms,
 };
 
 export default enUSMessages;


### PR DESCRIPTION
## Issues

Fixes https://github.com/estuary/ui/issues/827

## Changes

### 827
- Add a reusable adornment for clearing inputs
- Add the adornment to the bindings filter header

## Tests

Manually tested

- Lots of fussing around with entering values, clearing field, making it disabled/enabled

## Screenshots

![Screenshot_20231116-085542](https://github.com/estuary/ui/assets/270078/c297ae94-9297-48a2-9714-167465c381ab)

