### PR TITLE
Catch loading errors

### DIFF
--- a/src/components/shared/ErrorBoundryWrapper.tsx
+++ b/src/components/shared/ErrorBoundryWrapper.tsx
@@ -3,11 +3,9 @@ import { NavArrowDown } from 'iconoir-react';
 import { ReactNode, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useMount } from 'react-use';
 import { logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
 import AlertBox from './AlertBox';
-import MustReloadDialog from './MustReloadDialog';
 
 interface Props {
     children: ReactNode;
@@ -22,34 +20,15 @@ const logErrorToLogRocket = (error: Error) => {
     });
 };
 
-const ChunkError = 'ChunkLoadError';
-const FailedFetch_DynamicImport = 'Failed to fetch dynamically imported';
-
 function ErrorFallback({ error }: { error: Error }): JSX.Element {
     const intl = useIntl();
     const theme = useTheme();
 
-    const [offerReload, setOfferReload] = useState(false);
     const [expanded, setExpanded] = useState(false);
 
     const handleExpandClick = () => {
         setExpanded(!expanded);
     };
-
-    useMount(() => {
-        // In case the error is due to failing to fetch a chunk then show
-        //  a reload dialog to inform the user what happened.
-        if (
-            error.message.includes(FailedFetch_DynamicImport) ||
-            error.name === ChunkError
-        ) {
-            setOfferReload(true);
-        }
-    });
-
-    if (offerReload) {
-        return <MustReloadDialog />;
-    }
 
     return (
         <AlertBox

--- a/src/components/shared/ErrorBoundryWrapper.tsx
+++ b/src/components/shared/ErrorBoundryWrapper.tsx
@@ -22,6 +22,9 @@ const logErrorToLogRocket = (error: Error) => {
     });
 };
 
+const ChunkError = 'ChunkLoadError';
+const FailedFetch_DynamicImport = 'Failed to fetch dynamically imported';
+
 function ErrorFallback({ error }: { error: Error }): JSX.Element {
     const intl = useIntl();
     const theme = useTheme();
@@ -36,7 +39,10 @@ function ErrorFallback({ error }: { error: Error }): JSX.Element {
     useMount(() => {
         // In case the error is due to failing to fetch a chunk then show
         //  a reload dialog to inform the user what happened.
-        if (error.name === 'ChunkLoadError') {
+        if (
+            error.message.includes(FailedFetch_DynamicImport) ||
+            error.name === ChunkError
+        ) {
             setOfferReload(true);
         }
     });

--- a/src/context/Router/index.tsx
+++ b/src/context/Router/index.tsx
@@ -10,7 +10,7 @@ import DataPlaneAuthReq from 'pages/DataPlaneAuthReq';
 import Login from 'pages/Login';
 import TestJsonForms from 'pages/dev/TestJsonForms';
 import PageNotFound from 'pages/error/PageNotFound';
-import { Suspense, lazy } from 'react';
+import { Suspense } from 'react';
 import {
     Route,
     RouterProvider,
@@ -25,36 +25,41 @@ import AdminConnectors from 'components/admin/Connectors';
 import AdminBilling from 'components/admin/Billing';
 import AdminSettings from 'components/admin/Settings';
 import HomePage from 'pages/Home';
+import { handledLazy } from 'services/react';
 import MaterializationsTable from './MaterializationsTable';
 import CapturesTable from './CapturesTable';
 import RequireAuth from './RequireAuth';
 import Authenticated from './Authenticated';
 
 // Capture
-const CaptureCreateRoute = lazy(() => import('./CaptureCreate'));
-const CaptureCreateNewRoute = lazy(() => import('./CaptureCreateNew'));
-const CaptureDetailsRoute = lazy(() => import('./CaptureDetails'));
-const CaptureEditRoute = lazy(() => import('./CaptureEdit'));
+const CaptureCreateRoute = handledLazy(() => import('./CaptureCreate'));
+const CaptureCreateNewRoute = handledLazy(() => import('./CaptureCreateNew'));
+const CaptureDetailsRoute = handledLazy(() => import('./CaptureDetails'));
+const CaptureEditRoute = handledLazy(() => import('./CaptureEdit'));
 
 // Collection
-const DerivationCreateComponent = lazy(
+const DerivationCreateComponent = handledLazy(
     () => import('components/derivation/Create')
 );
-const CollectionCreateRoute = lazy(() => import('./CollectionCreate'));
-const CollectionCreateNewRoute = lazy(() => import('./CollectionCreateNew'));
-const CollectionDetailsRoute = lazy(() => import('./CollectionDetails'));
+const CollectionCreateRoute = handledLazy(() => import('./CollectionCreate'));
+const CollectionCreateNewRoute = handledLazy(
+    () => import('./CollectionCreateNew')
+);
+const CollectionDetailsRoute = handledLazy(() => import('./CollectionDetails'));
 
 //Materializations
-const MaterializationCreateRoute = lazy(
+const MaterializationCreateRoute = handledLazy(
     () => import('./MaterializationCreate')
 );
-const MaterializationCreateNewRoute = lazy(
+const MaterializationCreateNewRoute = handledLazy(
     () => import('./MaterializationCreateNew')
 );
-const MaterializationDetailsRoute = lazy(
+const MaterializationDetailsRoute = handledLazy(
     () => import('./MaterializationDetails')
 );
-const MaterializationEditRoute = lazy(() => import('./MaterializationEdit'));
+const MaterializationEditRoute = handledLazy(
+    () => import('./MaterializationEdit')
+);
 
 const router = createBrowserRouter(
     createRoutesFromElements(

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -2,6 +2,7 @@ import IconoirProvider from 'context/Iconoir';
 import NotificationProvider from 'context/Notifications';
 import SwrConfigProvider from 'context/SWR';
 import { BaseComponentProps } from 'types';
+import ErrorBoundryWrapper from 'components/shared/ErrorBoundryWrapper';
 import ClientProvider from './Client';
 import ContentProvider from './Content';
 import { SidePanelDocsProvider } from './SidePanelDocs';
@@ -15,13 +16,15 @@ const AppProviders = ({ children }: BaseComponentProps) => {
                 <IconoirProvider>
                     <ClientProvider>
                         <NotificationProvider>
-                            <SwrConfigProvider>
-                                <UserProvider>
-                                    <SidePanelDocsProvider>
-                                        {children}
-                                    </SidePanelDocsProvider>
-                                </UserProvider>
-                            </SwrConfigProvider>
+                            <ErrorBoundryWrapper>
+                                <SwrConfigProvider>
+                                    <UserProvider>
+                                        <SidePanelDocsProvider>
+                                            {children}
+                                        </SidePanelDocsProvider>
+                                    </UserProvider>
+                                </SwrConfigProvider>
+                            </ErrorBoundryWrapper>
                         </NotificationProvider>
                     </ClientProvider>
                 </IconoirProvider>

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -14,9 +14,9 @@ const AppProviders = ({ children }: BaseComponentProps) => {
         <ContentProvider>
             <ThemeProvider>
                 <IconoirProvider>
-                    <ClientProvider>
-                        <NotificationProvider>
-                            <ErrorBoundryWrapper>
+                    <ErrorBoundryWrapper>
+                        <ClientProvider>
+                            <NotificationProvider>
                                 <SwrConfigProvider>
                                     <UserProvider>
                                         <SidePanelDocsProvider>
@@ -24,9 +24,9 @@ const AppProviders = ({ children }: BaseComponentProps) => {
                                         </SidePanelDocsProvider>
                                     </UserProvider>
                                 </SwrConfigProvider>
-                            </ErrorBoundryWrapper>
-                        </NotificationProvider>
-                    </ClientProvider>
+                            </NotificationProvider>
+                        </ClientProvider>
+                    </ErrorBoundryWrapper>
                 </IconoirProvider>
             </ThemeProvider>
         </ContentProvider>

--- a/src/services/react.ts
+++ b/src/services/react.ts
@@ -1,0 +1,17 @@
+import MustReloadDialog from 'components/shared/MustReloadDialog';
+import { lazy } from 'react';
+import { logRocketConsole, logRocketEvent } from './shared';
+import { CustomEvents } from './types';
+
+const handledLazy = (factory: () => Promise<{ default: any }>) => {
+    return lazy(() =>
+        factory().catch((error) => {
+            logRocketEvent(CustomEvents.LAZY_LOADING, 'failed');
+            logRocketConsole('Component Failed Loading:', error);
+
+            return { default: MustReloadDialog };
+        })
+    );
+};
+
+export { handledLazy };

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -18,6 +18,7 @@ export enum CustomEvents {
     FULL_PAGE_ERROR_DISPLAYED = 'Full_Page_Error_Displayed',
     GATEWAY_TOKEN_FAILED = 'Gateway_Auth_Token:CallFailed',
     GATEWAY_TOKEN_INVALID_PREFIX = 'Gateway_Auth_Token:InvalidPrefix',
+    LAZY_LOADING = 'Lazy Loading',
     LOGIN = 'Login',
     MATERIALIZATION_CREATE = 'Materialization_Create',
     MATERIALIZATION_CREATE_CONFIG_CREATE = 'Materialization_Create_Config_Create',


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/900

## Changes

### 900

- New function that will handle errors from lazy loading and return the dialog whenever it is needed

## Tests

### Manually tested

- Ran a build, ran preview, hit the page, made simple change, stopped preview, ran a build, ran a preview, went back to browser and clicked around

### Automated tests

- n/a

## Screenshots

same as before
