### PR TITLE
Conditionally display optional field selection table columns

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -3,10 +3,8 @@ import {
     Checkbox,
     FormControl,
     FormControlLabel,
-    IconButton,
     Stack,
     Typography,
-    useTheme,
 } from '@mui/material';
 import MessageWithLink from 'components/content/MessageWithLink';
 import RefreshButton from 'components/editor/Bindings/FieldSelection/RefreshButton';
@@ -39,9 +37,7 @@ import FieldSelectionTable, {
 } from 'components/tables/FieldSelection';
 import SelectColumnMenu from 'components/tables/SelectColumnMenu';
 import { useDisplayTableColumns } from 'context/TableSettings';
-import { primaryColoredOutline } from 'context/Theme';
 import { useEntityWorkflow_Editing } from 'context/Workflow';
-import { ViewColumns3 } from 'iconoir-react';
 import { isEqual } from 'lodash';
 import {
     SyntheticEvent,
@@ -131,7 +127,6 @@ const optionalColumns = columns.filter((column) =>
 
 function FieldSelectionViewer({ collectionName }: Props) {
     const intl = useIntl();
-    const theme = useTheme();
 
     const { tableSettings, setTableSettings } = useDisplayTableColumns();
 
@@ -471,17 +466,6 @@ function FieldSelectionViewer({ collectionName }: Props) {
                         }
                     />
                 </FormControl>
-
-                <IconButton
-                    sx={{
-                        borderRadius: 2,
-                        border: primaryColoredOutline[theme.palette.mode],
-                    }}
-                >
-                    <ViewColumns3
-                        style={{ color: theme.palette.primary.main }}
-                    />
-                </IconButton>
 
                 <SelectColumnMenu
                     columns={optionalColumns}

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -31,7 +31,7 @@ import { useDisplayTableColumns } from 'context/TableSettings';
 import { useEntityWorkflow_Editing } from 'context/Workflow';
 import { isEqual } from 'lodash';
 import { SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { useMount } from 'react-use';
 import { logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
@@ -120,8 +120,6 @@ const optionalColumns = columns.filter(
 );
 
 function FieldSelectionViewer({ collectionName }: Props) {
-    const intl = useIntl();
-
     const { tableSettings, setTableSettings } = useDisplayTableColumns();
 
     const isEdit = useEntityWorkflow_Editing();
@@ -335,10 +333,8 @@ function FieldSelectionViewer({ collectionName }: Props) {
             setTableSettings({
                 ...existingSettings,
                 [TablePrefixes.fieldSelection]: {
-                    hiddenColumns: optionalColumns.map((column) =>
-                        column.headerIntlKey
-                            ? intl.formatMessage({ id: column.headerIntlKey })
-                            : ''
+                    hiddenColumns: optionalColumns.map(
+                        (column) => column.headerIntlKey
                     ),
                 },
             });

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -48,6 +48,7 @@ import {
     useState,
 } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useMount } from 'react-use';
 import { logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
 import { useEndpointConfig_serverUpdateRequired } from 'stores/EndpointConfig/hooks';
@@ -358,7 +359,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
         setSelectionSaving,
     ]);
 
-    useEffect(() => {
+    useMount(() => {
         const existingSettings = tableSettings ?? {};
 
         if (!tableSettings || !Object.hasOwn(tableSettings, 'fieldSelection')) {
@@ -373,7 +374,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
                 },
             });
         }
-    }, []);
+    });
 
     const updateTableSettings = (
         event: SyntheticEvent,

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -470,6 +470,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
                 <SelectColumnMenu
                     columns={optionalColumns}
                     onChange={updateTableSettings}
+                    disabled={loading}
                 />
             </Stack>
 

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -44,7 +44,9 @@ import {
 import { FormStatus } from 'stores/FormState/types';
 import { useResourceConfig_serverUpdateRequired } from 'stores/ResourceConfig/hooks';
 import { TablePrefixes } from 'stores/Tables/hooks';
-import { Schema } from 'types';
+import { Schema, TableColumns } from 'types';
+import { WithRequiredNonNullProperty } from 'types/utils';
+import { hasLength } from 'utils/misc-utils';
 import {
     evaluateRequiredIncludedFields,
     getBindingIndex,
@@ -105,10 +107,16 @@ const mapConstraintsToProjections = (
         };
     });
 
-const optionalColumns = columns.filter((column) =>
-    typeof column.headerIntlKey === 'string'
-        ? Object.values(optionalColumnIntlKeys).includes(column.headerIntlKey)
-        : false
+const optionalColumns = columns.filter(
+    (
+        column
+    ): column is WithRequiredNonNullProperty<TableColumns, 'headerIntlKey'> =>
+        typeof column.headerIntlKey === 'string' &&
+        hasLength(column.headerIntlKey)
+            ? Object.values(optionalColumnIntlKeys).includes(
+                  column.headerIntlKey
+              )
+            : false
 );
 
 function FieldSelectionViewer({ collectionName }: Props) {

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -353,49 +353,35 @@ function FieldSelectionViewer({ collectionName }: Props) {
         event.preventDefault();
         event.stopPropagation();
 
-        if (
-            tableSettings &&
-            Object.hasOwn(tableSettings, TablePrefixes.fieldSelection)
-        ) {
-            const { hiddenColumns } =
-                tableSettings[TablePrefixes.fieldSelection];
-
-            const evaluatedSettings =
-                checked && hiddenColumns.includes(column)
-                    ? {
-                          ...tableSettings,
-                          [TablePrefixes.fieldSelection]: {
-                              hiddenColumns: hiddenColumns.filter(
-                                  (value) => value !== column
-                              ),
-                          },
-                      }
-                    : !checked && !hiddenColumns.includes(column)
-                    ? {
-                          ...tableSettings,
-                          [TablePrefixes.fieldSelection]: {
-                              hiddenColumns: [...hiddenColumns, column],
-                          },
-                      }
-                    : tableSettings;
-
-            setTableSettings(evaluatedSettings);
-
-            return;
-        }
-
         const existingSettings = tableSettings ?? {};
 
-        setTableSettings(
-            !checked
+        const hiddenColumns = Object.hasOwn(
+            existingSettings,
+            TablePrefixes.fieldSelection
+        )
+            ? existingSettings[TablePrefixes.fieldSelection].hiddenColumns
+            : [];
+
+        const evaluatedSettings =
+            checked && hiddenColumns.includes(column)
                 ? {
                       ...existingSettings,
                       [TablePrefixes.fieldSelection]: {
-                          hiddenColumns: [column],
+                          hiddenColumns: hiddenColumns.filter(
+                              (value) => value !== column
+                          ),
                       },
                   }
-                : existingSettings
-        );
+                : !checked && !hiddenColumns.includes(column)
+                ? {
+                      ...existingSettings,
+                      [TablePrefixes.fieldSelection]: {
+                          hiddenColumns: [...hiddenColumns, column],
+                      },
+                  }
+                : existingSettings;
+
+        setTableSettings(evaluatedSettings);
     };
 
     const loading = formActive || formStatus === FormStatus.TESTING_BACKGROUND;

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -33,7 +33,10 @@ import {
     useEditorStore_id,
     useEditorStore_queryResponse_draftSpecs,
 } from 'components/editor/Store/hooks';
-import FieldSelectionTable, { columns } from 'components/tables/FieldSelection';
+import FieldSelectionTable, {
+    columns,
+    optionalColumnIntlKeys,
+} from 'components/tables/FieldSelection';
 import SelectColumnMenu from 'components/tables/SelectColumnMenu';
 import { useDisplayTableColumns } from 'context/TableSettings';
 import { primaryColoredOutline } from 'context/Theme';
@@ -120,13 +123,11 @@ const mapConstraintsToProjections = (
         };
     });
 
-const optionalColumns = columns.filter((column) => {
-    const intlKeys = ['data.pointer', 'fieldSelection.table.label.details'];
-
-    return typeof column.headerIntlKey === 'string'
-        ? intlKeys.includes(column.headerIntlKey)
-        : false;
-});
+const optionalColumns = columns.filter((column) =>
+    typeof column.headerIntlKey === 'string'
+        ? Object.values(optionalColumnIntlKeys).includes(column.headerIntlKey)
+        : false
+);
 
 function FieldSelectionViewer({ collectionName }: Props) {
     const intl = useIntl();

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -1,11 +1,4 @@
-import {
-    Box,
-    Checkbox,
-    FormControl,
-    FormControlLabel,
-    Stack,
-    Typography,
-} from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import MessageWithLink from 'components/content/MessageWithLink';
 import RefreshButton from 'components/editor/Bindings/FieldSelection/RefreshButton';
 import {
@@ -21,11 +14,9 @@ import {
 import useFieldSelection from 'components/editor/Bindings/FieldSelection/useFieldSelection';
 import {
     useBindingsEditorStore_initializeSelections,
-    useBindingsEditorStore_recommendFields,
     useBindingsEditorStore_selectionSaving,
     useBindingsEditorStore_setRecommendFields,
     useBindingsEditorStore_setSelectionSaving,
-    useBindingsEditorStore_setSingleSelection,
 } from 'components/editor/Bindings/Store/hooks';
 import {
     useEditorStore_id,
@@ -39,14 +30,7 @@ import SelectColumnMenu from 'components/tables/SelectColumnMenu';
 import { useDisplayTableColumns } from 'context/TableSettings';
 import { useEntityWorkflow_Editing } from 'context/Workflow';
 import { isEqual } from 'lodash';
-import {
-    SyntheticEvent,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import { SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useMount } from 'react-use';
 import { logRocketEvent } from 'services/shared';
@@ -144,11 +128,9 @@ function FieldSelectionViewer({ collectionName }: Props) {
     const { refresh } = useFieldSelectionRefresh();
 
     // Bindings Editor Store
-    const recommendFields = useBindingsEditorStore_recommendFields();
     const setRecommendFields = useBindingsEditorStore_setRecommendFields();
 
     const initializeSelections = useBindingsEditorStore_initializeSelections();
-    const setSingleSelection = useBindingsEditorStore_setSingleSelection();
 
     const selectionSaving = useBindingsEditorStore_selectionSaving();
     const setSelectionSaving = useBindingsEditorStore_setSelectionSaving();
@@ -292,31 +274,6 @@ function FieldSelectionViewer({ collectionName }: Props) {
         setRecommendFields,
     ]);
 
-    const toggleRecommendFields = useCallback(
-        (event: SyntheticEvent, checked) => {
-            event.preventDefault();
-            event.stopPropagation();
-
-            setRecommendFields(!recommendFields);
-
-            data?.forEach(({ field, constraint }) => {
-                if (!checked && constraint) {
-                    const includeRequired =
-                        constraint.type === ConstraintTypes.FIELD_REQUIRED ||
-                        constraint.type === ConstraintTypes.LOCATION_REQUIRED;
-
-                    setSingleSelection(
-                        field,
-                        includeRequired ? 'include' : null
-                    );
-                } else {
-                    setSingleSelection(field, 'default');
-                }
-            });
-        },
-        [setRecommendFields, setSingleSelection, data, recommendFields]
-    );
-
     const draftSpec = useMemo(
         () =>
             draftSpecs.length > 0 && draftSpecs[0].spec ? draftSpecs[0] : null,
@@ -448,26 +405,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
                 </Stack>
             </Stack>
 
-            <Stack
-                direction="row"
-                sx={{ mb: 1, justifyContent: 'space-between' }}
-            >
-                <FormControl sx={{ mx: 0 }}>
-                    <FormControlLabel
-                        control={
-                            <Checkbox
-                                value={recommendFields}
-                                checked={recommendFields}
-                                disabled={loading || !data}
-                            />
-                        }
-                        onChange={toggleRecommendFields}
-                        label={
-                            <FormattedMessage id="fieldSelection.cta.defaultAllFields" />
-                        }
-                    />
-                </FormControl>
-
+            <Stack direction="row" sx={{ mb: 1, justifyContent: 'flex-end' }}>
                 <SelectColumnMenu
                     columns={optionalColumns}
                     onChange={updateTableSettings}

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -32,7 +32,6 @@ import { useEntityWorkflow_Editing } from 'context/Workflow';
 import { isEqual } from 'lodash';
 import { SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useMount } from 'react-use';
 import { logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
 import { useEndpointConfig_serverUpdateRequired } from 'stores/EndpointConfig/hooks';
@@ -323,24 +322,6 @@ function FieldSelectionViewer({ collectionName }: Props) {
         setSelectionSaving,
     ]);
 
-    useMount(() => {
-        const existingSettings = tableSettings ?? {};
-
-        if (
-            !tableSettings ||
-            !Object.hasOwn(tableSettings, TablePrefixes.fieldSelection)
-        ) {
-            setTableSettings({
-                ...existingSettings,
-                [TablePrefixes.fieldSelection]: {
-                    hiddenColumns: optionalColumns.map(
-                        (column) => column.headerIntlKey
-                    ),
-                },
-            });
-        }
-    });
-
     const updateTableSettings = (
         event: SyntheticEvent,
         checked: boolean,
@@ -351,28 +332,32 @@ function FieldSelectionViewer({ collectionName }: Props) {
 
         const existingSettings = tableSettings ?? {};
 
-        const hiddenColumns = Object.hasOwn(
+        const shownOptionalColumns = Object.hasOwn(
             existingSettings,
             TablePrefixes.fieldSelection
         )
-            ? existingSettings[TablePrefixes.fieldSelection].hiddenColumns
+            ? existingSettings[TablePrefixes.fieldSelection]
+                  .shownOptionalColumns
             : [];
 
         const evaluatedSettings =
-            checked && hiddenColumns.includes(column)
+            !checked && shownOptionalColumns.includes(column)
                 ? {
                       ...existingSettings,
                       [TablePrefixes.fieldSelection]: {
-                          hiddenColumns: hiddenColumns.filter(
+                          shownOptionalColumns: shownOptionalColumns.filter(
                               (value) => value !== column
                           ),
                       },
                   }
-                : !checked && !hiddenColumns.includes(column)
+                : checked && !shownOptionalColumns.includes(column)
                 ? {
                       ...existingSettings,
                       [TablePrefixes.fieldSelection]: {
-                          hiddenColumns: [...hiddenColumns, column],
+                          shownOptionalColumns: [
+                              ...shownOptionalColumns,
+                              column,
+                          ],
                       },
                   }
                 : existingSettings;

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -340,8 +340,10 @@ function FieldSelectionViewer({ collectionName }: Props) {
                   .shownOptionalColumns
             : [];
 
+        const columnShown = shownOptionalColumns.includes(column);
+
         const evaluatedSettings =
-            !checked && shownOptionalColumns.includes(column)
+            !checked && columnShown
                 ? {
                       ...existingSettings,
                       [TablePrefixes.fieldSelection]: {
@@ -350,7 +352,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
                           ),
                       },
                   }
-                : checked && !shownOptionalColumns.includes(column)
+                : checked && !columnShown
                 ? {
                       ...existingSettings,
                       [TablePrefixes.fieldSelection]: {

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -43,6 +43,7 @@ import {
 } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
 import { useResourceConfig_serverUpdateRequired } from 'stores/ResourceConfig/hooks';
+import { TablePrefixes } from 'stores/Tables/hooks';
 import { Schema } from 'types';
 import {
     evaluateRequiredIncludedFields,
@@ -168,7 +169,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
             setRefreshRequired(true);
         } else if (formStatus === FormStatus.TESTED) {
             // If we are here then the flag might be true and we only can stop showing it
-            //  if there is a test ran. This is kinda janky as a test does not 100% garuntee
+            //  if there is a test ran. This is kinda janky as a test does not 100% guarantee
             //  a built spec but it is pretty darn close.
             setRefreshRequired(false);
         }
@@ -319,10 +320,13 @@ function FieldSelectionViewer({ collectionName }: Props) {
     useMount(() => {
         const existingSettings = tableSettings ?? {};
 
-        if (!tableSettings || !Object.hasOwn(tableSettings, 'fieldSelection')) {
+        if (
+            !tableSettings ||
+            !Object.hasOwn(tableSettings, TablePrefixes.fieldSelection)
+        ) {
             setTableSettings({
                 ...existingSettings,
-                fieldSelection: {
+                [TablePrefixes.fieldSelection]: {
                     hiddenColumns: optionalColumns.map((column) =>
                         column.headerIntlKey
                             ? intl.formatMessage({ id: column.headerIntlKey })
@@ -341,14 +345,18 @@ function FieldSelectionViewer({ collectionName }: Props) {
         event.preventDefault();
         event.stopPropagation();
 
-        if (tableSettings && Object.hasOwn(tableSettings, 'fieldSelection')) {
-            const { hiddenColumns } = tableSettings.fieldSelection;
+        if (
+            tableSettings &&
+            Object.hasOwn(tableSettings, TablePrefixes.fieldSelection)
+        ) {
+            const { hiddenColumns } =
+                tableSettings[TablePrefixes.fieldSelection];
 
             const evaluatedSettings =
                 checked && hiddenColumns.includes(column)
                     ? {
                           ...tableSettings,
-                          fieldSelection: {
+                          [TablePrefixes.fieldSelection]: {
                               hiddenColumns: hiddenColumns.filter(
                                   (value) => value !== column
                               ),
@@ -357,7 +365,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
                     : !checked && !hiddenColumns.includes(column)
                     ? {
                           ...tableSettings,
-                          fieldSelection: {
+                          [TablePrefixes.fieldSelection]: {
                               hiddenColumns: [...hiddenColumns, column],
                           },
                       }
@@ -374,7 +382,9 @@ function FieldSelectionViewer({ collectionName }: Props) {
             !checked
                 ? {
                       ...existingSettings,
-                      fieldSelection: { hiddenColumns: [column] },
+                      [TablePrefixes.fieldSelection]: {
+                          hiddenColumns: [column],
+                      },
                   }
                 : existingSettings
         );

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -3,8 +3,10 @@ import {
     Checkbox,
     FormControl,
     FormControlLabel,
+    IconButton,
     Stack,
     Typography,
+    useTheme,
 } from '@mui/material';
 import MessageWithLink from 'components/content/MessageWithLink';
 import RefreshButton from 'components/editor/Bindings/FieldSelection/RefreshButton';
@@ -31,8 +33,11 @@ import {
     useEditorStore_id,
     useEditorStore_queryResponse_draftSpecs,
 } from 'components/editor/Store/hooks';
-import FieldSelectionTable from 'components/tables/FieldSelection';
+import FieldSelectionTable, { columns } from 'components/tables/FieldSelection';
+import SelectColumnMenu from 'components/tables/SelectColumnMenu';
+import { primaryColoredOutline } from 'context/Theme';
 import { useEntityWorkflow_Editing } from 'context/Workflow';
+import { ViewColumns3 } from 'iconoir-react';
 import { isEqual } from 'lodash';
 import {
     SyntheticEvent,
@@ -115,6 +120,8 @@ const mapConstraintsToProjections = (
     });
 
 function FieldSelectionViewer({ collectionName }: Props) {
+    const theme = useTheme();
+
     const isEdit = useEntityWorkflow_Editing();
     const fireBackgroundTest = useRef(isEdit);
 
@@ -347,11 +354,7 @@ function FieldSelectionViewer({ collectionName }: Props) {
 
     return (
         <Box sx={{ mt: 3 }}>
-            <Stack
-                direction="row"
-                spacing={1}
-                sx={{ mb: 2, justifyContent: 'space-between' }}
-            >
+            <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
                 <Stack spacing={1}>
                     <Stack direction="row">
                         <Typography variant="h6" sx={{ mr: 0.5 }}>
@@ -372,21 +375,47 @@ function FieldSelectionViewer({ collectionName }: Props) {
                 </Stack>
             </Stack>
 
-            <FormControl sx={{ mb: 1, mx: 0 }}>
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            value={recommendFields}
-                            checked={recommendFields}
-                            disabled={loading || !data}
-                        />
-                    }
-                    onChange={toggleRecommendFields}
-                    label={
-                        <FormattedMessage id="fieldSelection.cta.defaultAllFields" />
-                    }
+            <Stack
+                direction="row"
+                sx={{ mb: 1, justifyContent: 'space-between' }}
+            >
+                <FormControl sx={{ mx: 0 }}>
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                value={recommendFields}
+                                checked={recommendFields}
+                                disabled={loading || !data}
+                            />
+                        }
+                        onChange={toggleRecommendFields}
+                        label={
+                            <FormattedMessage id="fieldSelection.cta.defaultAllFields" />
+                        }
+                    />
+                </FormControl>
+
+                <IconButton
+                    sx={{
+                        borderRadius: 2,
+                        border: primaryColoredOutline[theme.palette.mode],
+                    }}
+                >
+                    <ViewColumns3
+                        style={{ color: theme.palette.primary.main }}
+                    />
+                </IconButton>
+
+                <SelectColumnMenu
+                    columns={columns.filter(
+                        (column) =>
+                            column.headerIntlKey === 'data.pointer' ||
+                            column.headerIntlKey ===
+                                'fieldSelection.table.label.details'
+                    )}
+                    onChange={() => {}}
                 />
-            </FormControl>
+            </Stack>
 
             <FieldSelectionTable projections={data} />
         </Box>

--- a/src/components/menus/IconMenu.tsx
+++ b/src/components/menus/IconMenu.tsx
@@ -27,8 +27,9 @@ interface Props {
     identifier: string;
     tooltip: string;
     children: ReactNode;
-    hideArrow?: boolean;
     customMenuPosition?: CustomPopoverPosition;
+    disableCloseOnClick?: boolean;
+    hideArrow?: boolean;
 }
 
 const IconMenu = ({
@@ -37,8 +38,9 @@ const IconMenu = ({
     ariaLabel,
     icon,
     children,
-    hideArrow,
     customMenuPosition,
+    disableCloseOnClick,
+    hideArrow,
 }: Props) => {
     const [anchorEl, setAnchorEl] =
         React.useState<PopoverProps['anchorEl']>(null);
@@ -109,7 +111,7 @@ const IconMenu = ({
                 anchorEl={anchorEl}
                 open={open}
                 onClose={handlers.close}
-                onClick={handlers.close}
+                onClick={disableCloseOnClick ? undefined : handlers.close}
                 transformOrigin={
                     customMenuPosition?.transformOrigin ?? {
                         horizontal: 'right',

--- a/src/components/menus/IconMenu.tsx
+++ b/src/components/menus/IconMenu.tsx
@@ -13,6 +13,8 @@ import {
     defaultOutline,
     paperBackground,
     paperBackgroundImage,
+    primaryColoredOutline,
+    primaryColoredOutline_hovered,
 } from 'context/Theme';
 import React, { ReactNode } from 'react';
 
@@ -30,6 +32,7 @@ interface Props {
     customMenuPosition?: CustomPopoverPosition;
     disableCloseOnClick?: boolean;
     hideArrow?: boolean;
+    outlinedButton?: boolean;
 }
 
 const IconMenu = ({
@@ -41,6 +44,7 @@ const IconMenu = ({
     customMenuPosition,
     disableCloseOnClick,
     hideArrow,
+    outlinedButton,
 }: Props) => {
     const [anchorEl, setAnchorEl] =
         React.useState<PopoverProps['anchorEl']>(null);
@@ -98,7 +102,28 @@ const IconMenu = ({
                         aria-haspopup="true"
                         aria-expanded={open ? 'true' : undefined}
                         onClick={handlers.click}
-                        sx={{ color: (theme) => theme.palette.text.primary }}
+                        sx={
+                            outlinedButton
+                                ? {
+                                      'borderRadius': 2,
+                                      'border': (theme) =>
+                                          primaryColoredOutline[
+                                              theme.palette.mode
+                                          ],
+                                      'color': (theme) =>
+                                          theme.palette.primary.main,
+                                      '&:hover': {
+                                          border: (theme) =>
+                                              primaryColoredOutline_hovered[
+                                                  theme.palette.mode
+                                              ],
+                                      },
+                                  }
+                                : {
+                                      color: (theme) =>
+                                          theme.palette.text.primary,
+                                  }
+                        }
                     >
                         {icon}
                     </IconButton>

--- a/src/components/menus/IconMenu.tsx
+++ b/src/components/menus/IconMenu.tsx
@@ -14,6 +14,7 @@ import {
     paperBackground,
     paperBackgroundImage,
     primaryColoredOutline,
+    primaryColoredOutline_disabled,
     primaryColoredOutline_hovered,
 } from 'context/Theme';
 import React, { ReactNode } from 'react';
@@ -31,6 +32,7 @@ interface Props {
     children: ReactNode;
     customMenuPosition?: CustomPopoverPosition;
     disableCloseOnClick?: boolean;
+    disabled?: boolean;
     hideArrow?: boolean;
     outlinedButton?: boolean;
 }
@@ -43,6 +45,7 @@ const IconMenu = ({
     children,
     customMenuPosition,
     disableCloseOnClick,
+    disabled,
     hideArrow,
     outlinedButton,
 }: Props) => {
@@ -102,6 +105,7 @@ const IconMenu = ({
                         aria-haspopup="true"
                         aria-expanded={open ? 'true' : undefined}
                         onClick={handlers.click}
+                        disabled={disabled}
                         sx={
                             outlinedButton
                                 ? {
@@ -115,6 +119,12 @@ const IconMenu = ({
                                       '&:hover': {
                                           border: (theme) =>
                                               primaryColoredOutline_hovered[
+                                                  theme.palette.mode
+                                              ],
+                                      },
+                                      '&.Mui-disabled': {
+                                          border: (theme) =>
+                                              primaryColoredOutline_disabled[
                                                   theme.palette.mode
                                               ],
                                       },

--- a/src/components/menus/IconMenu.tsx
+++ b/src/components/menus/IconMenu.tsx
@@ -11,11 +11,9 @@ import {
 } from '@mui/material';
 import {
     defaultOutline,
+    outlinedIconButtonStyling,
     paperBackground,
     paperBackgroundImage,
-    primaryColoredOutline,
-    primaryColoredOutline_disabled,
-    primaryColoredOutline_hovered,
 } from 'context/Theme';
 import React, { ReactNode } from 'react';
 
@@ -108,27 +106,7 @@ const IconMenu = ({
                         disabled={disabled}
                         sx={
                             outlinedButton
-                                ? {
-                                      'borderRadius': 2,
-                                      'border': (theme) =>
-                                          primaryColoredOutline[
-                                              theme.palette.mode
-                                          ],
-                                      'color': (theme) =>
-                                          theme.palette.primary.main,
-                                      '&:hover': {
-                                          border: (theme) =>
-                                              primaryColoredOutline_hovered[
-                                                  theme.palette.mode
-                                              ],
-                                      },
-                                      '&.Mui-disabled': {
-                                          border: (theme) =>
-                                              primaryColoredOutline_disabled[
-                                                  theme.palette.mode
-                                              ],
-                                      },
-                                  }
+                                ? outlinedIconButtonStyling
                                 : {
                                       color: (theme) =>
                                           theme.palette.text.primary,

--- a/src/components/tables/EntityTable/TableHeader.tsx
+++ b/src/components/tables/EntityTable/TableHeader.tsx
@@ -43,6 +43,13 @@ function EntityTableHeader({
                         };
                     }
 
+                    if (column.width) {
+                        tableCellSX = {
+                            ...tableCellSX,
+                            width: column.width,
+                        };
+                    }
+
                     // If we have no message let the width be 0 so the cell can collapse
                     //   to the min-content of the column. Helpful for the button at the end of the table
                     if (column.collapseHeader) {

--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -1,7 +1,6 @@
 import { TableCell, TableRow, Typography } from '@mui/material';
 import { CompositeProjection } from 'components/editor/Bindings/FieldSelection/types';
 import ChipListCell from 'components/tables/cells/ChipList';
-import ConstraintDetails from 'components/tables/cells/fieldSelection/ConstraintDetails';
 import FieldActions from 'components/tables/cells/fieldSelection/FieldActions';
 import {
     doubleElevationHoverBackground,
@@ -99,21 +98,13 @@ function Row({ row }: RowProps) {
             )}
 
             {row.constraint ? (
-                <>
-                    <ConstraintDetails constraint={row.constraint} />
-
-                    <FieldActions
-                        field={row.field}
-                        constraint={row.constraint}
-                        selectionType={row.selectionType}
-                    />
-                </>
+                <FieldActions
+                    field={row.field}
+                    constraint={row.constraint}
+                    selectionType={row.selectionType}
+                />
             ) : (
-                <>
-                    <TableCell />
-
-                    <TableCell />
-                </>
+                <TableCell />
             )}
         </TableRow>
     );

--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -12,6 +12,7 @@ import {
     basicSort_string,
     compareInitialCharacterType,
 } from 'utils/misc-utils';
+import ConstraintDetails from '../cells/fieldSelection/ConstraintDetails';
 
 interface RowProps {
     row: CompositeProjection;
@@ -98,13 +99,21 @@ function Row({ row }: RowProps) {
             )}
 
             {row.constraint ? (
-                <FieldActions
-                    field={row.field}
-                    constraint={row.constraint}
-                    selectionType={row.selectionType}
-                />
+                <>
+                    <ConstraintDetails constraint={row.constraint} />
+
+                    <FieldActions
+                        field={row.field}
+                        constraint={row.constraint}
+                        selectionType={row.selectionType}
+                    />
+                </>
             ) : (
-                <TableCell />
+                <>
+                    <TableCell />
+
+                    <TableCell />
+                </>
             )}
         </TableRow>
     );

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -107,7 +107,7 @@ function FieldSelectionTable({ projections }: Props) {
                           : true
                   )
                 : columns,
-        [tableSettings]
+        [intl, tableSettings]
     );
 
     return (

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -105,9 +105,7 @@ function FieldSelectionTable({ projections }: Props) {
                       column.headerIntlKey
                           ? !tableSettings[
                                 TablePrefixes.fieldSelection
-                            ].hiddenColumns.includes(
-                                intl.formatMessage({ id: column.headerIntlKey })
-                            )
+                            ].hiddenColumns.includes(column.headerIntlKey)
                           : true
                   )
                 : columns,

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 export const optionalColumnIntlKeys = {
     pointer: 'data.pointer',
-    details: 'fieldSelection.table.label.details',
+    details: 'data.details',
 };
 
 export const columns: TableColumns[] = [
@@ -40,7 +40,7 @@ export const columns: TableColumns[] = [
     },
     {
         field: null,
-        headerIntlKey: 'fieldSelection.table.label.actions',
+        headerIntlKey: 'data.actions',
     },
 ];
 

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
+import { TablePrefixes } from 'stores/Tables/hooks';
 import { SortDirection, TableColumns, TableState, TableStatuses } from 'types';
 
 interface Props {
@@ -98,10 +99,13 @@ function FieldSelectionTable({ projections }: Props) {
 
     const columnsToShow = useMemo(
         () =>
-            tableSettings && Object.hasOwn(tableSettings, 'fieldSelection')
+            tableSettings &&
+            Object.hasOwn(tableSettings, TablePrefixes.fieldSelection)
                 ? columns.filter((column) =>
                       column.headerIntlKey
-                          ? !tableSettings.fieldSelection.hiddenColumns.includes(
+                          ? !tableSettings[
+                                TablePrefixes.fieldSelection
+                            ].hiddenColumns.includes(
                                 intl.formatMessage({ id: column.headerIntlKey })
                             )
                           : true

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -28,6 +28,10 @@ export const columns: TableColumns[] = [
         headerIntlKey: 'data.type',
     },
     {
+        field: 'constraint.type',
+        headerIntlKey: 'fieldSelection.table.label.details',
+    },
+    {
         field: null,
         headerIntlKey: 'fieldSelection.table.label.actions',
     },
@@ -43,7 +47,7 @@ function FieldSelectionTable({ projections }: Props) {
     });
 
     const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
-    const [columnToSort, setColumnToSort] = useState('constraint.type');
+    const [columnToSort, setColumnToSort] = useState('field');
 
     const handlers = {
         sortRequest: (_event: React.MouseEvent<unknown>, column: any) => {

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -28,10 +28,6 @@ export const columns: TableColumns[] = [
         headerIntlKey: 'data.type',
     },
     {
-        field: 'constraint.type',
-        headerIntlKey: 'fieldSelection.table.label.details',
-    },
-    {
         field: null,
         headerIntlKey: 'fieldSelection.table.label.actions',
     },

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -41,6 +41,7 @@ export const columns: TableColumns[] = [
     {
         field: null,
         headerIntlKey: 'data.actions',
+        width: 148,
     },
 ];
 

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -44,6 +44,13 @@ export const columns: TableColumns[] = [
     },
 ];
 
+const evaluateColumnsToShow = (columnsToHide: string[]) =>
+    columns.filter((column) =>
+        column.headerIntlKey
+            ? !columnsToHide.includes(column.headerIntlKey)
+            : true
+    );
+
 function FieldSelectionTable({ projections }: Props) {
     const intl = useIntl();
 
@@ -97,20 +104,25 @@ function FieldSelectionTable({ projections }: Props) {
 
     const { tableSettings } = useDisplayTableColumns();
 
-    const columnsToShow = useMemo(
-        () =>
+    const columnsToShow = useMemo(() => {
+        const optionalColumns = Object.values(optionalColumnIntlKeys);
+
+        if (
             tableSettings &&
             Object.hasOwn(tableSettings, TablePrefixes.fieldSelection)
-                ? columns.filter((column) =>
-                      column.headerIntlKey
-                          ? !tableSettings[
-                                TablePrefixes.fieldSelection
-                            ].hiddenColumns.includes(column.headerIntlKey)
-                          : true
-                  )
-                : columns,
-        [intl, tableSettings]
-    );
+        ) {
+            const hiddenColumns = optionalColumns.filter(
+                (column) =>
+                    !tableSettings[
+                        TablePrefixes.fieldSelection
+                    ].shownOptionalColumns.includes(column)
+            );
+
+            return evaluateColumnsToShow(hiddenColumns);
+        }
+
+        return evaluateColumnsToShow(optionalColumns);
+    }, [intl, tableSettings]);
 
     return (
         <Box>

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -14,16 +14,10 @@ import { ViewColumns3 } from 'iconoir-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { TablePrefixes } from 'stores/Tables/hooks';
 import { TableColumns } from 'types';
-
-// TODO: Move custom utility types to a shared location.
-// type WithRequiredProperty<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-
-// type WithRequiredNonNullProperty<T, K extends keyof T> = T & {
-//     [P in K]-?: Exclude<T[P], null>;
-// };
+import { WithRequiredNonNullProperty } from 'types/utils';
 
 interface Props {
-    columns: TableColumns[];
+    columns: WithRequiredNonNullProperty<TableColumns, 'headerIntlKey'>[];
     onChange: (
         event: React.SyntheticEvent<Element, Event>,
         checked: boolean,
@@ -69,9 +63,9 @@ function SelectColumnMenu({ columns, onChange, disabled }: Props) {
 
             <Stack sx={{ px: 2 }}>
                 {columns.map((column, index) => {
-                    const label = column.headerIntlKey
-                        ? intl.formatMessage({ id: column.headerIntlKey })
-                        : '';
+                    const label = intl.formatMessage({
+                        id: column.headerIntlKey,
+                    });
 
                     return (
                         <FormControl

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -1,0 +1,88 @@
+import {
+    Box,
+    Checkbox,
+    FormControl,
+    FormControlLabel,
+    Stack,
+    Typography,
+} from '@mui/material';
+import IconMenu from 'components/menus/IconMenu';
+import { useDisplayTableColumns } from 'context/TableSettings';
+import { ViewColumns3 } from 'iconoir-react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { TableColumns } from 'types';
+
+// type WithRequiredProperty<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+interface Props {
+    columns: TableColumns[];
+    onChange: (
+        event: React.SyntheticEvent<Element, Event>,
+        checked: boolean
+    ) => void;
+}
+
+function SelectColumnMenu({ columns, onChange }: Props) {
+    const intl = useIntl();
+
+    const { tableSettings } = useDisplayTableColumns();
+
+    return (
+        <IconMenu
+            ariaLabel={intl.formatMessage({
+                id: 'entityTable.selectColumn.button.ariaLabel',
+            })}
+            icon={<ViewColumns3 />}
+            identifier="select-table-columns-menu"
+            tooltip={intl.formatMessage({
+                id: 'entityTable.selectColumn.button.tooltip',
+            })}
+        >
+            <Typography
+                component={Box}
+                sx={{ width: 200, px: 2, pb: 1, fontWeight: 500 }}
+            >
+                <FormattedMessage id="entityTable.selectColumn.menu.header" />
+            </Typography>
+
+            <Stack sx={{ px: 2 }}>
+                {columns.map((column, index) => {
+                    const label = column.headerIntlKey
+                        ? intl.formatMessage({ id: column.headerIntlKey })
+                        : '';
+
+                    return (
+                        <FormControl
+                            key={`column-option-${index}`}
+                            sx={{ mx: 0 }}
+                        >
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        value={label}
+                                        checked={
+                                            tableSettings &&
+                                            Object.hasOwn(
+                                                tableSettings,
+                                                'fieldSelection'
+                                            )
+                                                ? tableSettings.fieldSelection.hiddenColumns.includes(
+                                                      label
+                                                  )
+                                                : false
+                                        }
+                                        // disabled={loading || !data}
+                                    />
+                                }
+                                onChange={onChange}
+                                label={label}
+                            />
+                        </FormControl>
+                    );
+                })}
+            </Stack>
+        </IconMenu>
+    );
+}
+
+export default SelectColumnMenu;

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -12,13 +12,19 @@ import { ViewColumns3 } from 'iconoir-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { TableColumns } from 'types';
 
+// TODO: Move custom utility types to a shared location.
 // type WithRequiredProperty<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+// type WithRequiredNonNullProperty<T, K extends keyof T> = T & {
+//     [P in K]-?: Exclude<T[P], null>;
+// };
 
 interface Props {
     columns: TableColumns[];
     onChange: (
         event: React.SyntheticEvent<Element, Event>,
-        checked: boolean
+        checked: boolean,
+        column: string
     ) => void;
 }
 
@@ -32,6 +38,7 @@ function SelectColumnMenu({ columns, onChange }: Props) {
             ariaLabel={intl.formatMessage({
                 id: 'entityTable.selectColumn.button.ariaLabel',
             })}
+            disableCloseOnClick
             icon={<ViewColumns3 />}
             identifier="select-table-columns-menu"
             tooltip={intl.formatMessage({
@@ -66,7 +73,7 @@ function SelectColumnMenu({ columns, onChange }: Props) {
                                                 tableSettings,
                                                 'fieldSelection'
                                             )
-                                                ? tableSettings.fieldSelection.hiddenColumns.includes(
+                                                ? !tableSettings.fieldSelection.hiddenColumns.includes(
                                                       label
                                                   )
                                                 : false
@@ -74,7 +81,9 @@ function SelectColumnMenu({ columns, onChange }: Props) {
                                         // disabled={loading || !data}
                                     />
                                 }
-                                onChange={onChange}
+                                onChange={(event, checked) =>
+                                    onChange(event, checked, label)
+                                }
                                 label={label}
                             />
                         </FormControl>

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -61,7 +61,7 @@ function SelectColumnMenu({ columns, onChange, disabled }: Props) {
         >
             <Typography
                 component={Box}
-                sx={{ width: 200, px: 2, pb: 1, fontWeight: 500 }}
+                sx={{ minWidth: 'max-content', px: 2, pb: 1, fontWeight: 500 }}
             >
                 <FormattedMessage id="entityTable.selectColumn.menu.header" />
             </Typography>

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -5,6 +5,7 @@ import {
     FormControlLabel,
     Stack,
     Typography,
+    useTheme,
 } from '@mui/material';
 import IconMenu from 'components/menus/IconMenu';
 import { useDisplayTableColumns } from 'context/TableSettings';
@@ -30,6 +31,7 @@ interface Props {
 
 function SelectColumnMenu({ columns, onChange }: Props) {
     const intl = useIntl();
+    const theme = useTheme();
 
     const { tableSettings } = useDisplayTableColumns();
 
@@ -39,8 +41,11 @@ function SelectColumnMenu({ columns, onChange }: Props) {
                 id: 'entityTable.selectColumn.button.ariaLabel',
             })}
             disableCloseOnClick
-            icon={<ViewColumns3 />}
+            icon={
+                <ViewColumns3 style={{ color: theme.palette.primary.main }} />
+            }
             identifier="select-table-columns-menu"
+            outlinedButton
             tooltip={intl.formatMessage({
                 id: 'entityTable.selectColumn.button.tooltip',
             })}

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import IconMenu from 'components/menus/IconMenu';
 import { useDisplayTableColumns } from 'context/TableSettings';
+import { disabledButtonText_primary } from 'context/Theme';
 import { ViewColumns3 } from 'iconoir-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { TableColumns } from 'types';
@@ -27,9 +28,10 @@ interface Props {
         checked: boolean,
         column: string
     ) => void;
+    disabled?: boolean;
 }
 
-function SelectColumnMenu({ columns, onChange }: Props) {
+function SelectColumnMenu({ columns, onChange, disabled }: Props) {
     const intl = useIntl();
     const theme = useTheme();
 
@@ -41,8 +43,15 @@ function SelectColumnMenu({ columns, onChange }: Props) {
                 id: 'entityTable.selectColumn.button.ariaLabel',
             })}
             disableCloseOnClick
+            disabled={disabled}
             icon={
-                <ViewColumns3 style={{ color: theme.palette.primary.main }} />
+                <ViewColumns3
+                    style={{
+                        color: disabled
+                            ? disabledButtonText_primary[theme.palette.mode]
+                            : theme.palette.primary.main,
+                    }}
+                />
             }
             identifier="select-table-columns-menu"
             outlinedButton

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -12,6 +12,7 @@ import { useDisplayTableColumns } from 'context/TableSettings';
 import { disabledButtonText_primary } from 'context/Theme';
 import { ViewColumns3 } from 'iconoir-react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { TablePrefixes } from 'stores/Tables/hooks';
 import { TableColumns } from 'types';
 
 // TODO: Move custom utility types to a shared location.
@@ -85,9 +86,12 @@ function SelectColumnMenu({ columns, onChange, disabled }: Props) {
                                             tableSettings &&
                                             Object.hasOwn(
                                                 tableSettings,
-                                                'fieldSelection'
+                                                TablePrefixes.fieldSelection
                                             )
-                                                ? !tableSettings.fieldSelection.hiddenColumns.includes(
+                                                ? !tableSettings[
+                                                      TablePrefixes
+                                                          .fieldSelection
+                                                  ].hiddenColumns.includes(
                                                       label
                                                   )
                                                 : false

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -74,9 +74,9 @@ function SelectColumnMenu({ columns, onChange, disabled }: Props) {
                                             tableSettings,
                                             TablePrefixes.fieldSelection
                                         )
-                                            ? !tableSettings[
+                                            ? tableSettings[
                                                   TablePrefixes.fieldSelection
-                                              ].hiddenColumns.includes(
+                                              ].shownOptionalColumns.includes(
                                                   headerIntlKey
                                               )
                                             : false

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -90,7 +90,6 @@ function SelectColumnMenu({ columns, onChange, disabled }: Props) {
                                                   )
                                                 : false
                                         }
-                                        // disabled={loading || !data}
                                     />
                                 }
                                 onChange={(event, checked) =>

--- a/src/components/tables/SelectColumnMenu.tsx
+++ b/src/components/tables/SelectColumnMenu.tsx
@@ -62,44 +62,34 @@ function SelectColumnMenu({ columns, onChange, disabled }: Props) {
             </Typography>
 
             <Stack sx={{ px: 2 }}>
-                {columns.map((column, index) => {
-                    const label = intl.formatMessage({
-                        id: column.headerIntlKey,
-                    });
-
-                    return (
-                        <FormControl
-                            key={`column-option-${index}`}
-                            sx={{ mx: 0 }}
-                        >
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        value={label}
-                                        checked={
-                                            tableSettings &&
-                                            Object.hasOwn(
-                                                tableSettings,
-                                                TablePrefixes.fieldSelection
-                                            )
-                                                ? !tableSettings[
-                                                      TablePrefixes
-                                                          .fieldSelection
-                                                  ].hiddenColumns.includes(
-                                                      label
-                                                  )
-                                                : false
-                                        }
-                                    />
-                                }
-                                onChange={(event, checked) =>
-                                    onChange(event, checked, label)
-                                }
-                                label={label}
-                            />
-                        </FormControl>
-                    );
-                })}
+                {columns.map(({ headerIntlKey }, index) => (
+                    <FormControl key={`column-option-${index}`} sx={{ mx: 0 }}>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    value={headerIntlKey}
+                                    checked={
+                                        tableSettings &&
+                                        Object.hasOwn(
+                                            tableSettings,
+                                            TablePrefixes.fieldSelection
+                                        )
+                                            ? !tableSettings[
+                                                  TablePrefixes.fieldSelection
+                                              ].hiddenColumns.includes(
+                                                  headerIntlKey
+                                              )
+                                            : false
+                                    }
+                                />
+                            }
+                            onChange={(event, checked) =>
+                                onChange(event, checked, headerIntlKey)
+                            }
+                            label={intl.formatMessage({ id: headerIntlKey })}
+                        />
+                    </FormControl>
+                ))}
             </Stack>
         </IconMenu>
     );

--- a/src/components/tables/cells/fieldSelection/OutlinedToggleButton.tsx
+++ b/src/components/tables/cells/fieldSelection/OutlinedToggleButton.tsx
@@ -65,6 +65,7 @@ function OutlinedToggleButton({
 
     const defaultStateSx: SxProps<Theme> = coloredDefaultState
         ? {
+              backgroundColor: (theme) => backgroundColor[theme.palette.mode],
               border: (theme) => outline[theme.palette.mode],
               color: (theme) => getTextColor(theme, value),
           }
@@ -72,6 +73,8 @@ function OutlinedToggleButton({
 
     const disabledStateSx: SxProps<Theme> = coloredDefaultState
         ? {
+              backgroundColor: (theme) =>
+                  disabledBackgroundColor[theme.palette.mode],
               border: (theme) => disabledOutline[theme.palette.mode],
               color: (theme) => getDisabledTextColor(theme, value),
           }

--- a/src/components/tables/cells/fieldSelection/OutlinedToggleButton.tsx
+++ b/src/components/tables/cells/fieldSelection/OutlinedToggleButton.tsx
@@ -1,4 +1,10 @@
-import { SxProps, Theme, ToggleButton, ToggleButtonProps } from '@mui/material';
+import {
+    SxProps,
+    Theme,
+    ToggleButton,
+    ToggleButtonProps,
+    useTheme,
+} from '@mui/material';
 import { FieldSelectionType } from 'components/editor/Bindings/FieldSelection/types';
 import {
     defaultOutline_hovered,
@@ -29,15 +35,58 @@ interface Props {
     onClick?: ToggleButtonProps['onClick'];
 }
 
-const getTextColor = (theme: Theme, value: FieldSelectionType) =>
-    value === 'include'
+const getBackgroundColor = (value: FieldSelectionType, disabled?: boolean) => {
+    if (disabled) {
+        return value === 'include'
+            ? successOutlinedButtonBackground_disabled
+            : errorOutlinedButtonBackground_disabled;
+    }
+
+    return value === 'include'
+        ? successOutlinedButtonBackground
+        : errorOutlinedButtonBackground;
+};
+
+const getOutline = (value: FieldSelectionType, disabled?: boolean) => {
+    if (disabled) {
+        return value === 'include'
+            ? successColoredOutline_disabled
+            : errorColoredOutline_disabled;
+    }
+
+    return value === 'include' ? successColoredOutline : errorColoredOutline;
+};
+
+const getTextColor = (
+    theme: Theme,
+    value: FieldSelectionType,
+    disabled?: boolean
+) => {
+    if (disabled) {
+        return value === 'include'
+            ? disabledButtonText_success[theme.palette.mode]
+            : disabledButtonText_error;
+    }
+
+    return value === 'include'
         ? successButtonText[theme.palette.mode]
         : theme.palette.error.main;
+};
 
-const getDisabledTextColor = (theme: Theme, value: FieldSelectionType) =>
-    value === 'include'
-        ? disabledButtonText_success[theme.palette.mode]
-        : disabledButtonText_error;
+const getBaseSx = (
+    theme: Theme,
+    value: FieldSelectionType,
+    disabled?: boolean
+) => {
+    const backgroundColor = getBackgroundColor(value, disabled);
+    const outline = getOutline(value, disabled);
+
+    return {
+        backgroundColor: backgroundColor[theme.palette.mode],
+        border: outline[theme.palette.mode],
+        color: getTextColor(theme, value, disabled),
+    };
+};
 
 function OutlinedToggleButton({
     messageId,
@@ -48,68 +97,40 @@ function OutlinedToggleButton({
     onChange,
     onClick,
 }: Props) {
-    const backgroundColor =
-        value === 'include'
-            ? successOutlinedButtonBackground
-            : errorOutlinedButtonBackground;
-
-    const disabledBackgroundColor =
-        value === 'include'
-            ? successOutlinedButtonBackground_disabled
-            : errorOutlinedButtonBackground_disabled;
-
-    const outline =
-        value === 'include' ? successColoredOutline : errorColoredOutline;
+    const theme = useTheme();
 
     const hoveredOutline =
         value === 'include'
             ? successColoredOutline_hovered
             : errorColoredOutline_hovered;
 
-    const disabledOutline =
-        value === 'include'
-            ? successColoredOutline_disabled
-            : errorColoredOutline_disabled;
+    const baseSx = getBaseSx(theme, value, disabled);
 
     const defaultStateSx: SxProps<Theme> = coloredDefaultState
         ? {
-              'backgroundColor': (theme) => backgroundColor[theme.palette.mode],
-              'border': (theme) => outline[theme.palette.mode],
-              'color': (theme) => getTextColor(theme, value),
+              ...baseSx,
               '&:hover': {
-                  border: (theme) => hoveredOutline[theme.palette.mode],
+                  border: hoveredOutline[theme.palette.mode],
               },
           }
         : {
               '&:hover': {
-                  border: (theme) => defaultOutline_hovered[theme.palette.mode],
+                  border: defaultOutline_hovered[theme.palette.mode],
               },
           };
 
     const disabledStateSx: SxProps<Theme> = coloredDefaultState
-        ? {
-              backgroundColor: (theme) =>
-                  disabledBackgroundColor[theme.palette.mode],
-              border: (theme) => disabledOutline[theme.palette.mode],
-              color: (theme) => getDisabledTextColor(theme, value),
-          }
+        ? baseSx
         : {
-              border: (theme) => `1px solid ${theme.palette.divider}`,
+              border: `1px solid ${theme.palette.divider}`,
           };
 
     const selectedStateSx: SxProps<Theme> = disabled
-        ? {
-              backgroundColor: (theme) =>
-                  disabledBackgroundColor[theme.palette.mode],
-              border: (theme) => disabledOutline[theme.palette.mode],
-              color: (theme) => getDisabledTextColor(theme, value),
-          }
+        ? baseSx
         : {
-              'backgroundColor': (theme) => backgroundColor[theme.palette.mode],
-              'border': (theme) => outline[theme.palette.mode],
-              'color': (theme) => getTextColor(theme, value),
+              ...baseSx,
               '&:hover': {
-                  border: (theme) => hoveredOutline[theme.palette.mode],
+                  border: hoveredOutline[theme.palette.mode],
               },
           };
 
@@ -124,7 +145,7 @@ function OutlinedToggleButton({
             sx={{
                 'px': '9px',
                 'py': '3px',
-                'border': (theme) => intensifiedOutline[theme.palette.mode],
+                'border': intensifiedOutline[theme.palette.mode],
                 'borderRadius': 2,
                 '&.Mui-disabled': disabledStateSx,
                 '&.Mui-selected': selectedStateSx,

--- a/src/components/tables/cells/fieldSelection/OutlinedToggleButton.tsx
+++ b/src/components/tables/cells/fieldSelection/OutlinedToggleButton.tsx
@@ -1,16 +1,19 @@
 import { SxProps, Theme, ToggleButton, ToggleButtonProps } from '@mui/material';
 import { FieldSelectionType } from 'components/editor/Bindings/FieldSelection/types';
 import {
+    defaultOutline_hovered,
     disabledButtonText_error,
     disabledButtonText_success,
     errorColoredOutline,
     errorColoredOutline_disabled,
+    errorColoredOutline_hovered,
     errorOutlinedButtonBackground,
     errorOutlinedButtonBackground_disabled,
     intensifiedOutline,
     successButtonText,
     successColoredOutline,
     successColoredOutline_disabled,
+    successColoredOutline_hovered,
     successOutlinedButtonBackground,
     successOutlinedButtonBackground_disabled,
 } from 'context/Theme';
@@ -58,6 +61,11 @@ function OutlinedToggleButton({
     const outline =
         value === 'include' ? successColoredOutline : errorColoredOutline;
 
+    const hoveredOutline =
+        value === 'include'
+            ? successColoredOutline_hovered
+            : errorColoredOutline_hovered;
+
     const disabledOutline =
         value === 'include'
             ? successColoredOutline_disabled
@@ -65,11 +73,18 @@ function OutlinedToggleButton({
 
     const defaultStateSx: SxProps<Theme> = coloredDefaultState
         ? {
-              backgroundColor: (theme) => backgroundColor[theme.palette.mode],
-              border: (theme) => outline[theme.palette.mode],
-              color: (theme) => getTextColor(theme, value),
+              'backgroundColor': (theme) => backgroundColor[theme.palette.mode],
+              'border': (theme) => outline[theme.palette.mode],
+              'color': (theme) => getTextColor(theme, value),
+              '&:hover': {
+                  border: (theme) => hoveredOutline[theme.palette.mode],
+              },
           }
-        : {};
+        : {
+              '&:hover': {
+                  border: (theme) => defaultOutline_hovered[theme.palette.mode],
+              },
+          };
 
     const disabledStateSx: SxProps<Theme> = coloredDefaultState
         ? {
@@ -90,9 +105,12 @@ function OutlinedToggleButton({
               color: (theme) => getDisabledTextColor(theme, value),
           }
         : {
-              backgroundColor: (theme) => backgroundColor[theme.palette.mode],
-              border: (theme) => outline[theme.palette.mode],
-              color: (theme) => getTextColor(theme, value),
+              'backgroundColor': (theme) => backgroundColor[theme.palette.mode],
+              'border': (theme) => outline[theme.palette.mode],
+              'color': (theme) => getTextColor(theme, value),
+              '&:hover': {
+                  border: (theme) => hoveredOutline[theme.palette.mode],
+              },
           };
 
     return (

--- a/src/components/tables/cells/fieldSelection/OutlinedToggleButton.tsx
+++ b/src/components/tables/cells/fieldSelection/OutlinedToggleButton.tsx
@@ -1,12 +1,18 @@
 import { SxProps, Theme, ToggleButton, ToggleButtonProps } from '@mui/material';
 import { FieldSelectionType } from 'components/editor/Bindings/FieldSelection/types';
 import {
-    disabledButtonText_primary,
+    disabledButtonText_error,
+    disabledButtonText_success,
+    errorColoredOutline,
+    errorColoredOutline_disabled,
+    errorOutlinedButtonBackground,
+    errorOutlinedButtonBackground_disabled,
     intensifiedOutline,
-    outlinedButtonBackground,
-    outlinedButtonBackground_disabled,
-    primaryColoredOutline,
-    primaryColoredOutline_disabled,
+    successButtonText,
+    successColoredOutline,
+    successColoredOutline_disabled,
+    successOutlinedButtonBackground,
+    successOutlinedButtonBackground_disabled,
 } from 'context/Theme';
 import { FormattedMessage } from 'react-intl';
 
@@ -20,6 +26,16 @@ interface Props {
     onClick?: ToggleButtonProps['onClick'];
 }
 
+const getTextColor = (theme: Theme, value: FieldSelectionType) =>
+    value === 'include'
+        ? successButtonText[theme.palette.mode]
+        : theme.palette.error.main;
+
+const getDisabledTextColor = (theme: Theme, value: FieldSelectionType) =>
+    value === 'include'
+        ? disabledButtonText_success[theme.palette.mode]
+        : disabledButtonText_error;
+
 function OutlinedToggleButton({
     messageId,
     selectedValue,
@@ -29,18 +45,35 @@ function OutlinedToggleButton({
     onChange,
     onClick,
 }: Props) {
+    const backgroundColor =
+        value === 'include'
+            ? successOutlinedButtonBackground
+            : errorOutlinedButtonBackground;
+
+    const disabledBackgroundColor =
+        value === 'include'
+            ? successOutlinedButtonBackground_disabled
+            : errorOutlinedButtonBackground_disabled;
+
+    const outline =
+        value === 'include' ? successColoredOutline : errorColoredOutline;
+
+    const disabledOutline =
+        value === 'include'
+            ? successColoredOutline_disabled
+            : errorColoredOutline_disabled;
+
     const defaultStateSx: SxProps<Theme> = coloredDefaultState
         ? {
-              border: (theme) => primaryColoredOutline[theme.palette.mode],
-              color: (theme) => theme.palette.primary.main,
+              border: (theme) => outline[theme.palette.mode],
+              color: (theme) => getTextColor(theme, value),
           }
         : {};
 
     const disabledStateSx: SxProps<Theme> = coloredDefaultState
         ? {
-              border: (theme) =>
-                  primaryColoredOutline_disabled[theme.palette.mode],
-              color: (theme) => disabledButtonText_primary[theme.palette.mode],
+              border: (theme) => disabledOutline[theme.palette.mode],
+              color: (theme) => getDisabledTextColor(theme, value),
           }
         : {
               border: (theme) => `1px solid ${theme.palette.divider}`,
@@ -49,16 +82,14 @@ function OutlinedToggleButton({
     const selectedStateSx: SxProps<Theme> = disabled
         ? {
               backgroundColor: (theme) =>
-                  outlinedButtonBackground_disabled[theme.palette.mode],
-              border: (theme) =>
-                  primaryColoredOutline_disabled[theme.palette.mode],
-              color: (theme) => disabledButtonText_primary[theme.palette.mode],
+                  disabledBackgroundColor[theme.palette.mode],
+              border: (theme) => disabledOutline[theme.palette.mode],
+              color: (theme) => getDisabledTextColor(theme, value),
           }
         : {
-              backgroundColor: (theme) =>
-                  outlinedButtonBackground[theme.palette.mode],
-              borderColor: (theme) => theme.palette.primary.main,
-              color: (theme) => theme.palette.primary.main,
+              backgroundColor: (theme) => backgroundColor[theme.palette.mode],
+              border: (theme) => outline[theme.palette.mode],
+              color: (theme) => getTextColor(theme, value),
           };
 
     return (

--- a/src/context/TableSettings.tsx
+++ b/src/context/TableSettings.tsx
@@ -1,0 +1,51 @@
+import { Dispatch, SetStateAction, createContext, useContext } from 'react';
+import { useLocalStorage } from 'react-use';
+import { BaseComponentProps } from 'types';
+import { LocalStorageKeys } from 'utils/localStorage-utils';
+
+interface TableSettings {
+    hiddenColumns: string[];
+}
+
+interface TableSettingsDictionary {
+    [key: string]: TableSettings;
+}
+
+interface TableSettingsState {
+    tableSettings: TableSettingsDictionary | undefined;
+    setTableSettings: Dispatch<
+        SetStateAction<TableSettingsDictionary | undefined>
+    >;
+}
+
+const TableSettingsContext = createContext<TableSettingsState | null>(null);
+
+const TableSettingsProvider = ({ children }: BaseComponentProps) => {
+    const [tableSettings, setTableSettings] =
+        useLocalStorage<TableSettingsDictionary>(
+            LocalStorageKeys.TABLE_SETTINGS,
+            {}
+        );
+
+    return (
+        <TableSettingsContext.Provider
+            value={{ tableSettings, setTableSettings }}
+        >
+            {children}
+        </TableSettingsContext.Provider>
+    );
+};
+
+const useDisplayTableColumns = () => {
+    const context = useContext(TableSettingsContext);
+
+    if (context === null) {
+        throw new Error(
+            'useDisplayTableColumns must be used within a TableSettingsProvider'
+        );
+    }
+
+    return context;
+};
+
+export { TableSettingsProvider, useDisplayTableColumns };

--- a/src/context/TableSettings.tsx
+++ b/src/context/TableSettings.tsx
@@ -4,7 +4,7 @@ import { BaseComponentProps } from 'types';
 import { LocalStorageKeys } from 'utils/localStorage-utils';
 
 interface TableSettings {
-    hiddenColumns: string[];
+    shownOptionalColumns: string[];
 }
 
 interface TableSettingsDictionary {

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -209,6 +209,11 @@ export const primaryColoredOutline_disabled = {
     dark: `1px solid rgba(186, 205, 253, 0.12)`,
 };
 
+export const primaryColoredOutline_hovered = {
+    light: `1px solid #3A56CA`,
+    dark: `1px solid #BACDFD`,
+};
+
 // Light is an RGB translation of #2A7942; Dark is an RGB translation of #66BB6A.
 export const successColoredOutline = {
     light: `1px solid rgba(42, 121, 66, 0.5)`,

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -591,6 +591,18 @@ export const disabledButtonText = {
     dark: 'rgba(255, 255, 255, 0.3)',
 };
 
+export const outlinedIconButtonStyling: SxProps<Theme> = {
+    'borderRadius': 2,
+    'border': (theme) => primaryColoredOutline[theme.palette.mode],
+    'color': (theme) => theme.palette.primary.main,
+    '&:hover': {
+        border: (theme) => primaryColoredOutline_hovered[theme.palette.mode],
+    },
+    '&.Mui-disabled': {
+        border: (theme) => primaryColoredOutline_disabled[theme.palette.mode],
+    },
+};
+
 // TODO (echarts) need to make a color service or something to
 //  generate a proper ECharts theme. These two colors are taken
 //  from ECharts default colors they apply in order

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -1,3 +1,4 @@
+import { ThemeKeys } from '@microlink/react-json-view';
 import {
     ThemeProvider as MUIThemeProvider,
     PaletteOptions,
@@ -12,7 +13,6 @@ import CssBaseline from '@mui/material/CssBaseline';
 import { DeleteCircle, Square } from 'iconoir-react';
 import CheckSquare from 'icons/CheckSquare';
 import React from 'react';
-import { ThemeKeys } from '@microlink/react-json-view';
 import { useLocalStorage } from 'react-use';
 import { BaseComponentProps } from 'types';
 import { DEFAULT_TOOLBAR_HEIGHT } from 'utils/editor-utils';
@@ -207,6 +207,28 @@ export const primaryColoredOutline = {
 export const primaryColoredOutline_disabled = {
     light: `1px solid rgba(58, 86, 202, 0.12)`,
     dark: `1px solid rgba(186, 205, 253, 0.12)`,
+};
+
+// Light is an RGB translation of #2A7942; Dark is an RGB translation of #66BB6A.
+export const successColoredOutline = {
+    light: `1px solid rgba(42, 121, 66, 0.5)`,
+    dark: `1px solid rgba(102, 187, 106, 0.5)`,
+};
+
+export const successColoredOutline_disabled = {
+    light: `1px solid rgba(42, 121, 66, 0.12)`,
+    dark: `1px solid rgba(102, 187, 106, 0.12)`,
+};
+
+// RGB translation of #CA3B55.
+export const errorColoredOutline = {
+    light: `1px solid rgba(202, 59, 85, 0.5)`,
+    dark: `1px solid rgba(202, 59, 85, 0.5)`,
+};
+
+export const errorColoredOutline_disabled = {
+    light: `1px solid rgba(202, 59, 85, 0.12)`,
+    dark: `1px solid rgba(202, 59, 85, 0.12)`,
 };
 
 export const jsonViewTheme: {
@@ -488,6 +510,42 @@ export const outlinedButtonBackground_disabled = {
     light: `rgba(58, 86, 202, 0.05)`,
     dark: `rgba(186, 205, 253, 0.05)`,
 };
+
+// Light is an RGB translation of #2A7942; Dark is an RGB translation of #66BB6A.
+export const successOutlinedButtonBackground = {
+    light: `rgba(42, 121, 66, 0.12)`,
+    dark: `rgba(102, 187, 106, 0.12)`,
+};
+
+export const successOutlinedButtonBackground_disabled = {
+    light: `rgba(42, 121, 66, 0.05)`,
+    dark: `rgba(102, 187, 106, 0.05)`,
+};
+
+// RGB translation of #CA3B55.
+export const errorOutlinedButtonBackground = {
+    light: `rgba(202, 59, 85, 0.12)`,
+    dark: `rgba(202, 59, 85, 0.12)`,
+};
+
+export const errorOutlinedButtonBackground_disabled = {
+    light: `rgba(202, 59, 85, 0.05)`,
+    dark: `rgba(202, 59, 85, 0.05)`,
+};
+
+export const successButtonText = {
+    light: '#2A7942',
+    dark: '#2A7942',
+};
+
+// Light is an RGB translation of #2A7942; Dark is an RGB translation of #66BB6A.
+export const disabledButtonText_success = {
+    light: `rgba(42, 121, 66, 0.26)`,
+    dark: `rgba(102, 187, 106, 0.26)`,
+};
+
+// RGB translation of #CA3B55.
+export const disabledButtonText_error = `rgba(202, 59, 85, 0.26)`;
 
 export const disabledButtonText_primary = {
     light: `rgba(58, 86, 202, 0.26)`,

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -183,8 +183,8 @@ export const defaultOutline = {
 };
 
 export const defaultOutline_hovered = {
-    light: `1px solid #0B131E`,
-    dark: `1px solid #F7F9FC`,
+    light: `1px solid rgba(11, 19, 30, 0.6)`,
+    dark: `1px solid rgba(247, 249, 252, 0.6)`,
 };
 
 export const defaultOutlineColor = {

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -182,6 +182,11 @@ export const defaultOutline = {
     dark: `1px solid rgba(247, 249, 252, 0.12)`,
 };
 
+export const defaultOutline_hovered = {
+    light: `1px solid #0B131E`,
+    dark: `1px solid #F7F9FC`,
+};
+
 export const defaultOutlineColor = {
     light: `rgba(11, 19, 30, 0.12)`,
     dark: `rgba(247, 249, 252, 0.12)`,
@@ -225,6 +230,11 @@ export const successColoredOutline_disabled = {
     dark: `1px solid rgba(102, 187, 106, 0.12)`,
 };
 
+export const successColoredOutline_hovered = {
+    light: `1px solid #2A7942`,
+    dark: `1px solid #66BB6A`,
+};
+
 // RGB translation of #CA3B55.
 export const errorColoredOutline = {
     light: `1px solid rgba(202, 59, 85, 0.5)`,
@@ -234,6 +244,11 @@ export const errorColoredOutline = {
 export const errorColoredOutline_disabled = {
     light: `1px solid rgba(202, 59, 85, 0.12)`,
     dark: `1px solid rgba(202, 59, 85, 0.12)`,
+};
+
+export const errorColoredOutline_hovered = {
+    light: `1px solid #CA3B55`,
+    dark: `1px solid #CA3B55`,
 };
 
 export const jsonViewTheme: {

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -535,7 +535,7 @@ export const errorOutlinedButtonBackground_disabled = {
 
 export const successButtonText = {
     light: '#2A7942',
-    dark: '#2A7942',
+    dark: '#66BB6A',
 };
 
 // Light is an RGB translation of #2A7942; Dark is an RGB translation of #66BB6A.

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -1,11 +1,12 @@
+import ErrorBoundryWrapper from 'components/shared/ErrorBoundryWrapper';
 import IconoirProvider from 'context/Iconoir';
 import NotificationProvider from 'context/Notifications';
 import SwrConfigProvider from 'context/SWR';
 import { BaseComponentProps } from 'types';
-import ErrorBoundryWrapper from 'components/shared/ErrorBoundryWrapper';
 import ClientProvider from './Client';
 import ContentProvider from './Content';
 import { SidePanelDocsProvider } from './SidePanelDocs';
+import { TableSettingsProvider } from './TableSettings';
 import ThemeProvider from './Theme';
 import { UserProvider } from './User';
 
@@ -20,7 +21,9 @@ const AppProviders = ({ children }: BaseComponentProps) => {
                                 <SwrConfigProvider>
                                     <UserProvider>
                                         <SidePanelDocsProvider>
-                                            {children}
+                                            <TableSettingsProvider>
+                                                {children}
+                                            </TableSettingsProvider>
                                         </SidePanelDocsProvider>
                                     </UserProvider>
                                 </SwrConfigProvider>

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -423,6 +423,10 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
 
     'entityTable.edit.aria': `Edit specification of {name}`,
     'entityTable.materialize.aria': `Materialize {name}`,
+
+    'entityTable.selectColumn.menu.header': `Select Columns`,
+    'entityTable.selectColumn.button.ariaLabel': `Open Table Column Customization Menu`,
+    'entityTable.selectColumn.button.tooltip': `Select Columns`,
 };
 
 const LogsDialog: ResolvedIntlConfig['messages'] = {

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -167,6 +167,8 @@ const Data: ResolvedIntlConfig['messages'] = {
     'data.data': `Data`,
     'data.docs': `Docs`,
     'data.connectorImage': `Connector Image`,
+    'data.details': `Details`,
+    'data.actions': `Actions`,
 };
 
 const Error: ResolvedIntlConfig['messages'] = {
@@ -1333,8 +1335,6 @@ const FieldSelection: ResolvedIntlConfig['messages'] = {
     'fieldSelection.table.empty.header': `No information found`,
     'fieldSelection.table.empty.message': `Click "Refresh" to evaluate the fields of the source collection.`,
     'fieldSelection.table.error.message': `There was an error attempting to fetch the list of fields.`,
-    'fieldSelection.table.label.details': `Details`,
-    'fieldSelection.table.label.actions': `Actions`,
     'fieldSelection.table.label.fieldRequired': `Field Required`,
     'fieldSelection.table.label.locationRequired': `Location Required`,
     'fieldSelection.table.label.locationRecommended': `Location Recommended`,

--- a/src/stores/Tables/hooks.ts
+++ b/src/stores/Tables/hooks.ts
@@ -25,6 +25,7 @@ export enum TablePrefixes {
     collections = 'col',
     collectionsSelector = 'csl',
     connectors = 'con',
+    fieldSelection = 'fs',
     materializations = 'mat',
     prefixes = 'pr',
     prefixAlerts = 'pal',

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,7 @@
+export type WithRequiredProperty<T, K extends keyof T> = T & {
+    [P in K]-?: T[P];
+};
+
+export type WithRequiredNonNullProperty<T, K extends keyof T> = T & {
+    [P in K]-?: Exclude<T[P], null>;
+};

--- a/src/utils/localStorage-utils.ts
+++ b/src/utils/localStorage-utils.ts
@@ -4,6 +4,7 @@ export enum LocalStorageKeys {
     COLOR_MODE = 'estuary.color-mode',
     GATEWAY = 'estuary.gateway-auth-config',
     NAVIGATION_SETTINGS = 'estuary.navigation-settings',
+    TABLE_SETTINGS = 'estuary.table-settings',
     SIDE_PANEL_DOCS = 'estuary.side-panel-docs',
 }
 

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -298,7 +298,6 @@ export const evaluateRecommendedIncludedFields = (
 
     return (
         includeRequired ||
-        constraintType === ConstraintTypes.LOCATION_RECOMMENDED ||
-        constraintType === ConstraintTypes.FIELD_OPTIONAL
+        constraintType === ConstraintTypes.LOCATION_RECOMMENDED
     );
 };


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/896

## Changes

### 896

The following features are included in this PR:

* Use semantic green as the base color of the _Include_ row action.

* Use semantic red as the base color of the _Exclude_ row action.

* Match the row action styling of a defaulted field to that of an explicitly included/excluded field. The row action should be outlined and lightly filled in the appropriate color.

* Display the `Exclude` row action as selected by default for optional fields if the `recommended` flag is set. If the `recommended` flag is unset and an optional field is not explicitly included/excluded, both row action buttons should be in a deselected state, mirroring the optional field styling in production today.

* Display the following columns by default: _Field_, _Type_, and _Actions_.

* Introduce an icon button to the table toolbar that opens a menu which enables the user to show/hide "optional" table columns (i.e., _Pointer_ and _Details_).

* Preserve table column display settings for the length of the session.

* Remove the _Include recommended fields_ checkbox.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

N/A

## Screenshots

**Field selection table initializing**

<img width="967" alt="pr_screenshot-918-field_selection_redesign-loading" src="https://github.com/estuary/ui/assets/77648584/86d2353d-e36a-4cec-b0c9-24503bf8f020">

<br />
<br />

**Field selection table initialized**

<img width="967" alt="pr_screenshot-918-field_selection_redesign-default" src="https://github.com/estuary/ui/assets/77648584/939b081f-8cc3-406e-a9d0-d7a36f7c69cf">

<br />
<br />

**Select column menu | Button hovered**

<img width="963" alt="pr_screenshot-918-field_selection_redesign-select_column_menu-hovered" src="https://github.com/estuary/ui/assets/77648584/0b05f6cf-0c78-40df-9177-63eb69ce487b">

<br />
<br />

**Select column menu | Opened**

<img width="965" alt="pr_screenshot-918-field_selection_redesign-select_column_menu-opened" src="https://github.com/estuary/ui/assets/77648584/12ba9478-b0de-4149-ab33-32b2d2ba9132">

<br />
<br />

**Select column menu | _Pointer_ menu item selected**

<img width="964" alt="pr_screenshot-918-field_selection_redesign-select_column_menu-pointer_selected" src="https://github.com/estuary/ui/assets/77648584/68f42cee-aaa5-467a-b0de-ccd76c2c5d9a">

<br />
<br />

**Select column menu | _Details_ menu item selected**

<img width="962" alt="pr_screenshot-918-field_selection_redesign-select_column_menu-details_selected" src="https://github.com/estuary/ui/assets/77648584/a0e4830c-9a38-46ed-8b6a-6f98fba87c1a">

<br />
<br />

**Select column menu | _Pointer_ and _Details_ menu items selected**

<img width="964" alt="pr_screenshot-918-field_selection_redesign-select_column_menu-pointer_and_details_selected" src="https://github.com/estuary/ui/assets/77648584/932066c2-59cc-459b-8e6a-e7519500b433">

<br />
<br />

**Recommended flag unset via the specification editor**

<img width="1065" alt="pr_screenshot-918-field_selection_redesign-recommended_unset" src="https://github.com/estuary/ui/assets/77648584/f05f3f9d-918f-4f24-8427-d967fc37c9cd">