### PR TITLE
Cleaning up notification query

### DIFF
--- a/src/api/alerts.ts
+++ b/src/api/alerts.ts
@@ -110,8 +110,7 @@ const getNotificationSubscriptionForUser = async (
 const getNotificationSubscriptionsForTable = (
     pagination: any,
     searchQuery: any,
-    sorting: SortingProps<any>[],
-    objectRoles: string[]
+    sorting: SortingProps<any>[]
 ) => {
     let queryBuilder = supabaseClient
         .from<AlertSubscriptionsExtendedQuery>(TABLES.ALERT_SUBSCRIPTIONS)
@@ -123,8 +122,7 @@ const getNotificationSubscriptionsForTable = (
                 email
             `,
             { count: 'exact' }
-        )
-        .in('catalog_prefix', objectRoles);
+        );
 
     queryBuilder = defaultTableFilter<AlertSubscriptionsExtendedQuery>(
         queryBuilder,

--- a/src/components/admin/Settings/PrefixAlerts/EmailSelector.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/EmailSelector.tsx
@@ -24,7 +24,8 @@ interface Props {
     setEmailsByPrefix: Dispatch<SetStateAction<EmailDictionary>>;
 }
 
-const simpleEmailRegEx = new RegExp(/.+@.+/m);
+// Validation is VERY basic 'non-whitespace@non-whitespace'
+const simpleEmailRegEx = new RegExp(/^\S+@\S+$/m);
 
 const minCapability = 'admin';
 

--- a/src/components/tables/PrefixAlerts/index.tsx
+++ b/src/components/tables/PrefixAlerts/index.tsx
@@ -3,7 +3,6 @@ import AlertGenerateButton from 'components/admin/Settings/PrefixAlerts/Generate
 import EntityTable from 'components/tables/EntityTable';
 import Rows from 'components/tables/PrefixAlerts/Rows';
 import { useMemo } from 'react';
-import { useEntitiesStore_capabilities_adminable } from 'stores/Entities/hooks';
 import { SelectTableStoreNames } from 'stores/names';
 import { TablePrefixes, useTableState } from 'stores/Tables/hooks';
 import PrefixAlertTableHydrator from 'stores/Tables/PrefixAlerts/Hydrator';
@@ -45,22 +44,14 @@ function PrefixAlertTable() {
         setColumnToSort,
     } = useTableState(TablePrefixes.prefixAlerts, 'catalog_prefix', 'asc');
 
-    const adminCapabilities = useEntitiesStore_capabilities_adminable();
-    const objectRoles = Object.keys(adminCapabilities);
-
     const query = useMemo(() => {
-        return getNotificationSubscriptionsForTable(
-            pagination,
-            searchQuery,
-            [
-                {
-                    col: columnToSort,
-                    direction: sortDirection,
-                },
-            ],
-            objectRoles
-        );
-    }, [columnToSort, objectRoles, pagination, searchQuery, sortDirection]);
+        return getNotificationSubscriptionsForTable(pagination, searchQuery, [
+            {
+                col: columnToSort,
+                direction: sortDirection,
+            },
+        ]);
+    }, [columnToSort, pagination, searchQuery, sortDirection]);
 
     return (
         <PrefixAlertTableHydrator query={query}>


### PR DESCRIPTION
Sharing code

## Issues

https://github.com/estuary/ui/issues/847

## Changes

### 847
- Update the RegEx so it only wants non-whitespace characters
- Trim strings when creating a new field

### Table
- Update query to not filter on roles


## Tests

Manually tested

-   _list the flows/cases you tested_

## Screenshots

Catching spaces inside
![image](https://github.com/estuary/ui/assets/270078/d510200b-799c-47e4-aa5b-3c26af278224)

Fields with strings at the end are stripped
![image](https://github.com/estuary/ui/assets/270078/d3c01638-1ec1-4f31-9dc1-4057a905c43d)
![image](https://github.com/estuary/ui/assets/270078/87fbbed5-2a94-44e7-aa29-089ecf5955d1)

