### PR TITLE
Phil/evolve backfill

### DIFF
--- a/src/api/evolutions.ts
+++ b/src/api/evolutions.ts
@@ -38,6 +38,10 @@ export function toEvolutionRequest(
     const req: EvolutionRequest = { current_name: ic.collection };
     if (hasLength(ic.requires_recreation)) {
         req.new_name = suggestedName(ic.collection);
+    } else if (ic.affected_materializations) {
+        // since we're _not_ re-creating the collection, restrict the evolution to only apply to
+        // the materializations that were affected.
+        req.materializations = ic.affected_materializations.map((m) => m.name);
     }
     return req;
 }
@@ -59,6 +63,10 @@ export interface EvolutionRequest {
     // If the desired action is to re-create the collection, then this field should be set to the new name.
     // Otherwise, the evolution will only update materialization bindings to materialize into new resources.
     new_name?: string;
+    // If specified, restrict the evolution to only the given materializations.
+    // At most one of `new_name` or `materializations` may be specified, since
+    // re-creating the collection must apply to all materializations.
+    materializations?: string[];
 }
 
 export const createEvolution = (

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -1248,15 +1248,12 @@ const EntityEvolution: ResolvedIntlConfig['messages'] = {
     'entityEvolution.error.note': `Note: This may result in additional cost as new versions are backfilled.`,
 
     // Single quotes are special and must be doubled: https://formatjs.io/docs/core-concepts/icu-syntax#quoting--escaping
-    'entityEvolution.action.recreateOneBinding.description': `the materialization ''{materializationName}'' will be updated to materialize the collection into a new resource`,
+    'entityEvolution.action.recreateOneBinding.description': `the materialization ''{materializationName}'' will be updated to increment the backfill counter and re-materialize the collection`,
     'entityEvolution.action.recreateBindings.description': `{materializationCount} {materializationCount, plural,
         one {Materialization}
         other {Materializations}
-    } will be updated to materialize the collection into new resources`,
-    'entityEvolution.action.recreateBindings.help': `Any materializations of this collection will be updated to materialize it
-    into a new resource (database table, for example) with an incremented version suffix (like "_v2"). The collection itself will
-    have the schema updated in place, and will retain all current data. The materialization will backfill from the beginning of
-    this collection, but other bindings in the materialization will not be affected.`,
+    } will be updated to increment the backfill counters and re-materialize the collection`,
+    'entityEvolution.action.recreateBindings.help': `The materialization will be updated to increment the ''backfill'' property of the affected binding, which causes it to re-create destination resources (such as tables) and re-materialize the source collection from the beginning. Other bindings in the materialization will not be affected. The source collection will retain all current data.`,
 
     'entityEvolution.action.recreateCollection.description': `Collection will be re-created as ''{newName}'' because {reason}`,
     'entityEvolution.action.recreateCollection.help': `This will create a new collection with the name shown.

--- a/src/stores/SchemaEvolution/Store.ts
+++ b/src/stores/SchemaEvolution/Store.ts
@@ -58,11 +58,7 @@ const getInitialState = (
     setAddNewBindings: (value, options) => {
         set(
             produce((state: SchemaEvolutionState) => {
-                const {
-                    autoDiscover,
-                    evolveIncompatibleCollections,
-                    settingsActive,
-                } = get();
+                const { autoDiscover, settingsActive } = get();
 
                 if (!settingsActive && !options?.initOnly) {
                     state.settingsActive = true;
@@ -71,11 +67,6 @@ const getInitialState = (
                 // Enable auto-discovery when the add new bindings option is enabled.
                 if (value && !autoDiscover) {
                     state.autoDiscover = true;
-                }
-
-                // Disable the incompatible collection evolution option when the add new bindings option is disabled.
-                if (!value && evolveIncompatibleCollections) {
-                    state.evolveIncompatibleCollections = false;
                 }
 
                 state.addNewBindings = value;
@@ -88,16 +79,15 @@ const getInitialState = (
     setEvolveIncompatibleCollections: (value, options) => {
         set(
             produce((state: SchemaEvolutionState) => {
-                const { addNewBindings, autoDiscover, settingsActive } = get();
+                const { autoDiscover, settingsActive } = get();
 
                 if (!settingsActive && !options?.initOnly) {
                     state.settingsActive = true;
                 }
 
-                // Enable auto-discovery and the add new bindings option when the incompatible collection evolution option is enabled.
-                if (value && (!autoDiscover || !addNewBindings)) {
+                // Enable auto-discovery when the incompatible collection evolution option is enabled.
+                if (value && !autoDiscover) {
                     state.autoDiscover = true;
-                    state.addNewBindings = true;
                 }
 
                 state.evolveIncompatibleCollections = value;


### PR DESCRIPTION
## Issues

Fixes #927
Also addresses a portion of #931 (allowing auto-discover properties to be set independently), but does not handle setting defaults.

## Changes

Individual commit messages have more details, but the general thrust of this is to update the UI to be consistent with the new behavior of the evolutions handler, which is updated in estuary/flow#1346. The basic idea is to have the evolutions handler increment the `backfill` counters of materializations instead of renaming the resource.

## Tests

### Manually tested


- Changing primary key of a captured table when published via the UI
- Incompatible change to a database column (I just dropped and re-created the source table)
- Inferred schema changing when publishing a capture via the UI
- Inferred schema changing when publishing a materialization via the UI

For each of those scenarios, I started with a captured collection, and then made a change that would result in an incompatibility. I then edited the capture and clicked the "refresh" button to trigger a discover. I published the changes, and observed the expected error message, and the offer to apply the evolution actions. Finally, I clicked "Apply" and then published after the evolution completed.

## Screenshots

<img width="1677" alt="Screen Shot 2024-01-17 at 7 50 33 AM" src="https://github.com/estuary/ui/assets/4495829/87cf5bb4-33c2-44bf-892b-e51016621e88">
