### PR TITLE
Adding some messaging to ops logs and starting on loading newer/older

### DIFF
--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -123,11 +123,12 @@ const collections = {
             path: 'history',
             fullPath: '/collections/details/history',
         },
-        ops: {
-            title: 'routeTitle.collectionDetails.ops',
-            path: 'ops',
-            fullPath: '/collections/details/ops',
-        },
+        // TODO (ops logs) need to handle collections (really derivations)
+        // ops: {
+        //     title: 'routeTitle.collectionDetails.ops',
+        //     path: 'ops',
+        //     fullPath: '/collections/details/ops',
+        // },
     },
 };
 

--- a/src/components/collection/DataPreview/index.tsx
+++ b/src/components/collection/DataPreview/index.tsx
@@ -78,7 +78,7 @@ export function DataPreview({ collectionName }: Props) {
                     <Button
                         variant="text"
                         startIcon={<Refresh style={{ fontSize: 12 }} />}
-                        onClick={journalData.refresh}
+                        onClick={() => journalData.refresh()}
                         disabled={
                             isLoading || !hasLength(journalData.data?.documents)
                         }

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -29,7 +29,8 @@ function Ops() {
     console.log('meta', meta);
 
     const parsedEnd = parseInt(meta?.fragment?.end ?? '0', 10);
-    const allLogsLoaded = parsedEnd >= (meta?.writeHead ?? 0);
+    const allLogsLoaded =
+        documents.length > 0 && parsedEnd >= (meta?.writeHead ?? 0);
 
     return (
         <Box>
@@ -48,8 +49,6 @@ function Ops() {
                 </Button>
 
                 <Stack>
-                    <Box>Documents {documents.length}</Box>
-
                     {/*                    <JournalAlerts
                         journalData={journalData}
                         notFoundTitleMessage={

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -28,9 +28,11 @@ function Ops() {
     const meta = journalData.data?.meta;
     console.log('meta', meta);
 
-    const parsedEnd = parseInt(meta?.fragment?.end ?? '0', 10);
+    const parsedEnd = parseInt(meta?.fragment.end ?? '0', 10);
     const allLogsLoaded =
         documents.length > 0 && parsedEnd >= (meta?.writeHead ?? 0);
+
+    console.log('parsedEnd', parsedEnd);
 
     return (
         <Box>
@@ -45,7 +47,7 @@ function Ops() {
                         })
                     }
                 >
-                    Load Older Logs (wip)
+                    Load More (wip)
                 </Button>
 
                 <Stack>

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -24,7 +24,7 @@ function Ops() {
         []) as OpsLogFlowDocument[];
 
     const meta = journalData.data?.meta;
-    console.log('meta', meta);
+    console.log('Ops:journalData:data:meta', meta);
 
     const parsedEnd = meta?.metadataResponse.offset
         ? parseInt(meta.metadataResponse.offset, 10)

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -28,29 +28,34 @@ function Ops() {
     const meta = journalData.data?.meta;
     console.log('meta', meta);
 
-    const parsedEnd = parseInt(meta?.fragment.end ?? '0', 10);
-    const allLogsLoaded =
-        documents.length > 0 && parsedEnd >= (meta?.writeHead ?? 0);
-
-    console.log('parsedEnd', parsedEnd);
+    const parsedEnd = meta?.metadataResponse.offset
+        ? parseInt(meta.metadataResponse.offset, 10)
+        : null;
+    const allLogsLoaded = documents.length > 0 && parsedEnd === 0;
 
     return (
         <Box>
             <UnderDev />
             <Box>
-                <Button
-                    disabled={allLogsLoaded}
-                    onClick={() =>
-                        journalData.refresh({
-                            offset: parsedEnd,
-                            endOffset: 0,
-                        })
-                    }
-                >
-                    Load More (wip)
-                </Button>
+                <Stack spacing={2} direction="row">
+                    <Button
+                        disabled={allLogsLoaded}
+                        onClick={() =>
+                            journalData.refresh({
+                                offset: 0,
+                                endOffset: parsedEnd ?? 0,
+                            })
+                        }
+                    >
+                        Load Older (wip)
+                    </Button>
 
-                <Stack>
+                    <Button onClick={() => journalData.refresh()}>
+                        Load Newer (wip)
+                    </Button>
+                </Stack>
+
+                <Stack spacing={2}>
                     {/*                    <JournalAlerts
                         journalData={journalData}
                         notFoundTitleMessage={

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Button, LinearProgress, Stack } from '@mui/material';
-import AlertBox from 'components/shared/AlertBox';
 import UnderDev from 'components/shared/UnderDev';
 import LogsTable from 'components/tables/Logs';
 import { useJournalData } from 'hooks/journals/useJournalData';
@@ -8,7 +7,6 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { OpsLogFlowDocument } from 'types';
 
 const docsRequested = 25;
@@ -31,7 +29,7 @@ function Ops() {
     const parsedEnd = meta?.metadataResponse.offset
         ? parseInt(meta.metadataResponse.offset, 10)
         : null;
-    const allLogsLoaded = documents.length > 0 && parsedEnd === 0;
+    const allOlderLogsLoaded = documents.length > 0 && parsedEnd === 0;
 
     return (
         <Box>
@@ -39,7 +37,7 @@ function Ops() {
             <Box>
                 <Stack spacing={2} direction="row">
                     <Button
-                        disabled={allLogsLoaded}
+                        disabled={allOlderLogsLoaded}
                         onClick={() =>
                             journalData.refresh({
                                 offset: 0,
@@ -68,12 +66,6 @@ function Ops() {
                         }
                     />*/}
 
-                    {allLogsLoaded ? (
-                        <AlertBox short severity="success">
-                            <FormattedMessage id="ops.logsTable.allOldLogsLoaded" />
-                        </AlertBox>
-                    ) : null}
-
                     {journalData.loading ? <LinearProgress /> : null}
 
                     <LogsTable
@@ -85,12 +77,16 @@ function Ops() {
                             // setLoading(true);
                             // setTimeout(() => setLoading(false), 2500);
                         }}
-                        fetchOlder={() => {
-                            console.log('fetch older logs');
+                        fetchOlder={
+                            allOlderLogsLoaded
+                                ? undefined
+                                : () => {
+                                      console.log('fetch older logs');
 
-                            // setLoading(true);
-                            // setTimeout(() => setLoading(false), 2500);
-                        }}
+                                      // setLoading(true);
+                                      // setTimeout(() => setLoading(false), 2500);
+                                  }
+                        }
                     />
                 </Stack>
             </Box>

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -6,11 +6,14 @@ import useJournalNameForLogs from 'hooks/journals/useJournalNameForLogs';
 import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
+import { useState } from 'react';
 import { OpsLogFlowDocument } from 'types';
 
-const docsRequested = 25;
+const docsRequested = 5;
 
 function Ops() {
+    const [loading, setLoading] = useState(false);
+
     const catalogName = useGlobalSearchParams(GlobalSearchParams.CATALOG_NAME);
     const [name, collectionName] = useJournalNameForLogs(catalogName);
 
@@ -27,7 +30,7 @@ function Ops() {
                 <Button onClick={journalData.refresh}>Refresh</Button>
 
                 <Stack>
-                    <Box>Documents {journalData.data?.documents.length}</Box>
+                    <Box>Documents {documents.length}</Box>
 
                     {/*                    <JournalAlerts
                         journalData={journalData}
@@ -43,7 +46,22 @@ function Ops() {
 
                     {journalData.loading ? <LinearProgress /> : null}
 
-                    <LogsTable documents={documents} />
+                    <LogsTable
+                        documents={documents}
+                        loading={loading}
+                        fetchNewer={() => {
+                            console.log('fetcher latest logs');
+                            setLoading(true);
+
+                            setTimeout(() => setLoading(false), 2500);
+                        }}
+                        fetchOlder={() => {
+                            console.log('fetch older logs');
+                            setLoading(true);
+
+                            setTimeout(() => setLoading(false), 2500);
+                        }}
+                    />
                 </Stack>
             </Box>
         </Box>

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -9,10 +9,10 @@ import useGlobalSearchParams, {
 import { useState } from 'react';
 import { OpsLogFlowDocument } from 'types';
 
-const docsRequested = 5;
+const docsRequested = 2;
 
 function Ops() {
-    const [loading, setLoading] = useState(false);
+    const [loading] = useState(false);
 
     const catalogName = useGlobalSearchParams(GlobalSearchParams.CATALOG_NAME);
     const [name, collectionName] = useJournalNameForLogs(catalogName);
@@ -27,7 +27,9 @@ function Ops() {
         <Box>
             <UnderDev />
             <Box>
-                <Button onClick={journalData.refresh}>Refresh</Button>
+                <Button onClick={() => journalData.refresh(0)}>
+                    Load Older Logs
+                </Button>
 
                 <Stack>
                     <Box>Documents {documents.length}</Box>
@@ -51,15 +53,15 @@ function Ops() {
                         loading={loading}
                         fetchNewer={() => {
                             console.log('fetcher latest logs');
-                            setLoading(true);
 
-                            setTimeout(() => setLoading(false), 2500);
+                            // setLoading(true);
+                            // setTimeout(() => setLoading(false), 2500);
                         }}
                         fetchOlder={() => {
                             console.log('fetch older logs');
-                            setLoading(true);
 
-                            setTimeout(() => setLoading(false), 2500);
+                            // setLoading(true);
+                            // setTimeout(() => setLoading(false), 2500);
                         }}
                     />
                 </Stack>

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -47,11 +47,11 @@ function Ops() {
                             })
                         }
                     >
-                        Load Older (wip)
+                        Load Older (wip - might blow up)
                     </Button>
 
                     <Button onClick={() => journalData.refresh()}>
-                        Load Newer (wip)
+                        Load Newer (wip - just full refresh right now)
                     </Button>
                 </Stack>
 

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, LinearProgress, Stack } from '@mui/material';
+import AlertBox from 'components/shared/AlertBox';
 import UnderDev from 'components/shared/UnderDev';
 import LogsTable from 'components/tables/Logs';
 import { useJournalData } from 'hooks/journals/useJournalData';
@@ -7,9 +8,10 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { OpsLogFlowDocument } from 'types';
 
-const docsRequested = 2;
+const docsRequested = 25;
 
 function Ops() {
     const [loading] = useState(false);
@@ -23,12 +25,26 @@ function Ops() {
     const documents = (journalData.data?.documents ??
         []) as OpsLogFlowDocument[];
 
+    const meta = journalData.data?.meta;
+    console.log('meta', meta);
+
+    const parsedEnd = parseInt(meta?.fragment?.end ?? '0', 10);
+    const allLogsLoaded = parsedEnd >= (meta?.writeHead ?? 0);
+
     return (
         <Box>
             <UnderDev />
             <Box>
-                <Button onClick={() => journalData.refresh(0)}>
-                    Load Older Logs
+                <Button
+                    disabled={allLogsLoaded}
+                    onClick={() =>
+                        journalData.refresh({
+                            offset: parsedEnd,
+                            endOffset: 0,
+                        })
+                    }
+                >
+                    Load Older Logs (wip)
                 </Button>
 
                 <Stack>
@@ -45,6 +61,12 @@ function Ops() {
                             />
                         }
                     />*/}
+
+                    {allLogsLoaded ? (
+                        <AlertBox short severity="success">
+                            <FormattedMessage id="ops.logsTable.allOldLogsLoaded" />
+                        </AlertBox>
+                    ) : null}
 
                     {journalData.loading ? <LinearProgress /> : null}
 

--- a/src/components/tables/Logs/Rows.tsx
+++ b/src/components/tables/Logs/Rows.tsx
@@ -1,7 +1,7 @@
 import { TableCell, TableRow } from '@mui/material';
 import { useToggle } from 'react-use';
 import { OpsLogFlowDocument } from 'types';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import LevelCell from '../cells/logs/LevelCell';
 import TimestampCell from '../cells/logs/TimestampCell';
 import MessageCell from '../cells/logs/MessageCell';
@@ -56,8 +56,6 @@ function Row({ row }: RowProps) {
 }
 
 function Rows({ data, loading, hitFileStart }: RowsProps) {
-    const intl = useIntl();
-
     return (
         <>
             {loading ? (
@@ -72,14 +70,9 @@ function Rows({ data, loading, hitFileStart }: RowsProps) {
                     <TableCell align="right">
                         <LevelIcon level="done" />
                     </TableCell>
-
-                    <TimestampCell ts="-" />
-
-                    <MessageCell
-                        message={intl.formatMessage({
-                            id: 'ops.logsTable.allOldLogsLoaded',
-                        })}
-                    />
+                    <TableCell colSpan={2}>
+                        <FormattedMessage id="ops.logsTable.allOldLogsLoaded" />
+                    </TableCell>
                 </TableRow>
             ) : null}
             {data.map((record) => (

--- a/src/components/tables/Logs/Rows.tsx
+++ b/src/components/tables/Logs/Rows.tsx
@@ -1,7 +1,7 @@
 import { TableCell, TableRow } from '@mui/material';
 import { useToggle } from 'react-use';
 import { OpsLogFlowDocument } from 'types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import LevelCell from '../cells/logs/LevelCell';
 import TimestampCell from '../cells/logs/TimestampCell';
 import MessageCell from '../cells/logs/MessageCell';
@@ -56,6 +56,8 @@ function Row({ row }: RowProps) {
 }
 
 function Rows({ data, loading, hitFileStart }: RowsProps) {
+    const intl = useIntl();
+
     return (
         <>
             {loading ? (
@@ -70,9 +72,14 @@ function Rows({ data, loading, hitFileStart }: RowsProps) {
                     <TableCell align="right">
                         <LevelIcon level="success" />
                     </TableCell>
-                    <TableCell colSpan={2}>
-                        <FormattedMessage id="ops.logsTable.allOldLogsLoaded" />
-                    </TableCell>
+
+                    <TimestampCell ts="-" />
+
+                    <MessageCell
+                        message={intl.formatMessage({
+                            id: 'ops.logsTable.allOldLogsLoaded',
+                        })}
+                    />
                 </TableRow>
             ) : null}
             {data.map((record) => (

--- a/src/components/tables/Logs/Rows.tsx
+++ b/src/components/tables/Logs/Rows.tsx
@@ -1,6 +1,7 @@
-import { TableRow } from '@mui/material';
+import { TableCell, TableRow } from '@mui/material';
 import { useToggle } from 'react-use';
 import { OpsLogFlowDocument } from 'types';
+import { FormattedMessage } from 'react-intl';
 import LevelCell from '../cells/logs/LevelCell';
 import TimestampCell from '../cells/logs/TimestampCell';
 import MessageCell from '../cells/logs/MessageCell';
@@ -12,6 +13,7 @@ interface RowProps {
 
 interface RowsProps {
     data: OpsLogFlowDocument[];
+    loading?: boolean;
 }
 
 function Row({ row }: RowProps) {
@@ -51,9 +53,16 @@ function Row({ row }: RowProps) {
     );
 }
 
-function Rows({ data }: RowsProps) {
+function Rows({ data, loading }: RowsProps) {
     return (
         <>
+            {loading ? (
+                <TableRow>
+                    <TableCell colSpan={3}>
+                        <FormattedMessage id="ops.logsTable.fetchingOlderLogs" />
+                    </TableCell>
+                </TableRow>
+            ) : null}
             {data.map((record) => (
                 <Row row={record} key={record._meta.uuid} />
             ))}

--- a/src/components/tables/Logs/Rows.tsx
+++ b/src/components/tables/Logs/Rows.tsx
@@ -70,7 +70,7 @@ function Rows({ data, loading, hitFileStart }: RowsProps) {
             {hitFileStart ? (
                 <TableRow>
                     <TableCell align="right">
-                        <LevelIcon level="success" />
+                        <LevelIcon level="done" />
                     </TableCell>
 
                     <TimestampCell ts="-" />

--- a/src/components/tables/Logs/Rows.tsx
+++ b/src/components/tables/Logs/Rows.tsx
@@ -6,6 +6,7 @@ import LevelCell from '../cells/logs/LevelCell';
 import TimestampCell from '../cells/logs/TimestampCell';
 import MessageCell from '../cells/logs/MessageCell';
 import FieldsExpandedCell from '../cells/logs/FieldsExpandedCell';
+import LevelIcon from '../cells/logs/LevelIcon';
 
 interface RowProps {
     row: OpsLogFlowDocument;
@@ -14,6 +15,7 @@ interface RowProps {
 interface RowsProps {
     data: OpsLogFlowDocument[];
     loading?: boolean;
+    hitFileStart?: boolean;
 }
 
 function Row({ row }: RowProps) {
@@ -53,13 +55,23 @@ function Row({ row }: RowProps) {
     );
 }
 
-function Rows({ data, loading }: RowsProps) {
+function Rows({ data, loading, hitFileStart }: RowsProps) {
     return (
         <>
             {loading ? (
                 <TableRow>
                     <TableCell colSpan={3}>
                         <FormattedMessage id="ops.logsTable.fetchingOlderLogs" />
+                    </TableCell>
+                </TableRow>
+            ) : null}
+            {hitFileStart ? (
+                <TableRow>
+                    <TableCell align="right">
+                        <LevelIcon level="success" />
+                    </TableCell>
+                    <TableCell colSpan={2}>
+                        <FormattedMessage id="ops.logsTable.allOldLogsLoaded" />
                     </TableCell>
                 </TableRow>
             ) : null}

--- a/src/components/tables/Logs/index.tsx
+++ b/src/components/tables/Logs/index.tsx
@@ -1,35 +1,77 @@
 import { Box, Table, TableContainer } from '@mui/material';
 import EntityTableBody from 'components/tables/EntityTable/TableBody';
 import EntityTableHeader from 'components/tables/EntityTable/TableHeader';
-import { useMemo } from 'react';
+import useScrollIntoView from 'hooks/useScrollIntoView';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
+import useStayScrolled from 'react-stay-scrolled';
+import { useScroll } from 'react-use';
 import { OpsLogFlowDocument, TableStatuses } from 'types';
 import Rows from './Rows';
 import useLogColumns from './useLogColumns';
 
 interface Props {
     documents: OpsLogFlowDocument[];
+    fetchNewer: () => void;
+    fetchOlder: () => void;
     loading?: boolean;
 }
 
-function LogsTable({ documents, loading }: Props) {
+function LogsTable({ documents, fetchNewer, fetchOlder, loading }: Props) {
     const intl = useIntl();
     const columns = useLogColumns();
 
     const dataRows = useMemo(
-        () => (documents.length > 0 ? <Rows data={documents} /> : null),
-        [documents]
+        () =>
+            documents.length > 0 ? (
+                <Rows data={documents} loading={loading} />
+            ) : null,
+        [documents, loading]
     );
 
+    console.log('loading', loading);
+
+    const tableScroller = useRef<HTMLDivElement>(null);
+    const { stayScrolled } = useStayScrolled(tableScroller);
+    const scrollIntoView = useScrollIntoView(tableScroller);
+
+    const { y } = useScroll(tableScroller);
+
+    useEffect(() => {
+        console.log('documents', documents);
+        scrollIntoView();
+    }, [documents, scrollIntoView]);
+
+    useEffect(() => {
+        // console.log('y', y);
+
+        if (y === 0) {
+            fetchOlder();
+        } else {
+            // Math.abs(tableScroller.scrollHeight - (tableScroller.scrollTop + tableScroller.clientHeight)) <= 1
+            // eslint-disable-next-line no-lonely-if
+            if (y > 500) {
+                fetchNewer();
+            }
+        }
+    }, [fetchNewer, fetchOlder, y]);
+
+    useLayoutEffect(() => {
+        console.log('they see me scrolling');
+        stayScrolled();
+    }, [documents, stayScrolled]);
+
+    stayScrolled();
+
     return (
-        <TableContainer component={Box} maxHeight={500}>
+        <TableContainer component={Box} maxHeight={150} ref={tableScroller}>
             <Table
                 aria-label={intl.formatMessage({
                     id: 'entityTable.title',
                 })}
                 size="small"
                 stickyHeader
-                sx={{ minWidth: 450 }}
+                sx={{ minWidth: 250 }}
             >
                 <EntityTableHeader columns={columns} />
 

--- a/src/components/tables/Logs/index.tsx
+++ b/src/components/tables/Logs/index.tsx
@@ -43,8 +43,6 @@ function LogsTable({ documents, fetchNewer, fetchOlder, loading }: Props) {
     }, [documents, scrollIntoView]);
 
     useEffect(() => {
-        // console.log('y', y);
-
         if (y === 0) {
             fetchOlder();
         } else {
@@ -64,7 +62,7 @@ function LogsTable({ documents, fetchNewer, fetchOlder, loading }: Props) {
     stayScrolled();
 
     return (
-        <TableContainer component={Box} maxHeight={150} ref={tableScroller}>
+        <TableContainer component={Box} maxHeight={500} ref={tableScroller}>
             <Table
                 aria-label={intl.formatMessage({
                     id: 'entityTable.title',

--- a/src/components/tables/Logs/index.tsx
+++ b/src/components/tables/Logs/index.tsx
@@ -29,8 +29,6 @@ function LogsTable({ documents, fetchNewer, fetchOlder, loading }: Props) {
         [documents, loading]
     );
 
-    console.log('loading', loading);
-
     const tableScroller = useRef<HTMLDivElement>(null);
     const { stayScrolled } = useStayScrolled(tableScroller);
     const scrollIntoView = useScrollIntoView(tableScroller);
@@ -38,7 +36,7 @@ function LogsTable({ documents, fetchNewer, fetchOlder, loading }: Props) {
     const { y } = useScroll(tableScroller);
 
     useEffect(() => {
-        console.log('documents', documents);
+        console.log('1', documents);
         scrollIntoView();
     }, [documents, scrollIntoView]);
 
@@ -55,7 +53,7 @@ function LogsTable({ documents, fetchNewer, fetchOlder, loading }: Props) {
     }, [fetchNewer, fetchOlder, y]);
 
     useLayoutEffect(() => {
-        console.log('they see me scrolling');
+        console.log('2');
         stayScrolled();
     }, [documents, stayScrolled]);
 

--- a/src/components/tables/cells/logs/LevelIcon.tsx
+++ b/src/components/tables/cells/logs/LevelIcon.tsx
@@ -8,7 +8,7 @@ import {
 } from 'iconoir-react';
 import { BaseTypographySx } from './shared';
 
-type Levels = 'error' | 'warn' | 'debug' | 'trace' | 'success' | any;
+type Levels = 'error' | 'warn' | 'debug' | 'trace' | 'done' | any;
 
 interface Props {
     level: Levels;
@@ -24,7 +24,7 @@ function LevelIcon({ level }: Props) {
             ? DeleteCircle
             : level === 'warn'
             ? WarningCircle
-            : level === 'success'
+            : level === 'done'
             ? CheckCircle
             : level === 'debug' || level === 'trace'
             ? MinusCircle
@@ -35,7 +35,7 @@ function LevelIcon({ level }: Props) {
             ? theme.palette.error.main
             : level === 'warn'
             ? theme.palette.warning.main
-            : level === 'success'
+            : level === 'done'
             ? theme.palette.success.main
             : theme.palette.info.main;
 

--- a/src/components/tables/cells/logs/LevelIcon.tsx
+++ b/src/components/tables/cells/logs/LevelIcon.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, Typography, useTheme } from '@mui/material';
 import {
+    CheckCircle,
     DeleteCircle,
     InfoEmpty,
     MinusCircle,
@@ -7,8 +8,10 @@ import {
 } from 'iconoir-react';
 import { BaseTypographySx } from './shared';
 
+type Levels = 'error' | 'warn' | 'debug' | 'trace' | 'success' | any;
+
 interface Props {
-    level: string;
+    level: Levels;
 }
 
 // TODO (icons)
@@ -21,6 +24,8 @@ function LevelIcon({ level }: Props) {
             ? DeleteCircle
             : level === 'warn'
             ? WarningCircle
+            : level === 'success'
+            ? CheckCircle
             : level === 'debug' || level === 'trace'
             ? MinusCircle
             : InfoEmpty;
@@ -30,6 +35,8 @@ function LevelIcon({ level }: Props) {
             ? theme.palette.error.main
             : level === 'warn'
             ? theme.palette.warning.main
+            : level === 'success'
+            ? theme.palette.success.main
             : theme.palette.info.main;
 
     return (

--- a/src/components/tables/cells/logs/TimestampCell.tsx
+++ b/src/components/tables/cells/logs/TimestampCell.tsx
@@ -7,10 +7,14 @@ interface Props {
 }
 
 function TimestampCell({ ts }: Props) {
+    const formattedDateTime = DateTime.fromISO(ts).toFormat(
+        'yyyy-LL-dd HH:mm:ss.SSS ZZZZ'
+    );
+
     return (
         <TableCell sx={BaseCellSx}>
             <Typography noWrap sx={BaseTypographySx}>
-                {DateTime.fromISO(ts).toFormat('yyyy-LL-dd HH:mm:ss.SSS ZZZZ')}
+                {formattedDateTime.includes('Invalid') ? '' : formattedDateTime}
             </Typography>
         </TableCell>
     );

--- a/src/context/Router/index.tsx
+++ b/src/context/Router/index.tsx
@@ -204,6 +204,7 @@ const router = createBrowserRouter(
                                 }
                             />
 
+                            {/*TODO (ops logs) need to handle collections (really derivations)
                             <Route
                                 path={
                                     authenticatedRoutes.collections.details.ops
@@ -214,7 +215,7 @@ const router = createBrowserRouter(
                                         <CollectionDetailsRoute tab="ops" />
                                     </Suspense>
                                 }
-                            />
+                            />*/}
                         </Route>
 
                         <Route

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -141,7 +141,9 @@ async function loadDocuments({
     client,
     documentCount,
     maxBytes,
+    startingOffset,
 }: {
+    startingOffset?: number;
     journalName?: string;
     client?: JournalClient;
     documentCount: number;
@@ -174,6 +176,8 @@ async function loadDocuments({
 
     const head = parseInt(metadataResponse.writeHead, 10);
     let start = head;
+
+    console.log('offset', { startingOffset, head });
 
     let documents: JournalRecord[] = [];
 
@@ -248,6 +252,7 @@ const useJournalData = (
     }, [gatewayConfig, journalName]);
 
     const [refreshing, setRefreshing] = useState(false);
+    const [startingOffset, setStartingOffset] = useState(0);
 
     const [data, setData] =
         useState<Awaited<ReturnType<typeof loadDocuments>>>();
@@ -271,6 +276,7 @@ const useJournalData = (
                         client: journalClient,
                         documentCount: desiredCount,
                         maxBytes,
+                        startingOffset,
                     });
                     setData(docs);
                 } catch (e: unknown) {
@@ -283,20 +289,25 @@ const useJournalData = (
             }
         })();
     }, [
+        data,
         desiredCount,
         journalClient,
         journalName,
+        loading,
         maxBytes,
         refreshing,
-        loading,
-        data,
+        startingOffset,
     ]);
 
     return {
         data,
         error,
         loading,
-        refresh: () => {
+        refresh: (newOffset?: number) => {
+            if (newOffset) {
+                setStartingOffset(newOffset);
+            }
+
             failures.current = 0;
             setRefreshing(true);
         },

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -227,7 +227,6 @@ async function loadDocuments({
     return {
         documents,
         meta: {
-            writeHead: head,
             metadataResponse,
         },
         tooFewDocuments: start <= 0,

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -124,7 +124,7 @@ async function* streamAsyncIterator<T>(stream: ReadableStream<T>) {
 
 // We increment the read window by this many bytes every time we get back
 // fewer than the desired number of rows.
-const INCREMENT = 1024 * 1024;
+const INCREMENT = 1024; //* 1024;
 
 async function readAllDocuments<T>(stream: ReadableStream<T>) {
     const accum: T[] = [];
@@ -182,7 +182,8 @@ async function loadDocuments({
 
     const end =
         offsets?.endOffset && offsets.endOffset > 0 ? offsets.endOffset : head;
-    let start = offsets?.offset && offsets.offset > 0 ? offsets.offset : head;
+    let start = offsets?.offset && offsets.offset > 0 ? offsets.offset : end;
+
     let documents: JournalRecord[] = [];
     let attempt = 0;
 
@@ -227,10 +228,7 @@ async function loadDocuments({
         documents,
         meta: {
             writeHead: head,
-            fragment: {
-                end: metadataResponse.fragment?.end,
-                begin: metadataResponse.fragment?.begin,
-            },
+            metadataResponse,
         },
         tooFewDocuments: start <= 0,
         tooManyBytes: head - start >= maxBytes,

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -147,6 +147,7 @@ async function loadDocuments({
     documentCount: number;
     maxBytes: number;
 }) {
+    console.log('sup', { client, journalName });
     if (!client || !journalName) {
         console.warn('Cannot load documents without client and journal');
         return {
@@ -235,6 +236,7 @@ const useJournalData = (
     );
 
     const journalClient = useMemo(() => {
+        console.log('journalClient memo', { journalName, gatewayConfig });
         if (journalName && gatewayConfig?.gateway_url && gatewayConfig.token) {
             const authToken = gatewayConfig.token;
             const baseUrl = new URL(gatewayConfig.gateway_url);

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -672,6 +672,7 @@ const Journals: ResolvedIntlConfig['messages'] = {
 const Ops: ResolvedIntlConfig['messages'] = {
     'ops.journals.notFound.message': `We were unable to find any logs for this {entityType}.`,
     'ops.logsTable.label.level': `Level`,
+    'ops.logsTable.fetchingOlderLogs': `Fetching older logs...`,
     'ops.logsTable.label.ts': `Timestamp`,
     'ops.logsTable.label.message': `Message`,
     'ops.logsTable.label.fields': `Fields`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -673,7 +673,7 @@ const Ops: ResolvedIntlConfig['messages'] = {
     'ops.journals.notFound.message': `We were unable to find any logs for this {entityType}.`,
     'ops.logsTable.label.level': `Level`,
     'ops.logsTable.fetchingOlderLogs': `Fetching older logs...`,
-    'ops.logsTable.allOldLogsLoaded': ` - START OF LOGS - `,
+    'ops.logsTable.allOldLogsLoaded': `All historical logs loaded`,
     'ops.logsTable.label.ts': `Timestamp`,
     'ops.logsTable.label.message': `Message`,
     'ops.logsTable.label.fields': `Fields`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -673,7 +673,7 @@ const Ops: ResolvedIntlConfig['messages'] = {
     'ops.journals.notFound.message': `We were unable to find any logs for this {entityType}.`,
     'ops.logsTable.label.level': `Level`,
     'ops.logsTable.fetchingOlderLogs': `Fetching older logs...`,
-    'ops.logsTable.allOldLogsLoaded': `No more previous logs to show`,
+    'ops.logsTable.allOldLogsLoaded': `All historical logs loaded`,
     'ops.logsTable.label.ts': `Timestamp`,
     'ops.logsTable.label.message': `Message`,
     'ops.logsTable.label.fields': `Fields`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -673,7 +673,7 @@ const Ops: ResolvedIntlConfig['messages'] = {
     'ops.journals.notFound.message': `We were unable to find any logs for this {entityType}.`,
     'ops.logsTable.label.level': `Level`,
     'ops.logsTable.fetchingOlderLogs': `Fetching older logs...`,
-    'ops.logsTable.allOldLogsLoaded': `All historical logs loaded`,
+    'ops.logsTable.allOldLogsLoaded': ` --- all historical logs loaded --- `,
     'ops.logsTable.label.ts': `Timestamp`,
     'ops.logsTable.label.message': `Message`,
     'ops.logsTable.label.fields': `Fields`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -673,7 +673,7 @@ const Ops: ResolvedIntlConfig['messages'] = {
     'ops.journals.notFound.message': `We were unable to find any logs for this {entityType}.`,
     'ops.logsTable.label.level': `Level`,
     'ops.logsTable.fetchingOlderLogs': `Fetching older logs...`,
-    'ops.logsTable.allOldLogsLoaded': `All historical logs loaded`,
+    'ops.logsTable.allOldLogsLoaded': ` - START OF LOGS - `,
     'ops.logsTable.label.ts': `Timestamp`,
     'ops.logsTable.label.message': `Message`,
     'ops.logsTable.label.fields': `Fields`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -673,6 +673,7 @@ const Ops: ResolvedIntlConfig['messages'] = {
     'ops.journals.notFound.message': `We were unable to find any logs for this {entityType}.`,
     'ops.logsTable.label.level': `Level`,
     'ops.logsTable.fetchingOlderLogs': `Fetching older logs...`,
+    'ops.logsTable.allOldLogsLoaded': `No more previous logs to show`,
     'ops.logsTable.label.ts': `Timestamp`,
     'ops.logsTable.label.message': `Message`,
     'ops.logsTable.label.fields': `Fields`,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/858

## Changes

### 858

- Add new buttons to test loading older and newer
- Starting to add code to keep an eye on where the user is scrolled to
- Adding handling when all logs were loaded in

## Tests

### Manually tested

- Tested logs in details
- Did some kick testing of the data preview

### Automated tests

- None right now

## Screenshots

Adding a message at top when all logs are loaded
![image](https://github.com/estuary/ui/assets/270078/5e4a9a40-cc44-4b14-9147-dcd018d63be9)


Scroll to bottom of logs when first loaded
![image](https://github.com/estuary/ui/assets/270078/462a5b88-a81f-428c-af7c-fc0fb254db24)
