### PR TITLE
Update how the connector version is determined in workflows

### DIFF
--- a/src/api/connectors.ts
+++ b/src/api/connectors.ts
@@ -1,16 +1,16 @@
 import {
-    ConnectorWithTagDetailQuery,
     CONNECTOR_WITH_TAG_QUERY,
+    ConnectorWithTagDetailQuery,
 } from 'hooks/useConnectorWithTagDetail';
 import {
     CONNECTOR_NAME,
     CONNECTOR_RECOMMENDED,
+    TABLES,
     defaultTableFilter,
     handleFailure,
     handleSuccess,
     supabaseClient,
     supabaseRetry,
-    TABLES,
 } from 'services/supabase';
 import { SortDirection } from 'types';
 
@@ -46,15 +46,17 @@ const getConnectors = (
 };
 
 // Hydration-specific queries
+export interface ConnectorTag_Base {
+    id: string;
+    connector_id: string;
+    image_tag: string;
+}
+
 export interface ConnectorsQuery_DetailsForm {
     id: string;
     image_name: string;
     logo_url: string;
-    connector_tags: {
-        id: string;
-        connector_id: string;
-        image_tag: string;
-    }[];
+    connector_tags: ConnectorTag_Base[];
 }
 
 const DETAILS_FORM_QUERY = `

--- a/src/components/shared/Entity/DetailsForm/Form.tsx
+++ b/src/components/shared/Entity/DetailsForm/Form.tsx
@@ -17,10 +17,9 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import defaultRenderers from 'services/jsonforms/defaultRenderers';
 import { defaultOptions, showValidation } from 'services/jsonforms/shared';
 import {
-    useDetailsForm_connectorImage_connectorId,
+    useDetailsForm_changed_connectorId,
     useDetailsForm_connectorImage_imagePath,
     useDetailsForm_details,
-    useDetailsForm_previousConnectorImage_connectorId,
     useDetailsForm_setDetails,
     useDetailsForm_setDetails_connector,
     useDetailsForm_setDraftedEntityName,
@@ -64,10 +63,8 @@ function DetailsFormForm({ connectorTags, entityType, readOnly }: Props) {
     const formData = useDetailsForm_details();
     const { connectorImage: originalConnectorImage } = formData;
 
-    const currentConnectorId = useDetailsForm_connectorImage_connectorId();
-    const currentConnectorImagePath = useDetailsForm_connectorImage_imagePath();
-    const previousConnectorId =
-        useDetailsForm_previousConnectorImage_connectorId();
+    const connectorImagePath = useDetailsForm_connectorImage_imagePath();
+    const connectorIdChanged = useDetailsForm_changed_connectorId();
 
     const setDetails = useDetailsForm_setDetails();
     const setDetails_connector = useDetailsForm_setDetails_connector();
@@ -85,11 +82,7 @@ function DetailsFormForm({ connectorTags, entityType, readOnly }: Props) {
     const isEdit = useEntityWorkflow_Editing();
 
     useEffect(() => {
-        if (
-            connectorId &&
-            hasLength(connectorTags) &&
-            currentConnectorId !== previousConnectorId
-        ) {
+        if (connectorId && hasLength(connectorTags) && connectorIdChanged) {
             connectorTags.find((connector) => {
                 const connectorTag = evaluateConnectorVersions(connector);
 
@@ -103,29 +96,23 @@ function DetailsFormForm({ connectorTags, entityType, readOnly }: Props) {
                 return connectorLocated;
             });
         }
-    }, [
-        setDetails_connector,
-        connectorId,
-        connectorTags,
-        currentConnectorId,
-        previousConnectorId,
-    ]);
+    }, [setDetails_connector, connectorId, connectorIdChanged, connectorTags]);
 
     const versionEvaluationOptions:
         | ConnectorVersionEvaluationOptions
         | undefined = useMemo(() => {
-        const imageTagStartIndex = currentConnectorImagePath.indexOf(':');
+        const imageTagStartIndex = connectorImagePath.indexOf(':');
 
-        return isEdit && hasLength(currentConnectorId) && imageTagStartIndex > 0
+        return isEdit && hasLength(connectorId) && imageTagStartIndex > 0
             ? {
-                  connectorId: currentConnectorId,
-                  existingImageTag: currentConnectorImagePath.substring(
+                  connectorId,
+                  existingImageTag: connectorImagePath.substring(
                       imageTagStartIndex,
-                      currentConnectorImagePath.length
+                      connectorImagePath.length
                   ),
               }
             : undefined;
-    }, [currentConnectorId, currentConnectorImagePath, isEdit]);
+    }, [connectorId, connectorImagePath, isEdit]);
 
     const connectorsOneOf = useMemo(() => {
         const response = [] as { title: string; const: Object }[];

--- a/src/hooks/useConnectorWithTagDetail.ts
+++ b/src/hooks/useConnectorWithTagDetail.ts
@@ -1,3 +1,4 @@
+import { ConnectorTag_Base } from 'api/connectors';
 import {
     CONNECTOR_NAME,
     CONNECTOR_RECOMMENDED,
@@ -6,16 +7,15 @@ import {
 import { EntityWithCreateWorkflow } from 'types';
 import { useQuery, useSelect } from './supabase-swr';
 
+export interface ConnectorTag extends ConnectorTag_Base {
+    documentation_url: string;
+    protocol: EntityWithCreateWorkflow;
+    image_name: string;
+    title: string;
+}
+
 export interface ConnectorWithTagDetailQuery {
-    connector_tags: {
-        documentation_url: string;
-        protocol: EntityWithCreateWorkflow;
-        image_tag: string;
-        image_name: string;
-        id: string;
-        connector_id: string;
-        title: string;
-    }[];
+    connector_tags: ConnectorTag[];
     id: string;
     detail: string;
     image_name: string;

--- a/src/stores/DetailsForm/Store.ts
+++ b/src/stores/DetailsForm/Store.ts
@@ -18,8 +18,9 @@ import {
 } from 'stores/extensions/Hydration';
 import { DetailsFormStoreNames } from 'stores/names';
 import { devtoolsOptions } from 'utils/store-utils';
-import { createStore, StoreApi } from 'zustand';
-import { devtools, NamedSet } from 'zustand/middleware';
+import { evaluateConnectorVersions } from 'utils/workflow-utils';
+import { StoreApi, createStore } from 'zustand';
+import { NamedSet, devtools } from 'zustand/middleware';
 
 const STORE_KEY = 'Details Form';
 
@@ -193,13 +194,16 @@ export const getInitialState = (
                 if (!error && data && data.length > 0) {
                     const { setDetails_connector, setPreviousDetails } = get();
 
-                    const { image_name, logo_url, connector_tags } = data[0];
+                    const connector = data[0];
+
+                    const { image_name, logo_url } = connector;
+                    const connectorTag = evaluateConnectorVersions(connector);
 
                     const connectorImage: Details['data']['connectorImage'] = {
                         connectorId,
-                        id: connector_tags[0].id,
+                        id: connectorTag.id,
                         imageName: image_name,
-                        imagePath: `${image_name}${connector_tags[0].image_tag}`,
+                        imagePath: `${image_name}${connectorTag.image_tag}`,
                         iconPath: logo_url,
                     };
 

--- a/src/stores/DetailsForm/hooks.ts
+++ b/src/stores/DetailsForm/hooks.ts
@@ -1,5 +1,8 @@
 import { useEntityType } from 'context/EntityContext';
 import { useZustandStore } from 'context/Zustand/provider';
+import useGlobalSearchParams, {
+    GlobalSearchParams,
+} from 'hooks/searchParams/useGlobalSearchParams';
 import { DetailsFormState } from 'stores/DetailsForm/types';
 import { DetailsFormStoreNames } from 'stores/names';
 import { Entity } from 'types';
@@ -233,6 +236,23 @@ export const useDetailsForm_changed = () => {
     return useZustandStore<DetailsFormState, DetailsFormState['stateChanged']>(
         getStoreName(entityType),
         (state) => state.stateChanged
+    );
+};
+
+export const useDetailsForm_changed_connectorId = () => {
+    const connectorId = useGlobalSearchParams(GlobalSearchParams.CONNECTOR_ID);
+    const entityType = useEntityType();
+
+    return useZustandStore<DetailsFormState, boolean>(
+        getStoreName(entityType),
+        (state) =>
+            state.details.data.connectorImage.connectorId !==
+                state.previousDetails.data.connectorImage.connectorId ||
+            Boolean(
+                connectorId &&
+                    connectorId !==
+                        state.details.data.connectorImage.connectorId
+            )
     );
 };
 


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/923

## Changes

### 923

The following features are included in this PR:

* Prevent automatic updates of the connector version of an edited task.

* Use the latest version of a connector when creating a task.

## Tests

### Manually tested

Approaches to testing are as follows:

* Capture Tests:

    * Enter the capture create workflow, select a source connector which has multiple supported versions, complete the form, publish the capture, and observe that the capture uses the latest version of the source connector.

    * Enter the capture create workflow, select a source connector which has multiple supported versions, change the selected connector in the _Details_ section of the form, and observe that the drafted specification uses the latest version of the whichever connector is selected.

    * Enter the capture create workflow, select a source connector which has multiple supported versions, toggle the selected connector in the _Details_ section of the form (i.e., select a different connector then return to the initial connector selected), and observe that the drafted specification uses the latest version of the whichever connector is selected.

    * Enter the edit workflow of a capture that uses an older version of a source connector, edit the resource configuration of an existing binding, edit the endpoint configuration, publish the altered specification, and observe that the version of the source connector was preserved.

* Materialization Tests:

    * Enter the materialization create workflow, select a destination connector which has multiple supported versions, complete the form, and observe that the drafted specification uses the latest version of the destination connector.

    * Enter the materialization create workflow, select a destination connector which has multiple supported versions, change the selected connector in the _Details_ section of the form, and observe that the drafted specification uses the latest version of the whichever connector is selected.

    * Enter the materialization create workflow, select a destination connector which has multiple supported versions, toggle the selected connector in the _Details_ section of the form (i.e., select a different connector then return to the initial connector selected), and observe that the drafted specification uses the latest version of the whichever connector is selected.

    * Enter the edit workflow of a materialization that uses an older version of a destination connector, edit the resource configuration of an existing binding, add/remove a binding, edit the endpoint configuration, and observe that the version of the destination connector was preserved.

### Automated tests

N/A

## Screenshots

N/A
