### PR TITLE
Ensure tenants fetch is fetching all

### DIFF
--- a/src/api/combinedGrantsExt.ts
+++ b/src/api/combinedGrantsExt.ts
@@ -6,6 +6,7 @@ import {
     SortingProps,
     supabaseClient,
     TABLES,
+    DEFAULT_PAGING_SIZE,
 } from 'services/supabase';
 import { AuthRoles, Capability, Grant_UserExt } from 'types';
 
@@ -77,10 +78,9 @@ const getGrants_Users = (
     return queryBuilder;
 };
 
-const getAuthPageSize = 1000;
 export async function getAuthRoles(
     capability: string,
-    pageSize: number = getAuthPageSize
+    pageSize: number = DEFAULT_PAGING_SIZE
 ) {
     const responses = await pagedFetchAll<AuthRoles>(
         pageSize,

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -1,4 +1,10 @@
-import { supabaseClient, TABLES } from 'services/supabase';
+import {
+    DEFAULT_PAGING_SIZE,
+    pagedFetchAll,
+    parsePagedFetchAllResponse,
+    supabaseClient,
+    TABLES,
+} from 'services/supabase';
 import { Tenants } from 'types';
 
 const COLUMNS = [
@@ -9,10 +15,18 @@ const COLUMNS = [
     'trial_start',
 ];
 
-const getTenantDetails = () => {
-    return supabaseClient
-        .from<Tenants>(TABLES.TENANTS)
-        .select(COLUMNS.join(','));
+const getTenantDetails = async (pageSize: number = DEFAULT_PAGING_SIZE) => {
+    const responses = await pagedFetchAll<Tenants>(
+        pageSize,
+        'getTenantDetails',
+        (start) =>
+            supabaseClient
+                .from<Tenants>(TABLES.TENANTS)
+                .select(COLUMNS.join(','))
+                .range(start, start + pageSize - 1)
+    );
+
+    return parsePagedFetchAllResponse<Tenants>(responses);
 };
 
 export { getTenantDetails };

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -1,11 +1,13 @@
 import { getTenantDetails } from 'api/tenants';
+import useSWR from 'swr';
 import { Tenants } from 'types';
-import { useSelectNew } from './supabase-swr/hooks/useSelect';
 
 const defaultResponse: Tenants[] = [];
 
 function useTenants() {
-    const { data, error, isValidating } = useSelectNew(getTenantDetails());
+    const { data, error, isValidating } = useSWR('useTenants', () =>
+        getTenantDetails()
+    );
 
     return {
         tenants: data ? (data.data as Tenants[]) : defaultResponse,

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -340,6 +340,8 @@ export const jobSucceeded = (jobStatus?: JobStatus) => {
     }
 };
 
+export const DEFAULT_PAGING_SIZE = 1000;
+
 export type ParsedPagedFetchAllResponse<T> =
     | { data: T[] | null; error: null }
     | { data: null; error: PostgrestError };


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/904

## Changes

### 904

- get all the tenants to be fetched through paging

## Tests

### Manually tested

- Ran a preview with support account and saw all fetches
- Ran local and clicked around

### Automated tests

- none

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/5a3dfd32-27ea-435a-acd6-f15c600db779)

