### PR TITLE
Handle schema evolution for server update monitor

### DIFF
--- a/src/hooks/useServerUpdateRequiredMonitor.ts
+++ b/src/hooks/useServerUpdateRequiredMonitor.ts
@@ -40,6 +40,13 @@ const useServerUpdateRequiredMonitor = (draftSpecs: DraftSpecQuery[]) => {
                         binding[collectionNameProp]
                     );
 
+                    // If the collection is no longer there then we are probably applying a schema evolution so we
+                    //      should not require server update as we just got back from the server
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                    if (!resourceConfig[collectionName]?.data) {
+                        return false;
+                    }
+
                     // Do a quick simple disabled check before comparing the entire object
                     if (
                         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition


### PR DESCRIPTION
## Issues

Fixes https://github.com/estuary/ui/issues/837

## Changes

### 837
- Add a check if the collection has been removed

## Tests

Manually tested

- Schema Evolution
- 

## Screenshots

Caused an incompatible error
![image](https://github.com/estuary/ui/assets/270078/3d6f35ab-e215-482d-b2b9-bd65f281e56d)

Now the error is gone and the updated collection is rendering
![image](https://github.com/estuary/ui/assets/270078/82c886f9-c71a-4bff-9d55-52ecaa57d8f2)

