### PR TITLE
Display derivation shard information in collections table and on details page

### DIFF
--- a/src/components/shared/Entity/Details/Overview/index.tsx
+++ b/src/components/shared/Entity/Details/Overview/index.tsx
@@ -9,6 +9,7 @@ import useGlobalSearchParams, {
 } from 'hooks/searchParams/useGlobalSearchParams';
 import { useLiveSpecs_details } from 'hooks/useLiveSpecs';
 import { useMemo } from 'react';
+import { ShardEntityTypes } from 'stores/ShardDetail/types';
 import { hasLength, specContainsDerivation } from 'utils/misc-utils';
 import ShardInformation from '../../Shard/Information';
 import Usage from '../Usage';
@@ -40,6 +41,14 @@ function Overview({ name }: Props) {
         [liveSpecs, validatingLiveSpecs]
     );
 
+    const taskTypes: ShardEntityTypes[] = useMemo(() => {
+        if (!isCollection || isDerivation) {
+            return isDerivation ? ['derivation'] : [entityType];
+        }
+
+        return [];
+    }, [entityType, isCollection, isDerivation]);
+
     return (
         <Grid container spacing={2}>
             <Grid item xs={12} md={8} lg={9}>
@@ -67,10 +76,10 @@ function Overview({ name }: Props) {
                 </Grid>
             ) : null}
 
-            {!isCollection || isDerivation ? (
+            {hasLength(taskTypes) ? (
                 <Grid item xs={12}>
                     <ShardInformation
-                        taskTypes={[entityType]}
+                        taskTypes={taskTypes}
                         taskName={entityName}
                     />
                 </Grid>

--- a/src/stores/ShardDetail/hooks.ts
+++ b/src/stores/ShardDetail/hooks.ts
@@ -10,6 +10,7 @@ import {
     ShardDetailStore,
     ShardEntityTypes,
     ShardReadDictionaryResponse,
+    ShardStatusMessageIds,
 } from './types';
 
 const storeName = (entityType: Entity): ShardDetailStoreNames => {
@@ -120,20 +121,24 @@ export const useShardDetail_readDictionary = (
                     !shardsHaveWarnings && !isEmpty(filteredValue.warnings);
             });
 
+            const isCollection = Boolean(
+                taskTypes?.includes('collection') && !hasLength(filteredValues)
+            );
+
             return {
                 allShards: filteredValues,
-                compositeColor:
-                    taskTypes?.includes('collection') &&
-                    !hasLength(filteredValues)
-                        ? successMain
-                        : state.error
-                        ? state.defaultStatusColor
-                        : getCompositeColor(
-                              filteredValues,
-                              state.defaultStatusColor
-                          ),
+                compositeColor: isCollection
+                    ? successMain
+                    : state.error
+                    ? state.defaultStatusColor
+                    : getCompositeColor(
+                          filteredValues,
+                          state.defaultStatusColor
+                      ),
                 disabled,
-                defaultMessageId: state.defaultMessageId,
+                defaultMessageId: isCollection
+                    ? ShardStatusMessageIds.COLLECTION
+                    : state.defaultMessageId,
                 shardsHaveErrors,
                 shardsHaveWarnings,
             };

--- a/src/stores/ShardDetail/hooks.ts
+++ b/src/stores/ShardDetail/hooks.ts
@@ -4,6 +4,7 @@ import { useZustandStore } from 'context/Zustand/provider';
 import { isEmpty } from 'lodash';
 import { ShardDetailStoreNames } from 'stores/names';
 import { Entity } from 'types';
+import { hasLength } from 'utils/misc-utils';
 import { getCompositeColor } from './Store';
 import {
     ShardDetailStore,
@@ -121,14 +122,16 @@ export const useShardDetail_readDictionary = (
 
             return {
                 allShards: filteredValues,
-                compositeColor: taskTypes?.includes('collection')
-                    ? successMain
-                    : state.error
-                    ? state.defaultStatusColor
-                    : getCompositeColor(
-                          filteredValues,
-                          state.defaultStatusColor
-                      ),
+                compositeColor:
+                    taskTypes?.includes('collection') &&
+                    !hasLength(filteredValues)
+                        ? successMain
+                        : state.error
+                        ? state.defaultStatusColor
+                        : getCompositeColor(
+                              filteredValues,
+                              state.defaultStatusColor
+                          ),
                 disabled,
                 defaultMessageId: state.defaultMessageId,
                 shardsHaveErrors,


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/921

## Changes

### 921

The following features are included in this PR:

* Populate the shard information table on the derivation details page when available.

* Correct the logic that determines the color of the shard status indicator so that it accurately reflects the composite shard status of a derivation.

* Display the following text in the shard status indicator tooltip of a collection: _Collection_. Previously, this tooltip was only showing the following text: _No shard information found._

## Tests

### Manually tested

Approaches to testing are as follows:

* Collection Tests:

    * Validate the shard status indicator color and tooltip of a collections table row corresponding to a single-shard derivation when the shard has a `PRIMARY` status.

    * Validate the shard information table on the details page of a single-shard derivation when the shard has a `PRIMARY` status.

    * Validate the shard status indicator color and tooltip of a collections table row corresponding to a single-shard derivation when the shard has a `FAILED` status.

    * Validate the shard information table on the details page of a single-shard derivation when the shard has a `FAILED` status.

    * Validate the shard status indicator color and tooltip of a collections table row corresponding to a collection.

    * Validate that the details page of a collection remains unchanged (i.e., the shard information table is still **absent** from this page).

* Capture Tests:

    * Validate the shard status indicator color and tooltip of a captures table row corresponding to a single-shard capture when the shard has a `PRIMARY` status.

    * Validate the shard information table on the details page of a single-shard capture when the shard has a `PRIMARY` status.

    * Validate the shard status indicator color and tooltip of a captures table row corresponding to a single-shard capture when the shard has a `FAILED` status.

    * Validate the shard information table on the details page of a single-shard capture when the shard has a `FAILED` status.

* Materialization Tests:

    * Validate the shard status indicator color and tooltip of a materializations table row corresponding to a single-shard materialization when the shard has a `PRIMARY` status.

    * Validate the shard information table on the details page of a single-shard materialization when the shard has a `PRIMARY` status.

    * Validate the shard status indicator color and tooltip of a materializations table row corresponding to a single-shard materialization when the shard has a `FAILED` status.

    * Validate the shard information table on the details page of a single-shard materialization when the shard has a `FAILED` status.

### Automated tests

N/A

## Screenshots

**Collections table | Derivation shard status indicator hovered**

<img width="1057" alt="pr_screenshot-922-derivation_shard_info-collections_table-derivation-primary" src="https://github.com/estuary/ui/assets/77648584/40aa53a0-f9fe-40d8-8ade-0ff681e18702">

<br />
<br />

**Collections table | Derivation shard status indicator hovered | Failed shard exists**

<img width="1057" alt="pr_screenshot-922-derivation_shard_info-collections_table-derivation-failed" src="https://github.com/estuary/ui/assets/77648584/6f7a3795-385f-4089-8c9e-4ac7aaa121be">

<br />
<br />

**Collections table | Collection shard status indicator hovered**

<img width="1057" alt="pr_screenshot-922-derivation_shard_info-collections_table-collection" src="https://github.com/estuary/ui/assets/77648584/119881bf-fadc-4c86-bf8e-05674d64d845">

<br />
<br />

**Derivation details page | Failed shard exists**

<img width="1057" alt="pr_screenshot-922-derivation_shard_info-details_page-derivation-failed" src="https://github.com/estuary/ui/assets/77648584/cf3f7448-0b2e-4fef-a787-36af90d1380e">