### PR TITLE
Adjust the constraint type sort behavior on the field selection table

### DIFF
--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -24,7 +24,7 @@ interface RowsProps {
     columnToSort: string;
 }
 
-const evaluateConstraintTypes = (
+const compareConstraintTypes = (
     a: CompositeProjection,
     b: CompositeProjection,
     ascendingSort: boolean
@@ -71,7 +71,7 @@ const constraintTypeSort = (
 
     const ascendingSort = sortDirection === 'asc';
 
-    return evaluateConstraintTypes(a, b, ascendingSort);
+    return compareConstraintTypes(a, b, ascendingSort);
 };
 
 function Row({ row }: RowProps) {

--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -21,6 +21,78 @@ interface RowsProps {
     columnToSort: string;
 }
 
+const constraintTypeSort_ascending = (
+    a: CompositeProjection,
+    b: CompositeProjection
+): number => {
+    // If a and b have constraint types but they are not equal, compare their severity.
+    // The projection with the greater severity should appear first.
+    if (
+        a.constraint &&
+        b.constraint &&
+        a.constraint.type !== b.constraint.type
+    ) {
+        return a.constraint.type - b.constraint.type;
+    }
+
+    // If a and b do not have defined constraint types or their constraint types are equal,
+    // perform an ascending, alphabetic sort on their fields.
+    return a.field.localeCompare(b.field);
+};
+
+const constraintTypeSort_descending = (
+    a: CompositeProjection,
+    b: CompositeProjection
+): number => {
+    // If a and b have constraint types but they are not equal, compare their severity.
+    // The projection with the greater severity should appear first.
+    if (
+        a.constraint &&
+        b.constraint &&
+        a.constraint.type !== b.constraint.type
+    ) {
+        return b.constraint.type - a.constraint.type;
+    }
+
+    // If a and b do not have defined constraint types or their constraint types are equal,
+    // perform an descending, alphabetic sort on their fields.
+    return b.field.localeCompare(a.field);
+};
+
+const constraintTypeSort = (
+    a: CompositeProjection,
+    b: CompositeProjection,
+    sortDirection: SortDirection
+) => {
+    // See if the values start with alphanumeric
+    const aIsAlphabetical = a.field.localeCompare('a') >= 0;
+    const bIsAlphabetical = b.field.localeCompare('a') >= 0;
+
+    // If a is not alpha and b is then return >0 to put b first
+    if (!aIsAlphabetical && bIsAlphabetical) {
+        return 1;
+    }
+
+    // If a is alpha and b isn't then return <0 to put a first
+    if (aIsAlphabetical && !bIsAlphabetical) {
+        return -1;
+    }
+
+    // If a does not have a constraint type and b does then return >0 to put b first
+    if (!a.constraint && b.constraint) {
+        return 1;
+    }
+
+    // If a has a constraint type and b does not then return <0 to put a first
+    if (a.constraint && !b.constraint) {
+        return -1;
+    }
+
+    return sortDirection === 'asc'
+        ? constraintTypeSort_ascending(a, b)
+        : constraintTypeSort_descending(a, b);
+};
+
 function Row({ row }: RowProps) {
     return (
         <TableRow
@@ -87,6 +159,26 @@ function Rows({ data, sortDirection, columnToSort }: RowsProps) {
                                 second.field,
                                 sortDirection
                             )
+                    )
+                    .map((record: CompositeProjection, index: number) => (
+                        <Row
+                            row={record}
+                            key={`field-selection-table-rows-${index}`}
+                        />
+                    ))}
+            </>
+        );
+    }
+
+    if (columnToSort === 'constraint.type') {
+        return (
+            <>
+                {data
+                    .sort(
+                        (
+                            first: CompositeProjection,
+                            second: CompositeProjection
+                        ) => constraintTypeSort(first, second, sortDirection)
                     )
                     .map((record: CompositeProjection, index: number) => (
                         <Row

--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -9,7 +9,10 @@ import {
 } from 'context/Theme';
 import { orderBy } from 'lodash';
 import { SortDirection } from 'types';
-import { basicSort_string } from 'utils/misc-utils';
+import {
+    basicSort_string,
+    compareInitialCharacterType,
+} from 'utils/misc-utils';
 
 interface RowProps {
     row: CompositeProjection;
@@ -50,18 +53,10 @@ const constraintTypeSort = (
     b: CompositeProjection,
     sortDirection: SortDirection
 ) => {
-    // See if the values start with alphanumeric
-    const aIsAlphabetical = a.field.localeCompare('a') >= 0;
-    const bIsAlphabetical = b.field.localeCompare('a') >= 0;
+    const sortResult = compareInitialCharacterType(a.field, b.field);
 
-    // If a is not alpha and b is then return >0 to put b first
-    if (!aIsAlphabetical && bIsAlphabetical) {
-        return 1;
-    }
-
-    // If a is alpha and b isn't then return <0 to put a first
-    if (aIsAlphabetical && !bIsAlphabetical) {
-        return -1;
+    if (typeof sortResult === 'number') {
+        return sortResult;
     }
 
     // If a does not have a constraint type and b does then return >0 to put b first

--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -21,9 +21,10 @@ interface RowsProps {
     columnToSort: string;
 }
 
-const constraintTypeSort_ascending = (
+const evaluateConstraintTypes = (
     a: CompositeProjection,
-    b: CompositeProjection
+    b: CompositeProjection,
+    ascendingSort: boolean
 ): number => {
     // If a and b have constraint types but they are not equal, compare their severity.
     // The projection with the greater severity should appear first.
@@ -32,31 +33,16 @@ const constraintTypeSort_ascending = (
         b.constraint &&
         a.constraint.type !== b.constraint.type
     ) {
-        return a.constraint.type - b.constraint.type;
+        return ascendingSort
+            ? a.constraint.type - b.constraint.type
+            : b.constraint.type - a.constraint.type;
     }
 
     // If a and b do not have defined constraint types or their constraint types are equal,
     // perform an ascending, alphabetic sort on their fields.
-    return a.field.localeCompare(b.field);
-};
-
-const constraintTypeSort_descending = (
-    a: CompositeProjection,
-    b: CompositeProjection
-): number => {
-    // If a and b have constraint types but they are not equal, compare their severity.
-    // The projection with the greater severity should appear first.
-    if (
-        a.constraint &&
-        b.constraint &&
-        a.constraint.type !== b.constraint.type
-    ) {
-        return b.constraint.type - a.constraint.type;
-    }
-
-    // If a and b do not have defined constraint types or their constraint types are equal,
-    // perform an descending, alphabetic sort on their fields.
-    return b.field.localeCompare(a.field);
+    return ascendingSort
+        ? a.field.localeCompare(b.field)
+        : b.field.localeCompare(a.field);
 };
 
 const constraintTypeSort = (
@@ -88,9 +74,9 @@ const constraintTypeSort = (
         return -1;
     }
 
-    return sortDirection === 'asc'
-        ? constraintTypeSort_ascending(a, b)
-        : constraintTypeSort_descending(a, b);
+    const ascendingSort = sortDirection === 'asc';
+
+    return evaluateConstraintTypes(a, b, ascendingSort);
 };
 
 function Row({ row }: RowProps) {

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -116,11 +116,7 @@ export const specContainsDerivation = (
     return { isDerivation, derivationKey };
 };
 
-export const basicSort_string = (
-    a: any,
-    b: any,
-    sortDirection: SortDirection
-) => {
+export const compareInitialCharacterType = (a: any, b: any): number | null => {
     // See if the values start with alphanumeric
     const aIsAlphabetical = a.localeCompare('a') >= 0;
     const bIsAlphabetical = b.localeCompare('a') >= 0;
@@ -133,6 +129,23 @@ export const basicSort_string = (
     // If a is alpha and b isn't then return <0 to put a first
     if (aIsAlphabetical && !bIsAlphabetical) {
         return -1;
+    }
+
+    // If a and b have the same classification then return null
+    // to indicate that additional logic is required to determine
+    // the sort order.
+    return null;
+};
+
+export const basicSort_string = (
+    a: any,
+    b: any,
+    sortDirection: SortDirection
+) => {
+    const sortResult = compareInitialCharacterType(a, b);
+
+    if (typeof sortResult === 'number') {
+        return sortResult;
     }
 
     // If we're here we know both strings are alphanumeric and can do normal sorts

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -125,7 +125,7 @@ export const basicSort_string = (
     const aIsAlphabetical = a.localeCompare('a') >= 0;
     const bIsAlphabetical = b.localeCompare('a') >= 0;
 
-    // If a is alpha and b isn't then return >0 to put b first
+    // If a isn't alpha and b is then return >0 to put b first
     if (!aIsAlphabetical && bIsAlphabetical) {
         return 1;
     }


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/775

## Changes

The following features are included in this PR:

-   775
    * Update the constraint type sort behavior on the field selection table so that fields prefixed by `_meta` always appear last. See the issue for an example of the desired sort behavior.
    * Correct a comment in the `basicSort_string` function definition.

## Tests

Approaches to testing are as follows:

-   775
    * Validate the constraint type ascending sort behavior on the field selection table.
    * Validate the constraint type descending sort behavior on the field selection table.
    * Validate the field ascending sort behavior on the field selection table.
    * Validate the field descending sort behavior on the field selection table.

## Screenshots

**Field Selection Table | Constraint Type Sort | Ascending**

<img width="518" alt="pr_screenshot-873-field_selection_sort-constraint_type_asc" src="https://github.com/estuary/ui/assets/77648584/0551028d-4661-454c-9a64-15828462989e">

<br />
<br />

**Field Selection Table | Constraint Type Sort | Descending**

<img width="518" alt="pr_screenshot-873-field_selection_sort-constraint_type_desc" src="https://github.com/estuary/ui/assets/77648584/1041415a-7fc4-40f9-b4b5-ccdd39f2deff">

<br />
<br />

**Field Selection Table | Field Sort | Ascending**

<img width="516" alt="pr_screenshot-873-field_selection_sort-field_asc" src="https://github.com/estuary/ui/assets/77648584/e72abf55-9fd8-4276-959f-8325fcfadfe4">

<br />
<br />

**Field Selection Table | Field Sort | Descending**

<img width="516" alt="pr_screenshot-873-field_selection_sort-field_desc" src="https://github.com/estuary/ui/assets/77648584/759df233-c3e6-41c7-8dd5-4414bd14a255">