### PR TITLE
Wiring up paths for the new ops logs beta stuff

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,14 +4,19 @@ https://github.com/estuary/ui/issues/{issue_number}
 
 ## Changes
 
--   {issue_number}
-    -   _list your changes_
+### {issue_number}
+
+-   changes...
 
 ## Tests
 
-Manually tested
+### Manually tested
 
--   _list the flows/cases you tested_
+-   scenarios you manually tested
+
+### Automated tests
+
+-   unit testing covered
 
 ## Screenshots
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "lint:fix": "eslint --fix --ext js,jsx,ts,tsx .",
         "maintenance:off": "rm public/maintenance",
         "maintenance:on": "touch public/maintenance",
-        "pre_commit": "npm run lint-staged; npm run licenses",
+        "pre_commit": "npm run lint-staged && npm run licenses",
         "prepare": "husky install",
         "preview": "vite preview",
         "start": "npm run licenses && vite",

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -77,6 +77,11 @@ const captures = {
             path: 'history',
             fullPath: '/captures/details/history',
         },
+        ops: {
+            title: 'routeTitle.captureDetails.ops',
+            path: 'ops',
+            fullPath: '/captures/details/ops',
+        },
     },
     edit: {
         title: 'routeTitle.captureEdit',
@@ -117,6 +122,11 @@ const collections = {
             title: 'routeTitle.collectionDetails.history',
             path: 'history',
             fullPath: '/collections/details/history',
+        },
+        ops: {
+            title: 'routeTitle.collectionDetails.ops',
+            path: 'ops',
+            fullPath: '/collections/details/ops',
         },
     },
 };
@@ -163,6 +173,11 @@ const materializations = {
             title: 'routeTitle.materializationDetails.history',
             path: 'history',
             fullPath: '/materializations/details/history',
+        },
+        ops: {
+            title: 'routeTitle.materializationDetails.ops',
+            path: 'ops',
+            fullPath: '/materializations/details/ops',
         },
     },
     edit: {

--- a/src/components/shared/Entity/Details/History.tsx
+++ b/src/components/shared/Entity/Details/History.tsx
@@ -12,7 +12,7 @@ import {
     useTheme,
 } from '@mui/material';
 import ListAndDetails from 'components/editor/ListAndDetails';
-import AlertBox from 'components/shared/AlertBox';
+import UnderDev from 'components/shared/UnderDev';
 import {
     editorToolBarSx,
     monacoEditorComponentBackground,
@@ -93,20 +93,13 @@ function History() {
         }
     }, [publications, selectedPublication]);
 
-    console.log('publications', publications);
-
     if (isValidating || !publications) {
         return <CircularProgress />;
     }
 
     return (
         <Box>
-            <Box sx={{ m: 2 }}>
-                <AlertBox short severity="warning" title="Under Development">
-                    Please feel free to provide any and all feedback to the
-                    front end team.
-                </AlertBox>
-            </Box>
+            <UnderDev />
             <ListAndDetails
                 displayBorder
                 height={getEditorTotalHeight(HEIGHT)}

--- a/src/components/shared/Entity/Details/Ops.tsx
+++ b/src/components/shared/Entity/Details/Ops.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { Box } from '@mui/material';
+import UnderDev from 'components/shared/UnderDev';
+
+function Ops() {
+    // const catalogName = useGlobalSearchParams(GlobalSearchParams.CATALOG_NAME);
+
+    return (
+        <Box>
+            <UnderDev />
+            <Box>Ops logs go here</Box>
+        </Box>
+    );
+}
+
+export default Ops;

--- a/src/components/shared/Entity/Details/RenderTab.tsx
+++ b/src/components/shared/Entity/Details/RenderTab.tsx
@@ -2,6 +2,7 @@ import History from './History';
 import Overview from './Overview';
 import Spec from './Spec';
 import { useDetailsPage } from './context';
+import Ops from './Ops';
 
 function RenderTab() {
     const page = useDetailsPage();
@@ -12,6 +13,9 @@ function RenderTab() {
 
         case 'history':
             return <History />;
+
+        case 'ops':
+            return <Ops />;
 
         default:
             return <Overview />;

--- a/src/components/shared/Entity/Details/context.tsx
+++ b/src/components/shared/Entity/Details/context.tsx
@@ -2,7 +2,10 @@ import { authenticatedRoutes } from 'app/routes';
 import { createContext, useContext } from 'react';
 import { BaseComponentProps } from 'types';
 
-export type Pages = keyof typeof authenticatedRoutes.captures.details;
+export type Pages =
+    | keyof typeof authenticatedRoutes.captures.details
+    | keyof typeof authenticatedRoutes.collections.details
+    | keyof typeof authenticatedRoutes.materializations.details;
 
 interface Props extends BaseComponentProps {
     value: Pages;

--- a/src/components/shared/UnderDev.tsx
+++ b/src/components/shared/UnderDev.tsx
@@ -1,0 +1,15 @@
+import { Box } from '@mui/material';
+import AlertBox from './AlertBox';
+
+function UnderDev() {
+    return (
+        <Box sx={{ m: 2 }}>
+            <AlertBox short severity="warning" title="Under Development">
+                Please feel free to provide any and all feedback to the front
+                end team.
+            </AlertBox>
+        </Box>
+    );
+}
+
+export default UnderDev;

--- a/src/context/Router/index.tsx
+++ b/src/context/Router/index.tsx
@@ -198,6 +198,18 @@ const router = createBrowserRouter(
                                     </Suspense>
                                 }
                             />
+
+                            <Route
+                                path={
+                                    authenticatedRoutes.collections.details.ops
+                                        .path
+                                }
+                                element={
+                                    <Suspense fallback={null}>
+                                        <CollectionDetailsRoute tab="ops" />
+                                    </Suspense>
+                                }
+                            />
                         </Route>
 
                         <Route
@@ -298,6 +310,18 @@ const router = createBrowserRouter(
                                     </Suspense>
                                 }
                             />
+
+                            <Route
+                                path={
+                                    authenticatedRoutes.captures.details.ops
+                                        .path
+                                }
+                                element={
+                                    <Suspense fallback={null}>
+                                        <CaptureDetailsRoute tab="ops" />
+                                    </Suspense>
+                                }
+                            />
                         </Route>
                     </Route>
 
@@ -383,6 +407,18 @@ const router = createBrowserRouter(
                                 element={
                                     <Suspense fallback={null}>
                                         <MaterializationDetailsRoute tab="history" />
+                                    </Suspense>
+                                }
+                            />
+
+                            <Route
+                                path={
+                                    authenticatedRoutes.materializations.details
+                                        .ops.path
+                                }
+                                element={
+                                    <Suspense fallback={null}>
+                                        <MaterializationDetailsRoute tab="ops" />
                                     </Suspense>
                                 }
                             />


### PR DESCRIPTION
## Issues

Contributes to https://github.com/estuary/ui/issues/858

## Changes

### 858
- Add in a new path

### Misc
- Updated GitHub PR template due to how it was formatting nested lists
- Cleaning up some logging
- Update `pre_commit` script

## Tests

Manually tested

- Hit all the new paths

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/7ce6b403-0335-4054-be15-be9e4db22a2f)
![image](https://github.com/estuary/ui/assets/270078/6092de9d-2cb1-44e7-9c2e-e7efe9a7e374)
![image](https://github.com/estuary/ui/assets/270078/c28793c8-e584-4730-b5d2-81e3ae49d676)
