### PR TITLE
Ops Tweaks : Quick error handling and better token scoping

### DIFF
--- a/src/components/collection/DataPreview/index.tsx
+++ b/src/components/collection/DataPreview/index.tsx
@@ -56,6 +56,14 @@ export function DataPreview({ collectionName }: Props) {
     const journalData = useJournalData(journal?.name, collectionName, {
         desiredCount: 20,
     });
+    const readError = journalData.error
+        ? {
+              code: '',
+              details: '',
+              hint: '',
+              message: journalData.error.message,
+          }
+        : journalsError;
 
     // There is a brief delay between when the data preview card is rendered and the two journal-related
     // hooks are called, which resulted in `isLoading` being a false negative. If the journal client is
@@ -118,8 +126,8 @@ export function DataPreview({ collectionName }: Props) {
                     notFoundTitleMessage="collectionsPreview.notFound.message"
                 />
 
-                {journalsError ? (
-                    <Error error={journalsError} condensed />
+                {readError ? (
+                    <Error error={readError} condensed />
                 ) : isLoading ? (
                     <ListViewSkeleton />
                 ) : (journalData.data?.documents.length ?? 0) > 0 && spec ? (

--- a/src/components/collection/DataPreview/index.tsx
+++ b/src/components/collection/DataPreview/index.tsx
@@ -12,6 +12,7 @@ import { LiveSpecsQuery_spec, useLiveSpecs_spec } from 'hooks/useLiveSpecs';
 import { Refresh } from 'iconoir-react';
 import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { BASE_ERROR } from 'services/supabase';
 import { hasLength } from 'utils/misc-utils';
 import ListViewSkeleton from './ListViewSkeleton';
 
@@ -58,9 +59,7 @@ export function DataPreview({ collectionName }: Props) {
     });
     const readError = journalData.error
         ? {
-              code: '',
-              details: '',
-              hint: '',
+              ...BASE_ERROR,
               message: journalData.error.message,
           }
         : journalsError;

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -10,7 +10,8 @@ import useGlobalSearchParams, {
 import { useEffect, useMemo, useState } from 'react';
 import { OpsLogFlowDocument } from 'types';
 import { MEGABYTE } from 'utils/dataPlane-utils';
-import AlertBox from 'components/shared/AlertBox';
+import Error from 'components/shared/Error';
+import { BASE_ERROR } from 'services/supabase';
 
 const maxBytes = Math.round(MEGABYTE / 25);
 
@@ -127,9 +128,13 @@ function Ops() {
                     />*/}
 
                     {error ? (
-                        <AlertBox title={error.message} severity="error" short>
-                            {error.stack}
-                        </AlertBox>
+                        <Error
+                            error={{
+                                ...BASE_ERROR,
+                                message: error.message,
+                            }}
+                            condensed
+                        />
                     ) : null}
 
                     <LogsTable

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -10,6 +10,7 @@ import useGlobalSearchParams, {
 import { useEffect, useMemo, useState } from 'react';
 import { OpsLogFlowDocument } from 'types';
 import { MEGABYTE } from 'utils/dataPlane-utils';
+import AlertBox from 'components/shared/AlertBox';
 
 const maxBytes = Math.round(MEGABYTE / 25);
 
@@ -24,9 +25,13 @@ function Ops() {
 
     // TODO (typing)
     //  need to handle typing
-    const { data, loading, refresh } = useJournalData(name, collectionName, {
-        maxBytes,
-    });
+    const { data, error, loading, refresh } = useJournalData(
+        name,
+        collectionName,
+        {
+            maxBytes,
+        }
+    );
 
     const documents = useMemo(
         () => (data?.documents ?? []) as OpsLogFlowDocument[],
@@ -120,6 +125,12 @@ function Ops() {
                             />
                         }
                     />*/}
+
+                    {error ? (
+                        <AlertBox title={error.message} severity="error" short>
+                            {error.stack}
+                        </AlertBox>
+                    ) : null}
 
                     <LogsTable
                         documents={docs}

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -15,6 +15,7 @@ import {
     MAX_DOCUMENT_SIZE,
     shouldRefreshToken,
 } from 'utils/dataPlane-utils';
+import { journalStatusIsError } from 'utils/misc-utils';
 
 const errorRetryCount = 2;
 
@@ -180,6 +181,11 @@ async function loadDocuments({
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!metadataResponse?.writeHead) {
         throw new Error('Unable to load metadata');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (journalStatusIsError(metadataResponse?.status)) {
+        throw new Error(metadataResponse.status);
     }
 
     const head = parseInt(metadataResponse.writeHead, 10);

--- a/src/hooks/journals/useJournalNameForLogs.ts
+++ b/src/hooks/journals/useJournalNameForLogs.ts
@@ -15,7 +15,7 @@ function useJournalNameForLogs(entityName: string, region: number = 0) {
             `${collectionName}/kind=${entityType}/name=${encodeURIComponent(
                 entityName
             )}/pivot=00`,
-            collectionName,
+            entityName,
         ];
     }, [entityName, entityType, region]);
 }

--- a/src/hooks/notifications/useInitializeTaskNotification.ts
+++ b/src/hooks/notifications/useInitializeTaskNotification.ts
@@ -8,6 +8,7 @@ import {
     getTaskNotification,
 } from 'api/alerts';
 import { useCallback, useMemo } from 'react';
+import { BASE_ERROR } from 'services/supabase';
 import { useEntitiesStore_capabilities_adminable } from 'stores/Entities/hooks';
 import { hasLength } from 'utils/misc-utils';
 
@@ -37,7 +38,7 @@ function useInitializeTaskNotification(catalogName: string) {
             // Error if the system cannot determine the user email or object roles cannot be found for the user.
             return {
                 data: null,
-                error: { message: '', details: '', hint: '', code: '' },
+                error: { ...BASE_ERROR },
             };
         }
 
@@ -59,7 +60,7 @@ function useInitializeTaskNotification(catalogName: string) {
             // Error if the system cannot determine the user email or object roles cannot be found for the user.
             return {
                 data: null,
-                error: { message: '', details: '', hint: '', code: '' },
+                error: { ...BASE_ERROR },
             };
         }
 

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -51,6 +51,13 @@ export const tokenHasIssues = (errorMessage?: string) => {
 
 export const DEFAULT_FILTER = '__unknown__';
 
+export const BASE_ERROR = {
+    code: '',
+    details: '',
+    hint: '',
+    message: '',
+};
+
 export enum TABLES {
     ALERT_DATA_PROCESSING = 'alert_data_processing',
     ALERT_SUBSCRIPTIONS = 'alert_subscriptions',

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -12,6 +12,25 @@ export const DATE_TIME_PATTERN = `[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[
 // Default size used when splitting up larged promises
 export const CHUNK_SIZE = 10;
 
+const JOURNAL_READ_ERRORS = [
+    'JOURNAL_NOT_FOUND',
+    'NO_JOURNAL_PRIMARY_BROKER',
+    'NOT_JOURNAL_PRIMARY_BROKER',
+    'NOT_JOURNAL_BROKER',
+    'INSUFFICIENT_JOURNAL_BROKERS',
+    'OFFSET_NOT_YET_AVAILABLE',
+    'WRONG_ROUTE',
+    'PROPOSAL_MISMATCH',
+    'ETCD_TRANSACTION_FAILED',
+    'NOT_ALLOWED',
+    'WRONG_APPEND_OFFSET',
+    'INDEX_HAS_GREATER_OFFSET',
+    'REGISTER_MISMATCH',
+];
+export const journalStatusIsError = (status: string | undefined) => {
+    return status ? JOURNAL_READ_ERRORS.includes(status) : false;
+};
+
 // Max time stored in
 //  go/flowctl-go/cmd-api-discover.go
 //  go/flowctl-go/cmd-discover.go


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/858

## Changes

### 858

- Update the reading to be scoped to only the document
- Some quick and dirty error handling 

## Tests

### Manually tested

- Error for logs and data preview
- Success for logs and data preview

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/36145df8-6287-4fae-956d-97449cf5faa3)

This should almost never happen in prod
![image](https://github.com/estuary/ui/assets/270078/8700156e-160c-4340-8767-5629f57eb55d)

