### PR TITLE
Tweaks to log rocket logging

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -8,12 +8,10 @@ import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
-import { Schema } from 'types';
 
-const trackEvent = (status: string, args: Schema = {}) => {
+const trackEvent = (status: string) => {
     logRocketEvent(CustomEvents.LOGIN, {
         status: `getSessionFromUrl ${status}`,
-        ...args,
     });
 };
 
@@ -64,7 +62,7 @@ const Auth = () => {
                     if (response.error) {
                         const error = response.error.message;
 
-                        trackEvent('failed', { error });
+                        trackEvent('failed');
                         await failed(error);
                     }
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -7,9 +7,9 @@ import { useSnackbar } from 'notistack';
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { logRocketEvent } from 'services/shared';
-import { CustomEvents } from 'services/types';
+import { CommonStatuses, CustomEvents } from 'services/types';
 
-const trackEvent = (status: string) => {
+const trackEvent = (status: CommonStatuses) => {
     logRocketEvent(CustomEvents.LOGIN, {
         status: `getSessionFromUrl ${status}`,
     });

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -6,11 +6,10 @@ import {
 import { User, createClient } from '@supabase/supabase-js';
 import { ToPostgrestFilterBuilder } from 'hooks/supabase-swr';
 import { forEach, isEmpty } from 'lodash';
-import LogRocket from 'logrocket';
 import { JobStatus, SortDirection, SupabaseInvokeResponse } from 'types';
 import { hasLength, incrementInterval, timeoutCleanUp } from 'utils/misc-utils';
 import retry from 'retry';
-import { logRocketEvent, retryAfterFailure } from './shared';
+import { logRocketConsole, logRocketEvent, retryAfterFailure } from './shared';
 import { CustomEvents } from './types';
 
 if (
@@ -433,11 +432,11 @@ export const jobStatusPoller = (
     let interval = DEFAULT_POLLING_INTERVAL;
     let attempts = 0;
     const makeApiCall = () => {
-        LogRocket.log('Poller : start ');
+        logRocketConsole('Poller : start ');
 
         return query.throwOnError().then(
             (payload: any) => {
-                LogRocket.log('Poller : response : ', payload);
+                logRocketConsole('Poller : response');
                 timeoutCleanUp(pollerTimeout);
 
                 if (payload.error) {
@@ -452,8 +451,9 @@ export const jobStatusPoller = (
                         response?.job_status?.type &&
                         response.job_status.type !== 'queued'
                     ) {
-                        LogRocket.log(
-                            `Poller : response : ${response.job_status.type}`
+                        logRocketConsole(
+                            `Poller : response : ${response.job_status.type}`,
+                            response
                         );
 
                         if (
@@ -466,6 +466,8 @@ export const jobStatusPoller = (
                             failure(response);
                         }
                     } else {
+                        logRocketConsole('Poller : response : trying again');
+
                         interval = incrementInterval(interval);
                         pollerTimeout = window.setTimeout(
                             makeApiCall,
@@ -475,14 +477,14 @@ export const jobStatusPoller = (
                 }
             },
             (error: any) => {
-                LogRocket.log('Poller : error : ', error);
+                logRocketConsole('Poller : error : ', error);
 
                 if (
                     attempts === 0 &&
                     typeof error?.message === 'string' &&
                     retryAfterFailure(error.message)
                 ) {
-                    LogRocket.log('Poller : error : trying again');
+                    logRocketConsole('Poller : error : trying again');
                     attempts += 1;
 
                     // We do not update the interval here like we do up above
@@ -492,7 +494,7 @@ export const jobStatusPoller = (
                         incrementInterval(interval)
                     );
                 } else {
-                    LogRocket.log('Poller : error : returning failure');
+                    logRocketConsole('Poller : error : returning failure');
                     timeoutCleanUp(pollerTimeout);
                     failure(handleFailure(JOB_STATUS_POLLER_ERROR));
                 }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -31,3 +31,5 @@ export enum CustomEvents {
     SUPABASE_CALL_UNAUTHENTICATED = 'Supabase_Call_Unauthenticated',
     SWR_LOADING_SLOW = 'SWR_Loading_Slow',
 }
+
+export type CommonStatuses = 'success' | 'failed' | 'exception' | 'skipped';

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -18,6 +18,7 @@ export enum CustomEvents {
     FULL_PAGE_ERROR_DISPLAYED = 'Full_Page_Error_Displayed',
     GATEWAY_TOKEN_FAILED = 'Gateway_Auth_Token:CallFailed',
     GATEWAY_TOKEN_INVALID_PREFIX = 'Gateway_Auth_Token:InvalidPrefix',
+    LOGIN = 'Login',
     MATERIALIZATION_CREATE = 'Materialization_Create',
     MATERIALIZATION_CREATE_CONFIG_CREATE = 'Materialization_Create_Config_Create',
     MATERIALIZATION_CREATE_CONFIG_EDIT = 'Materialization_Create_Config_Edit',


### PR DESCRIPTION
## Issues

tech debt

## Changes

### Misc

- Used the `logRocketConsole` so the poller shows in logs during dev
- Cleaned up how often we log the `response` because we are no longer debuggin the `realtime` issue and it is logging overboard at this point.
- Added some login specific events

## Tests

### Manually tested

- Tested discover, publish, etc. 

### Automated tests

- N/A

## Screenshots

Capture Discover
Top outline = logging
Bottom outline = custom event
![image](https://github.com/estuary/ui/assets/270078/c139785d-8124-4558-915e-92985202bbdb)

Capture Publish
Top outline = logging
Bottom outline = custom event
![image](https://github.com/estuary/ui/assets/270078/0668f002-45cb-4e8f-b35c-b2834af27b8e)


