### PR TITLE
Updating logic so if a schema issue is on the root we catch it

### DIFF
--- a/src/stores/ShardDetail/Store.ts
+++ b/src/stores/ShardDetail/Store.ts
@@ -47,7 +47,7 @@ const findAllErrorsAndWarnings = (shard: Shard) => {
         statusErrors?.forEach((error) => {
             if (
                 error.includes(
-                    'absoluteKeywordLocation": "flow://inferred-schema#/'
+                    'absoluteKeywordLocation": "flow://inferred-schema'
                 )
             ) {
                 warnings.push(error);


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/844

## Changes

### 844
- Updated logic to catch when the schema has an issue at root. Since this will catch both I just updated the string and did not check for multiple strings

## Tests

Manually tested
This is a prod issue so not testing locally. I checked the string would catch the value by doing a "find" in LogRocket

## Screenshots
