### PR TITLE
PROD: Update handling resource config change detection

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -32,6 +32,7 @@ import {
     useEditorStore_queryResponse_draftSpecs,
 } from 'components/editor/Store/hooks';
 import FieldSelectionTable from 'components/tables/FieldSelection';
+import { useEntityWorkflow_Editing } from 'context/Workflow';
 import { isEqual } from 'lodash';
 import {
     SyntheticEvent,
@@ -114,7 +115,8 @@ const mapConstraintsToProjections = (
     });
 
 function FieldSelectionViewer({ collectionName }: Props) {
-    const fireBackgroundTest = useRef(true);
+    const isEdit = useEntityWorkflow_Editing();
+    const fireBackgroundTest = useRef(isEdit);
 
     const [refreshRequired, setRefreshRequired] = useState(false);
     const [saveInProgress, setSaveInProgress] = useState(false);
@@ -152,11 +154,11 @@ function FieldSelectionViewer({ collectionName }: Props) {
             // Mainly for when a user enters edit and their initial bg test fails
             //  want to make sure we fire off another bg test if they click on
             //  next and not refresh after updating the config.
-            if (formStatus === FormStatus.FAILED) {
+            if (isEdit && formStatus === FormStatus.FAILED) {
                 fireBackgroundTest.current = true;
             }
         };
-    }, [formStatus]);
+    }, [formStatus, isEdit]);
 
     useEffect(() => {
         // If we need an update at the same time we are generating then we need to show

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -65,13 +65,16 @@ function FieldSelectionTable({ projections }: Props) {
 
     useEffect(() => {
         if (
-            formStatus !== FormStatus.INIT &&
-            formStatus !== FormStatus.FAILED &&
-            (typeof projections === 'undefined' ||
-                projections === null ||
-                formStatus === FormStatus.GENERATING ||
-                formStatus === FormStatus.TESTING ||
-                formStatus === FormStatus.TESTING_BACKGROUND)
+            formStatus === FormStatus.INIT ||
+            formStatus === FormStatus.FAILED
+        ) {
+            setTableState({
+                status: TableStatuses.NO_EXISTING_DATA,
+            });
+        } else if (
+            formStatus === FormStatus.GENERATING ||
+            formStatus === FormStatus.TESTING ||
+            formStatus === FormStatus.TESTING_BACKGROUND
         ) {
             setTableState({ status: TableStatuses.LOADING });
         } else {
@@ -82,7 +85,7 @@ function FieldSelectionTable({ projections }: Props) {
                         : TableStatuses.NO_EXISTING_DATA,
             });
         }
-    }, [setTableState, formStatus, projections]);
+    }, [formStatus, projections]);
 
     const failed = formStatus === FormStatus.FAILED;
     const loading = tableState.status === TableStatuses.LOADING;

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -61,8 +61,6 @@ function FieldSelectionTable({ projections }: Props) {
         },
     };
 
-    console.log('fieldSelection', { formStatus, projections });
-
     useEffect(() => {
         if (
             formStatus === FormStatus.INIT ||

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -61,8 +61,11 @@ function FieldSelectionTable({ projections }: Props) {
         },
     };
 
+    console.log('fieldSelection', { formStatus, projections });
+
     useEffect(() => {
         if (
+            formStatus !== FormStatus.INIT &&
             formStatus !== FormStatus.FAILED &&
             (typeof projections === 'undefined' ||
                 projections === null ||

--- a/src/context/SWR.tsx
+++ b/src/context/SWR.tsx
@@ -111,8 +111,10 @@ const SwrConfigProvider = ({ children }: BaseComponentProps) => {
                         }
                     },
 
-                    onLoadingSlow: () => {
-                        logRocketEvent(CustomEvents.SWR_LOADING_SLOW);
+                    onLoadingSlow: (key) => {
+                        logRocketEvent(CustomEvents.SWR_LOADING_SLOW, {
+                            key,
+                        });
                     },
 
                     // Start with a quick retry in case the problem was ephemeral

--- a/src/hooks/useServerUpdateRequiredMonitor.ts
+++ b/src/hooks/useServerUpdateRequiredMonitor.ts
@@ -40,13 +40,6 @@ const useServerUpdateRequiredMonitor = (draftSpecs: DraftSpecQuery[]) => {
                         binding[collectionNameProp]
                     );
 
-                    // If the collection is no longer there then we are probably applying a schema evolution so we
-                    //      should not require server update as we just got back from the server
-                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                    if (!resourceConfig[collectionName]?.data) {
-                        return false;
-                    }
-
                     // Do a quick simple disabled check before comparing the entire object
                     if (
                         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -58,7 +51,8 @@ const useServerUpdateRequiredMonitor = (draftSpecs: DraftSpecQuery[]) => {
 
                     // Since we checked disabled up above we can not just check if the data changed
                     return !isEqual(
-                        resourceConfig[collectionName].data,
+                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                        resourceConfig[collectionName]?.data,
                         resource
                     );
                 });


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/859

## Changes

### 859
- No longer checking if the collection has been removed in the resource config change monitor
- No longer kick off background testing in create
- 

## Tests

Manually tested

- Create capture
- Create materialization
- Edit capture
- Edit materialization

## Screenshots


