### PR TITLE
Create sharable findBindingIndex function for field selection

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -45,7 +45,10 @@ import {
 } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
 import { Schema } from 'types';
-import { evaluateRequiredIncludedFields } from 'utils/workflow-utils';
+import {
+    evaluateRequiredIncludedFields,
+    getBindingIndex,
+} from 'utils/workflow-utils';
 
 interface Props {
     collectionName: string;
@@ -162,11 +165,13 @@ function FieldSelectionViewer({ collectionName }: Props) {
                         )
                     )?.constraints;
 
-                const selectedBinding: Schema | undefined =
-                    draftSpecs[0].spec.bindings.find(
-                        (binding: any) => binding.source === collectionName
-                    );
-
+                const bindingIndex: number = getBindingIndex(
+                    draftSpecs[0].spec.bindings,
+                    collectionName
+                );
+                const selectedBinding: Schema | undefined = bindingIndex
+                    ? draftSpecs[0].spec.bindings[bindingIndex]
+                    : undefined;
                 let evaluatedFieldMetadata: FieldMetadata | undefined;
 
                 if (

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -169,9 +169,10 @@ function FieldSelectionViewer({ collectionName }: Props) {
                     draftSpecs[0].spec.bindings,
                     collectionName
                 );
-                const selectedBinding: Schema | undefined = bindingIndex
-                    ? draftSpecs[0].spec.bindings[bindingIndex]
-                    : undefined;
+                const selectedBinding: Schema | undefined =
+                    bindingIndex > -1
+                        ? draftSpecs[0].spec.bindings[bindingIndex]
+                        : undefined;
                 let evaluatedFieldMetadata: FieldMetadata | undefined;
 
                 if (

--- a/src/components/editor/Bindings/FieldSelection/useFieldSelection.ts
+++ b/src/components/editor/Bindings/FieldSelection/useFieldSelection.ts
@@ -12,6 +12,7 @@ import { omit } from 'lodash';
 import { useCallback } from 'react';
 import { Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
+import { getBindingIndex } from 'utils/workflow-utils';
 
 function useFieldSelection(collectionName: string) {
     // Bindings Editor Store
@@ -24,8 +25,12 @@ function useFieldSelection(collectionName: string) {
 
     return useCallback(
         async (draftSpec: DraftSpecQuery) => {
-            const bindingIndex: number = draftSpec.spec.bindings.findIndex(
-                (binding: any) => binding.source === collectionName
+            // TODO (field selection) we should make it so this does not need to be figured out
+            //  every call as it is pretty wasteful. Since we are passing in the spec already maybe
+            //  we just pass in the index along with it? Not sure how to do this and make it feel good.
+            const bindingIndex: number = getBindingIndex(
+                draftSpec.spec.bindings,
+                collectionName
             );
 
             if (!mutateDraftSpecs || bindingIndex === -1) {

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -44,6 +44,12 @@ export const getCollectionName = (binding: any) => {
     return getCollectionNameDirectly(scopedBinding);
 };
 
+export const getBindingIndex = (bindings: any[], collectionName: string) => {
+    return bindings.findIndex(
+        (binding: any) => getCollectionName(binding) === collectionName
+    );
+};
+
 export const getDisableProps = (disable: boolean | undefined) => {
     return disable ? { disable } : {};
 };

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -44,10 +44,15 @@ export const getCollectionName = (binding: any) => {
     return getCollectionNameDirectly(scopedBinding);
 };
 
-export const getBindingIndex = (bindings: any[], collectionName: string) => {
-    return bindings.findIndex(
-        (binding: any) => getCollectionName(binding) === collectionName
-    );
+export const getBindingIndex = (
+    bindings: any[] | null | undefined,
+    collectionName: string
+) => {
+    return bindings?.findIndex
+        ? bindings.findIndex(
+              (binding: any) => getCollectionName(binding) === collectionName
+          )
+        : -1;
 };
 
 export const getDisableProps = (disable: boolean | undefined) => {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/830

## Changes

### 830
- Use new function so that the binding index will be found even when time travel props are set

### Misc
- Make a util function to fetch the binding index

## Tests

Manually tested

- Materialization create/edit

## Screenshots

Nothing to really screenshot in terms of the changes a user would notice... but:

1. Switched to disabled
2. The time travel was already set
3. The network calls were made to update the draft properly
![image](https://github.com/estuary/ui/assets/270078/8dd4ab75-5b2e-4b62-a726-eef8f249cda1)

