### PR TITLE
PROD: try to get previous merge to deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10322,7 +10322,7 @@
         "node_modules/data-plane-gateway": {
             "version": "0.0.0",
             "resolved": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-9IWuCPjKUJbgAIYi6mqQsrcrQhvKOUzszS7/CPB4xBeW6/Jg1KkIlCcMsmn8IkDddf3yCTmMfYdHlGoEagNowQ==",
+            "integrity": "sha512-cqpz09q0M2cma0OOwt7Ky+2Wth9Si/TxjDaRxuJo1RIm33up+FoguIM7SHYRbgaG2DSPnDWTB2BViQEGrRGX3w==",
             "license": "MIT"
         },
         "node_modules/data-urls": {
@@ -37814,7 +37814,7 @@
         },
         "data-plane-gateway": {
             "version": "https://gitpkg.now.sh/estuary/data-plane-gateway/client/dist?main",
-            "integrity": "sha512-9IWuCPjKUJbgAIYi6mqQsrcrQhvKOUzszS7/CPB4xBeW6/Jg1KkIlCcMsmn8IkDddf3yCTmMfYdHlGoEagNowQ=="
+            "integrity": "sha512-cqpz09q0M2cma0OOwt7Ky+2Wth9Si/TxjDaRxuJo1RIm33up+FoguIM7SHYRbgaG2DSPnDWTB2BViQEGrRGX3w=="
         },
         "data-urls": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "estuary-ui",
-    "version": "0.2.0-alpha",
+    "version": "0.2.1-alpha",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "estuary-ui",
-            "version": "0.2.0-alpha",
+            "version": "0.2.1-alpha",
             "dependencies": {
                 "@date-fns/utc": "^1.0.0",
                 "@dnd-kit/core": "^6.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "estuary-ui",
-    "version": "0.2.0-alpha",
+    "version": "0.2.1-alpha",
     "description": "A web based UI to assist in working with Estuary Flow",
     "main": "index.js",
     "private": true,


### PR DESCRIPTION
GitHub actions failed yesterday to pickup https://github.com/estuary/ui/pull/831 due to: 
https://www.githubstatus.com/incidents/66vhjmd266r9
https://github.com/orgs/community/discussions/77211

So trying this to see if the actions are fixed today