### PR TITLE
Using `update_only` when doing background discover and content change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
                 "use-constant": "^1.1.1",
                 "use-local-storage-state": "^17.3.0",
                 "use-query-params": "^2.2.1",
+                "use-resize-observer": "^9.1.0",
                 "zustand": "^4.3.9"
             },
             "devDependencies": {
@@ -1430,6 +1431,11 @@
                 "@jsonforms/core": "3.0.0",
                 "react": "^16.12.0 || ^17.0.0 || ^18.0.0"
             }
+        },
+        "node_modules/@juggle/resize-observer": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
         },
         "node_modules/@microlink/react-json-view": {
             "version": "1.23.0",
@@ -15026,6 +15032,18 @@
                 "react-router-dom": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/use-resize-observer": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
+            "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+            "dependencies": {
+                "@juggle/resize-observer": "^3.3.1"
+            },
+            "peerDependencies": {
+                "react": "16.8.0 - 18",
+                "react-dom": "16.8.0 - 18"
             }
         },
         "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
         "use-constant": "^1.1.1",
         "use-local-storage-state": "^17.3.0",
         "use-query-params": "^2.2.1",
+        "use-resize-observer": "^9.1.0",
         "zustand": "^4.3.9"
     },
     "devDependencies": {

--- a/src/api/discovers.ts
+++ b/src/api/discovers.ts
@@ -4,12 +4,14 @@ export const discover = (
     entityName: string,
     config: any,
     connectorID: string,
-    draftID: string
+    draftID: string,
+    updateOnly?: boolean
 ) => {
     return insertSupabase(TABLES.DISCOVERS, {
         capture_name: entityName,
         endpoint_config: config,
         connector_tag_id: connectorID,
         draft_id: draftID,
+        update_only: updateOnly ?? false,
     });
 };

--- a/src/components/capture/GenerateButton.tsx
+++ b/src/components/capture/GenerateButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@mui/material';
 import { buttonSx } from 'components/shared/Entity/Header';
+import { useEntityWorkflow_Editing } from 'context/Workflow';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -7,6 +8,7 @@ import {
     useDetailsForm_entityNameChanged,
     useDetailsForm_previousConnectorImage_connectorId,
 } from 'stores/DetailsForm/hooks';
+import { useEndpointConfigStore_changed } from 'stores/EndpointConfig/hooks';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
 import { useResourceConfig_rediscoveryRequired } from 'stores/ResourceConfig/hooks';
@@ -27,10 +29,18 @@ function CaptureGenerateButton({
     disabled,
     createWorkflowMetadata,
 }: Props) {
+    const isEdit = useEntityWorkflow_Editing();
+    const endpointConfigChanged = useEndpointConfigStore_changed();
     const rediscoveryRequired = useResourceConfig_rediscoveryRequired();
+
     const { generateCatalog, isSaving, formActive } = useDiscoverCapture(
         entityType,
         {
+            // We only want to set updateOnly if the user is editing and not updating the config
+            //  This should cover when a user has enable previously disabled collection(s)
+            updateOnly: Boolean(
+                rediscoveryRequired && isEdit && !endpointConfigChanged
+            ),
             initiateDiscovery: createWorkflowMetadata?.initiateDiscovery,
             initiateRediscovery: rediscoveryRequired,
         }

--- a/src/components/capture/GenerateButton.tsx
+++ b/src/components/capture/GenerateButton.tsx
@@ -8,7 +8,6 @@ import {
     useDetailsForm_entityNameChanged,
     useDetailsForm_previousConnectorImage_connectorId,
 } from 'stores/DetailsForm/hooks';
-import { useEndpointConfigStore_changed } from 'stores/EndpointConfig/hooks';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
 import { useResourceConfig_rediscoveryRequired } from 'stores/ResourceConfig/hooks';
@@ -30,7 +29,6 @@ function CaptureGenerateButton({
     createWorkflowMetadata,
 }: Props) {
     const isEdit = useEntityWorkflow_Editing();
-    const endpointConfigChanged = useEndpointConfigStore_changed();
     const rediscoveryRequired = useResourceConfig_rediscoveryRequired();
 
     const { generateCatalog, isSaving, formActive } = useDiscoverCapture(
@@ -38,9 +36,7 @@ function CaptureGenerateButton({
         {
             // We only want to set updateOnly if the user is editing and not updating the config
             //  This should cover when a user has enable previously disabled collection(s)
-            updateOnly: Boolean(
-                rediscoveryRequired && isEdit && !endpointConfigChanged()
-            ),
+            updateOnly: Boolean(isEdit && rediscoveryRequired),
             initiateDiscovery: createWorkflowMetadata?.initiateDiscovery,
             initiateRediscovery: rediscoveryRequired,
         }

--- a/src/components/capture/GenerateButton.tsx
+++ b/src/components/capture/GenerateButton.tsx
@@ -36,7 +36,9 @@ function CaptureGenerateButton({
         {
             // We only want to set updateOnly if the user is editing and not updating the config
             //  This should cover when a user has enable previously disabled collection(s)
-            updateOnly: Boolean(isEdit && rediscoveryRequired),
+            updateOnly: createWorkflowMetadata?.initiateDiscovery
+                ? false
+                : Boolean(isEdit && rediscoveryRequired),
             initiateDiscovery: createWorkflowMetadata?.initiateDiscovery,
             initiateRediscovery: rediscoveryRequired,
         }

--- a/src/components/capture/GenerateButton.tsx
+++ b/src/components/capture/GenerateButton.tsx
@@ -39,7 +39,7 @@ function CaptureGenerateButton({
             // We only want to set updateOnly if the user is editing and not updating the config
             //  This should cover when a user has enable previously disabled collection(s)
             updateOnly: Boolean(
-                rediscoveryRequired && isEdit && !endpointConfigChanged
+                rediscoveryRequired && isEdit && !endpointConfigChanged()
             ),
             initiateDiscovery: createWorkflowMetadata?.initiateDiscovery,
             initiateRediscovery: rediscoveryRequired,

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -115,7 +115,8 @@ function useDiscoverCapture(
                 const discoveryStartSuccess = await startDiscovery(
                     processedEntityName,
                     encryptedEndpointConfig.data,
-                    options.initiateRediscovery
+                    options.initiateRediscovery,
+                    options.updateOnly
                 );
 
                 return discoveryStartSuccess;

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -143,6 +143,7 @@ function useDiscoverCapture(
             endpointConfigErrorsExist,
             options?.initiateDiscovery,
             options?.initiateRediscovery,
+            options?.updateOnly,
             persistedDraftId,
             processedEntityName,
             resetEditorState,

--- a/src/components/capture/useDiscoverCapture.ts
+++ b/src/components/capture/useDiscoverCapture.ts
@@ -28,7 +28,11 @@ import useDiscoverStartDiscovery from './useDiscoverStartDiscovery';
 
 function useDiscoverCapture(
     entityType: Entity,
-    options?: { initiateRediscovery?: boolean; initiateDiscovery?: boolean }
+    options?: {
+        initiateRediscovery?: boolean;
+        initiateDiscovery?: boolean;
+        updateOnly?: boolean;
+    }
 ) {
     const draftUpdate = useDiscoverDraftUpdate(options);
     const configEncrypt = useDiscoverConfigEncrypt();

--- a/src/components/capture/useDiscoverStartDiscovery.ts
+++ b/src/components/capture/useDiscoverStartDiscovery.ts
@@ -34,7 +34,8 @@ function useDiscoverStartDiscovery(entityType: Entity) {
         async (
             processedEntityName: string,
             encryptedEndpointConfigResponse: any,
-            rediscover?: boolean
+            rediscover?: boolean,
+            updateOnly?: boolean
         ) => {
             // If we are doing a rediscovery and we have a draft then go ahead and use that draft
             //  that way the most recent changes to bindings and endpoints will get added to the draft before rediscovery
@@ -67,7 +68,7 @@ function useDiscoverStartDiscovery(entityType: Entity) {
                 encryptedEndpointConfigResponse,
                 imageConnectorTagId,
                 newDraftId,
-                rediscover
+                updateOnly
             );
 
             if (discoverResponse.error) {

--- a/src/components/capture/useDiscoverStartDiscovery.ts
+++ b/src/components/capture/useDiscoverStartDiscovery.ts
@@ -4,6 +4,7 @@ import { createEntityDraft } from 'api/drafts';
 import {
     useEditorStore_persistedDraftId,
     useEditorStore_setCatalogName,
+    useEditorStore_setId,
 } from 'components/editor/Store/hooks';
 import useEntityWorkflowHelpers from 'components/shared/Entity/hooks/useEntityWorkflowHelpers';
 import { useCallback } from 'react';
@@ -19,6 +20,7 @@ function useDiscoverStartDiscovery(entityType: Entity) {
         useDiscoverStartSubscription(entityType);
     const { callFailed } = useEntityWorkflowHelpers();
 
+    const setDraftId = useEditorStore_setId();
     const persistedDraftId = useEditorStore_persistedDraftId();
     const setCatalogName = useEditorStore_setCatalogName();
 
@@ -64,9 +66,16 @@ function useDiscoverStartDiscovery(entityType: Entity) {
                 processedEntityName,
                 encryptedEndpointConfigResponse,
                 imageConnectorTagId,
-                newDraftId
+                newDraftId,
+                rediscover
             );
+
             if (discoverResponse.error) {
+                // If we failed at discovery we need to clear draft ID like we do
+                //  when we createDiscoversSubscription. Otherwise, the Test|Save
+                //  buttons will appear.
+                setDraftId(null);
+
                 callFailed({
                     error: {
                         title: 'captureCreate.generate.failedErrorTitle',

--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -13,6 +13,7 @@ import { useEffect, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useMount, useUnmount } from 'react-use';
 import { createJSONFormDefaults } from 'services/ajv';
+import { useDetailsForm_unsupportedConnectorVersion } from 'stores/DetailsForm/hooks';
 import {
     useEndpointConfigStore_endpointConfig_data,
     useEndpointConfigStore_endpointSchema,
@@ -69,6 +70,9 @@ function EndpointConfig({
         useEndpointConfigStore_setEncryptedEndpointConfig();
     const endpointConfigErrorsExist = useEndpointConfigStore_errorsExist();
 
+    const unsupportedConnectorVersion =
+        useDetailsForm_unsupportedConnectorVersion();
+
     // Workflow related props
     const workflow = useEntityWorkflow();
     const editWorkflow =
@@ -103,7 +107,11 @@ function EndpointConfig({
     );
 
     useEffect(() => {
-        if (connectorTag?.endpoint_spec_schema && endpointSchemaChanged) {
+        if (
+            unsupportedConnectorVersion &&
+            connectorTag?.endpoint_spec_schema &&
+            endpointSchemaChanged
+        ) {
             // force some new data in
             setServerUpdateRequired(true);
             setEncryptedEndpointConfig({
@@ -121,14 +129,14 @@ function EndpointConfig({
             setPreviousEndpointConfig(defaultConfig);
         }
     }, [
-        setServerUpdateRequired,
-        setEndpointConfig,
-        setEndpointSchema,
-        setPreviousEndpointConfig,
-        connectorTag,
         connectorTag?.endpoint_spec_schema,
         endpointSchemaChanged,
         setEncryptedEndpointConfig,
+        setEndpointConfig,
+        setEndpointSchema,
+        setPreviousEndpointConfig,
+        setServerUpdateRequired,
+        unsupportedConnectorVersion,
     ]);
 
     // Controlling if we need to show the generate button again

--- a/src/components/tables/EntityTable/TableBody.tsx
+++ b/src/components/tables/EntityTable/TableBody.tsx
@@ -5,6 +5,7 @@ import {
     getColumnKeyList,
     getEmptyTableHeader,
     getEmptyTableMessage,
+    getTableComponents,
 } from 'utils/table-utils';
 import { useMemo } from 'react';
 import TableLoadingRows from '../Loading';
@@ -33,21 +34,27 @@ function EntityTableBody({
         return getColumnKeyList(columns);
     }, [columns]);
 
+    const { tbodyComponent, tdComponent, trComponent } =
+        getTableComponents(enableDivRendering);
+
     if (rows && CustomBody) {
         return <CustomBody />;
     }
 
     return (
-        <TableBody component={enableDivRendering ? 'div' : 'thead'}>
+        <TableBody component={tbodyComponent}>
             {rows ? (
                 rows
             ) : loading ? (
-                <TableLoadingRows columnKeys={columnKeys} />
+                <TableLoadingRows
+                    columnKeys={columnKeys}
+                    enableDivRendering={enableDivRendering}
+                />
             ) : (
-                <TableRow component={enableDivRendering ? 'div' : 'tr'}>
+                <TableRow component={trComponent}>
                     <TableCell
                         colSpan={columnKeys.length}
-                        component={enableDivRendering ? 'div' : 'td'}
+                        component={tdComponent}
                     >
                         <Box
                             sx={{

--- a/src/components/tables/EntityTable/TableHeader.tsx
+++ b/src/components/tables/EntityTable/TableHeader.tsx
@@ -1,15 +1,10 @@
-import {
-    Box,
-    TableCell,
-    TableHead,
-    TableRow,
-    TableSortLabel,
-} from '@mui/material';
+import { TableCell, TableHead, TableRow, TableSortLabel } from '@mui/material';
 import { getStickyTableCell } from 'context/Theme';
 import { ArrowDown } from 'iconoir-react';
 import { FormattedMessage } from 'react-intl';
 import { SelectTableStoreNames } from 'stores/names';
 import { SortDirection } from 'types';
+import { getTableComponents } from 'utils/table-utils';
 import { ColumnProps } from './types';
 
 interface Props {
@@ -35,10 +30,13 @@ function EntityTableHeader({
 }: Props) {
     const enableSort = Boolean(columnToSort && headerClick && sortDirection);
 
+    const { theaderComponent, tdComponent, trComponent } =
+        getTableComponents(enableDivRendering);
+
     return (
-        <TableHead component={enableDivRendering ? 'div' : 'thead'}>
+        <TableHead component={theaderComponent}>
             <TableRow
-                component={enableDivRendering ? Box : TableRow}
+                component={trComponent}
                 sx={{
                     background: (theme) => theme.palette.background.default,
                 }}
@@ -84,7 +82,7 @@ function EntityTableHeader({
 
                     return (
                         <TableCell
-                            component={enableDivRendering ? 'div' : 'td'}
+                            component={tdComponent}
                             key={`${column.field}-${index}`}
                             align={column.align}
                             sortDirection={

--- a/src/components/tables/EntityTable/TableHeader.tsx
+++ b/src/components/tables/EntityTable/TableHeader.tsx
@@ -10,6 +10,7 @@ import { ColumnProps } from './types';
 interface Props {
     columns: ColumnProps[];
     headerClick?: (column: any) => (event: React.MouseEvent<unknown>) => void;
+    height?: number;
     hide?: boolean;
     columnToSort?: string;
     selectData?: any;
@@ -23,6 +24,7 @@ function EntityTableHeader({
     columnToSort,
     enableDivRendering,
     headerClick,
+    height,
     hide,
     selectData,
     selectableTableStoreName,
@@ -39,6 +41,7 @@ function EntityTableHeader({
                 component={trComponent}
                 sx={{
                     background: (theme) => theme.palette.background.default,
+                    height,
                 }}
             >
                 {columns.map((column, index) => {

--- a/src/components/tables/Loading.tsx
+++ b/src/components/tables/Loading.tsx
@@ -1,38 +1,63 @@
 import { Skeleton, TableCell, TableRow } from '@mui/material';
 import { useMemo } from 'react';
+import { getTableComponents } from 'utils/table-utils';
 
 interface Props {
     columnKeys: string[];
+    enableDivRendering?: boolean;
     singleRow?: boolean;
 }
 
 const styling = { height: 45 };
 
-function TableLoadingRows({ columnKeys, singleRow }: Props) {
+function TableLoadingRows({
+    columnKeys,
+    enableDivRendering,
+    singleRow,
+}: Props) {
     const loadingRows = useMemo(() => {
+        const { tdComponent, trComponent } =
+            getTableComponents(enableDivRendering);
+
         const loadingRow = columnKeys.map((columnKey, index) => (
-            <TableCell key={`loading-${columnKey}__-${index}`}>
+            <TableCell
+                key={`loading-${columnKey}__-${index}`}
+                component={tdComponent}
+            >
                 <Skeleton variant="rectangular" />
             </TableCell>
         ));
 
         if (singleRow) {
-            return <TableRow sx={styling}>{loadingRow}</TableRow>;
+            return (
+                <TableRow component={trComponent} sx={styling}>
+                    {loadingRow}
+                </TableRow>
+            );
         }
 
         return (
             <>
-                <TableRow sx={styling}>{loadingRow}</TableRow>
-
-                <TableRow sx={{ ...styling, opacity: '75%' }}>
-                    {loadingRow}
-                </TableRow>
-
-                <TableRow sx={{ ...styling, opacity: '50%' }}>
+                <TableRow component={trComponent} sx={styling}>
                     {loadingRow}
                 </TableRow>
 
                 <TableRow
+                    component={trComponent}
+                    sx={{ ...styling, opacity: '75%' }}
+                >
+                    {loadingRow}
+                </TableRow>
+
+                <TableRow
+                    component={trComponent}
+                    sx={{ ...styling, opacity: '50%' }}
+                >
+                    {loadingRow}
+                </TableRow>
+
+                <TableRow
+                    component={trComponent}
                     sx={{
                         ...styling,
                         'opacity': '25%',
@@ -45,7 +70,7 @@ function TableLoadingRows({ columnKeys, singleRow }: Props) {
                 </TableRow>
             </>
         );
-    }, [columnKeys, singleRow]);
+    }, [columnKeys, enableDivRendering, singleRow]);
 
     return loadingRows;
 }

--- a/src/components/tables/Logs/Body.tsx
+++ b/src/components/tables/Logs/Body.tsx
@@ -68,7 +68,6 @@ function LogsTableBody({
 
     const renderRow = useCallback(
         ({ data, index, style }: ListChildComponentProps) => {
-            console.log('renderRow');
             return (
                 <LogsTableRow
                     row={data[index]}
@@ -83,10 +82,8 @@ function LogsTableBody({
     if (documents.length > 0) {
         return (
             <TableBody component="div">
-                1
                 <AutoSizer>
                     {({ width, height }: AutoSizer['state']) => {
-                        console.log('{ width, height }', { width, height });
                         return (
                             <VariableSizeList
                                 ref={tableScroller}

--- a/src/components/tables/Logs/Body.tsx
+++ b/src/components/tables/Logs/Body.tsx
@@ -68,6 +68,7 @@ function LogsTableBody({
 
     const renderRow = useCallback(
         ({ data, index, style }: ListChildComponentProps) => {
+            console.log('renderRow');
             return (
                 <LogsTableRow
                     row={data[index]}
@@ -82,8 +83,10 @@ function LogsTableBody({
     if (documents.length > 0) {
         return (
             <TableBody component="div">
+                1
                 <AutoSizer>
                     {({ width, height }: AutoSizer['state']) => {
+                        console.log('{ width, height }', { width, height });
                         return (
                             <VariableSizeList
                                 ref={tableScroller}
@@ -114,6 +117,7 @@ function LogsTableBody({
     return (
         <EntityTableBody
             columns={columns}
+            enableDivRendering
             noExistingDataContentIds={{
                 header: 'ops.logsTable.emptyTableDefault.header',
                 message: 'ops.logsTable.emptyTableDefault.message',

--- a/src/components/tables/Logs/Body.tsx
+++ b/src/components/tables/Logs/Body.tsx
@@ -39,8 +39,8 @@ function LogsTableBody({
             }
 
             return (
-                (expandedHeights.current.get(documents[rowIndex]._meta.uuid) ??
-                    0) + DEFAULT_ROW_HEIGHT
+                expandedHeights.current.get(documents[rowIndex]._meta.uuid) ??
+                DEFAULT_ROW_HEIGHT
             );
         },
         [documents]
@@ -48,7 +48,11 @@ function LogsTableBody({
 
     const expandRow = useCallback(
         (index: number, height: number) => {
-            if (height > 0) {
+            if (
+                height > 0 ||
+                height === DEFAULT_ROW_HEIGHT_WITHOUT_FIELDS ||
+                height === DEFAULT_ROW_HEIGHT
+            ) {
                 expandedHeights.current.set(
                     documents[index]._meta.uuid,
                     height
@@ -63,16 +67,16 @@ function LogsTableBody({
     );
 
     const renderRow = useCallback(
-        ({ index, style }: ListChildComponentProps) => {
+        ({ data, index, style }: ListChildComponentProps) => {
             return (
                 <LogsTableRow
-                    row={documents[index]}
+                    row={data[index]}
                     style={style}
                     rowExpanded={(height) => expandRow(index, height)}
                 />
             );
         },
-        [documents, expandRow]
+        [expandRow]
     );
 
     if (documents.length > 0) {
@@ -87,6 +91,7 @@ function LogsTableBody({
                                 innerRef={virtualRows}
                                 height={height}
                                 width={width}
+                                itemData={documents}
                                 itemSize={getItemSize}
                                 estimatedItemSize={DEFAULT_ROW_HEIGHT}
                                 itemCount={documents.length}

--- a/src/components/tables/Logs/Columns.tsx
+++ b/src/components/tables/Logs/Columns.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack } from '@mui/material';
 import { OpsLogFlowDocument } from 'types';
+import { RefCallback } from 'react';
 import LevelCell from '../cells/logs/LevelCell';
 import TimestampCell from '../cells/logs/TimestampCell';
 import MessageCell from '../cells/logs/MessageCell';
@@ -7,21 +8,16 @@ import FieldsExpandedCell from '../cells/logs/FieldsExpandedCell';
 
 interface RowProps {
     row: OpsLogFlowDocument;
+    sizeRef: RefCallback<HTMLElement>;
     open: boolean;
     opening: boolean;
-    toggleRowHeight: any;
 }
 
-export function LogsTableColumns({
-    row,
-    open,
-    opening,
-    toggleRowHeight,
-}: RowProps) {
+export function LogsTableColumns({ row, sizeRef, open, opening }: RowProps) {
     const hasFields = Boolean(row.fields);
 
     return (
-        <Stack>
+        <Stack ref={sizeRef}>
             <Box>
                 <LevelCell
                     disableExpand={!hasFields}
@@ -40,7 +36,6 @@ export function LogsTableColumns({
                     message={row.message}
                     open={open}
                     opening={opening}
-                    toggleRowHeight={toggleRowHeight}
                 />
             ) : null}
         </Stack>

--- a/src/components/tables/Logs/Columns.tsx
+++ b/src/components/tables/Logs/Columns.tsx
@@ -10,10 +10,15 @@ interface RowProps {
     row: OpsLogFlowDocument;
     sizeRef: RefCallback<HTMLElement>;
     open: boolean;
-    opening: boolean;
+    heightChanging: boolean;
 }
 
-export function LogsTableColumns({ row, sizeRef, open, opening }: RowProps) {
+export function LogsTableColumns({
+    row,
+    sizeRef,
+    open,
+    heightChanging,
+}: RowProps) {
     const hasFields = Boolean(row.fields);
 
     return (
@@ -35,7 +40,7 @@ export function LogsTableColumns({ row, sizeRef, open, opening }: RowProps) {
                     uuid={row._meta.uuid}
                     message={row.message}
                     open={open}
-                    opening={opening}
+                    heightChanging={heightChanging}
                 />
             ) : null}
         </Stack>

--- a/src/components/tables/Logs/Row.tsx
+++ b/src/components/tables/Logs/Row.tsx
@@ -33,7 +33,6 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
                 return;
             }
 
-            console.log('debounce calling expanded', rowSizeHeight);
             previousHeight.current = rowSizeHeight;
             rowExpanded(rowSizeHeight);
             setHeightChanging(false);
@@ -74,7 +73,7 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
             <LogsTableColumns
                 row={row}
                 open={open}
-                opening={heightChanging}
+                heightChanging={heightChanging}
                 sizeRef={sizeRef}
             />
         </TableRow>

--- a/src/components/tables/Logs/Row.tsx
+++ b/src/components/tables/Logs/Row.tsx
@@ -1,26 +1,34 @@
 import { Box, TableRow, useTheme } from '@mui/material';
 import { OpsLogFlowDocument } from 'types';
 import { CSSProperties, useLayoutEffect, useRef, useState } from 'react';
-import { doubleElevationHoverBackground } from 'context/Theme';
 import useResizeObserver from 'use-resize-observer';
+import { defaultOutline_hovered } from 'context/Theme';
 import { DEFAULT_ROW_HEIGHT } from './shared';
 import { LogsTableColumns } from './Columns';
 
 interface RowProps {
     row: OpsLogFlowDocument;
     rowExpanded: (height: number) => void;
+    rowOpened: (isOpen: boolean) => void;
+    renderOpen?: boolean;
     style?: CSSProperties;
 }
 
-export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
+export function LogsTableRow({
+    row,
+    rowExpanded,
+    renderOpen = false,
+    rowOpened,
+    style,
+}: RowProps) {
     // const startOfLogs = row._meta.uuid === START_OF_LOGS_UUID;
 
     const theme = useTheme();
     const renderedHeight = style?.height ?? DEFAULT_ROW_HEIGHT;
 
-    const [open, setOpen] = useState(renderedHeight > DEFAULT_ROW_HEIGHT);
-    const [heightChanging, setHeightChanging] = useState(false);
     const previousHeight = useRef(renderedHeight);
+    const [open, setOpen] = useState(renderOpen);
+    const [heightChanging, setHeightChanging] = useState(false);
 
     const { ref: sizeRef, height: rowSizeHeight } =
         useResizeObserver<HTMLElement>();
@@ -40,6 +48,7 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
 
         setHeightChanging(true);
         setOpen(newVal);
+        rowOpened(newVal);
     };
 
     return (
@@ -51,9 +60,8 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
             style={style}
             sx={{
                 cursor: 'pointer',
-                borderLeft: open ? '5px solid' : undefined,
-                borderLeftColor:
-                    doubleElevationHoverBackground[theme.palette.mode],
+                borderLeft: open ? '3px solid' : undefined,
+                borderLeftColor: defaultOutline_hovered[theme.palette.mode],
             }}
             onClick={handleClick}
         >

--- a/src/components/tables/Logs/Row.tsx
+++ b/src/components/tables/Logs/Row.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react';
 import { doubleElevationHoverBackground } from 'context/Theme';
 import useResizeObserver from 'use-resize-observer';
 import { useDebounce } from 'react-use';
-import { DEFAULT_ROW_HEIGHT } from './shared';
+import { DEFAULT_ROW_HEIGHT, EXPAND_ROW_WAIT } from './shared';
 import { LogsTableColumns } from './Columns';
 
 interface RowProps {
@@ -27,7 +27,7 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
     const { ref: sizeRef, height: rowSizeHeight } =
         useResizeObserver<HTMLElement>();
 
-    const [, cancel] = useDebounce(
+    useDebounce(
         () => {
             if (!rowSizeHeight || rowSizeHeight === previousHeight.current) {
                 return;
@@ -37,7 +37,7 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
             rowExpanded(rowSizeHeight);
             setHeightChanging(false);
         },
-        10,
+        EXPAND_ROW_WAIT,
         [rowSizeHeight, rowExpanded, setHeightChanging]
     );
 
@@ -46,19 +46,12 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
 
         setHeightChanging(true);
         setOpen(newVal);
-
-        if (!newVal) {
-            cancel();
-        }
     };
-
-    const id = open ? `jsonPopper_${row._meta.uuid}` : undefined;
 
     return (
         <TableRow
             component={Box}
             aria-expanded={hasFields ? open : undefined}
-            aria-describedby={id}
             hover={Boolean(hasFields && !open)}
             selected={open}
             style={style}

--- a/src/components/tables/Logs/Row.tsx
+++ b/src/components/tables/Logs/Row.tsx
@@ -1,16 +1,15 @@
 import { Box, TableRow, useTheme } from '@mui/material';
 import { OpsLogFlowDocument } from 'types';
-import { useRef, useState } from 'react';
+import { CSSProperties, useLayoutEffect, useRef, useState } from 'react';
 import { doubleElevationHoverBackground } from 'context/Theme';
 import useResizeObserver from 'use-resize-observer';
-import { useDebounce } from 'react-use';
-import { DEFAULT_ROW_HEIGHT, EXPAND_ROW_WAIT } from './shared';
+import { DEFAULT_ROW_HEIGHT } from './shared';
 import { LogsTableColumns } from './Columns';
 
 interface RowProps {
     row: OpsLogFlowDocument;
     rowExpanded: (height: number) => void;
-    style?: any;
+    style?: CSSProperties;
 }
 
 export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
@@ -21,24 +20,20 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
 
     const [open, setOpen] = useState(renderedHeight > DEFAULT_ROW_HEIGHT);
     const [heightChanging, setHeightChanging] = useState(false);
-    const previousHeight = useRef<Number>(renderedHeight);
+    const previousHeight = useRef(renderedHeight);
 
     const { ref: sizeRef, height: rowSizeHeight } =
         useResizeObserver<HTMLElement>();
 
-    useDebounce(
-        () => {
-            if (!rowSizeHeight || rowSizeHeight === previousHeight.current) {
-                return;
-            }
+    useLayoutEffect(() => {
+        if (!rowSizeHeight || rowSizeHeight === previousHeight.current) {
+            return;
+        }
 
-            previousHeight.current = rowSizeHeight;
-            rowExpanded(rowSizeHeight);
-            setHeightChanging(false);
-        },
-        EXPAND_ROW_WAIT,
-        [rowSizeHeight, rowExpanded, setHeightChanging]
-    );
+        previousHeight.current = rowSizeHeight;
+        rowExpanded(rowSizeHeight);
+        setHeightChanging(false);
+    }, [rowExpanded, rowSizeHeight]);
 
     const handleClick = () => {
         const newVal = !open;

--- a/src/components/tables/Logs/Row.tsx
+++ b/src/components/tables/Logs/Row.tsx
@@ -17,7 +17,6 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
     // const startOfLogs = row._meta.uuid === START_OF_LOGS_UUID;
 
     const theme = useTheme();
-    const hasFields = Boolean(row.fields);
     const renderedHeight = style?.height ?? DEFAULT_ROW_HEIGHT;
 
     const [open, setOpen] = useState(renderedHeight > DEFAULT_ROW_HEIGHT);
@@ -51,17 +50,17 @@ export function LogsTableRow({ row, rowExpanded, style }: RowProps) {
     return (
         <TableRow
             component={Box}
-            aria-expanded={hasFields ? open : undefined}
-            hover={Boolean(hasFields && !open)}
+            aria-expanded={open}
+            hover={!open}
             selected={open}
             style={style}
             sx={{
-                cursor: hasFields ? 'pointer' : undefined,
+                cursor: 'pointer',
                 borderLeft: open ? '5px solid' : undefined,
                 borderLeftColor:
                     doubleElevationHoverBackground[theme.palette.mode],
             }}
-            onClick={hasFields ? handleClick : undefined}
+            onClick={handleClick}
         >
             <LogsTableColumns
                 row={row}

--- a/src/components/tables/Logs/index.tsx
+++ b/src/components/tables/Logs/index.tsx
@@ -121,7 +121,11 @@ function LogsTable({ documents, fetchNewer, fetchOlder, loading }: Props) {
                     stickyHeader
                     sx={{ minWidth: 250, width: '100%', height: '100%' }}
                 >
-                    <EntityTableHeader columns={columns} enableDivRendering />
+                    <EntityTableHeader
+                        columns={columns}
+                        enableDivRendering
+                        height={35} // This is required for FF to render the body for some reason (Q1 2024)
+                    />
 
                     <LogsTableBody
                         documents={documents}

--- a/src/components/tables/Logs/index.tsx
+++ b/src/components/tables/Logs/index.tsx
@@ -85,6 +85,7 @@ function LogsTable({ documents, fetchNewer, fetchOlder, loading }: Props) {
             }
             setFetchingOlder(false);
             setFetchingNewer(false);
+            setLastCheckedForNew(null);
         } else if (fetchingNewer && lastCount.current === documents.length) {
             setLastCheckedForNew(new Date().toISOString());
             setFetchingNewer(false);

--- a/src/components/tables/Logs/shared.ts
+++ b/src/components/tables/Logs/shared.ts
@@ -10,3 +10,7 @@ export const DEFAULT_ROW_HEIGHT = 55;
 export const DEFAULT_ROW_HEIGHT_WITHOUT_FIELDS = 35;
 
 export const START_OF_LOGS_UUID = 'UI-start-of-logs';
+
+// Try to keep this close so that the icon rotates just as the height is being adjusted
+export const EXPAND_ROW_WAIT = 15;
+export const EXPAND_ROW_TRANSITION = 200;

--- a/src/components/tables/Logs/shared.ts
+++ b/src/components/tables/Logs/shared.ts
@@ -11,6 +11,4 @@ export const DEFAULT_ROW_HEIGHT_WITHOUT_FIELDS = 35;
 
 export const START_OF_LOGS_UUID = 'UI-start-of-logs';
 
-// Try to keep this close so that the icon rotates just as the height is being adjusted
-export const EXPAND_ROW_WAIT = 15;
 export const EXPAND_ROW_TRANSITION = 200;

--- a/src/components/tables/cells/logs/ExpandRowButton.tsx
+++ b/src/components/tables/cells/logs/ExpandRowButton.tsx
@@ -1,4 +1,5 @@
 import { Box, IconButton, Tooltip } from '@mui/material';
+import { EXPAND_ROW_TRANSITION } from 'components/tables/Logs/shared';
 import { NavArrowRight } from 'iconoir-react';
 import { useIntl } from 'react-intl';
 
@@ -29,7 +30,7 @@ function ExpandRowButton({ disable, expanded }: Props) {
                         padding: 0.5,
                         marginRight: 0,
                         transform: `rotate(${expanded ? '90' : '0'}deg)`,
-                        transition: 'all 50ms ease-in-out',
+                        transition: `all ${EXPAND_ROW_TRANSITION}ms ease-in-out`,
                     }}
                 >
                     <NavArrowRight />

--- a/src/components/tables/cells/logs/FieldsExpandedCell.tsx
+++ b/src/components/tables/cells/logs/FieldsExpandedCell.tsx
@@ -7,18 +7,10 @@ interface Props {
     message: string;
     open: boolean;
     opening: boolean;
-    toggleRowHeight: (event: HTMLElement) => void;
     uuid: string;
 }
 
-function FieldsExpandedCell({
-    fields,
-    open,
-    opening,
-    message,
-    toggleRowHeight,
-    uuid,
-}: Props) {
+function FieldsExpandedCell({ fields, open, opening, message, uuid }: Props) {
     const theme = useTheme();
 
     return (
@@ -30,8 +22,6 @@ function FieldsExpandedCell({
                 event.preventDefault();
                 event.stopPropagation();
             }}
-            onEntered={toggleRowHeight}
-            onExited={toggleRowHeight}
             unmountOnExit
         >
             <Box

--- a/src/components/tables/cells/logs/FieldsExpandedCell.tsx
+++ b/src/components/tables/cells/logs/FieldsExpandedCell.tsx
@@ -1,6 +1,6 @@
 import { Box, Collapse, Divider, Typography, useTheme } from '@mui/material';
 import ReactJson from '@microlink/react-json-view';
-import { jsonViewTheme } from 'context/Theme';
+import { jsonViewTheme, paperBackground } from 'context/Theme';
 
 interface Props {
     fields: any;
@@ -32,6 +32,8 @@ function FieldsExpandedCell({
         >
             <Box
                 sx={{
+                    background: paperBackground[theme.palette.mode],
+                    borderBottomWidth: 1,
                     px: 3,
                     py: 2,
                     opacity: heightChanging ? 0 : undefined,

--- a/src/components/tables/cells/logs/FieldsExpandedCell.tsx
+++ b/src/components/tables/cells/logs/FieldsExpandedCell.tsx
@@ -6,11 +6,17 @@ interface Props {
     fields: any;
     message: string;
     open: boolean;
-    opening: boolean;
+    heightChanging: boolean;
     uuid: string;
 }
 
-function FieldsExpandedCell({ fields, open, opening, message, uuid }: Props) {
+function FieldsExpandedCell({
+    fields,
+    open,
+    heightChanging,
+    message,
+    uuid,
+}: Props) {
     const theme = useTheme();
 
     return (
@@ -28,7 +34,7 @@ function FieldsExpandedCell({ fields, open, opening, message, uuid }: Props) {
                 sx={{
                     px: 3,
                     py: 2,
-                    opacity: opening ? 0 : undefined,
+                    opacity: heightChanging ? 0 : undefined,
                 }}
             >
                 <Typography sx={{ fontFamily: 'Monospace' }}>

--- a/src/components/tables/cells/logs/MessageCell.tsx
+++ b/src/components/tables/cells/logs/MessageCell.tsx
@@ -21,7 +21,7 @@ function MessageCell({ fields, message }: Props) {
             </Typography>
 
             {fields ? (
-                <Typography component="div" sx={BaseTypographySx}>
+                <Typography component="div" sx={{ ...BaseTypographySx }}>
                     <ObjectPreview data={fields} />
                 </Typography>
             ) : null}

--- a/src/components/tables/cells/logs/shared.ts
+++ b/src/components/tables/cells/logs/shared.ts
@@ -1,2 +1,2 @@
-export const BaseTypographySx = { fontFamily: 'Monospace', textWrap: 'nowrap' };
+export const BaseTypographySx = { fontFamily: 'Monospace' };
 export const BaseCellSx = { maxWidth: 'min-content', py: 0 };

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -787,7 +787,7 @@ const CaptureEdit: ResolvedIntlConfig['messages'] = {
     'captureEdit.editor.default': `Before you can edit the capture specification, you must fill out the Connection Configuration section and click "${CTAs['cta.generateCatalog.capture']}." `,
     'captureEdit.finalReview.instructions': `The following Flow specification was generated from the details you provided. To make changes, you can enter new values in the form above or edit the YAML file directly. Click "${CTAs['cta.saveEntity']}" to proceed.`,
 
-    'captureEdit.collections.heading': `3. Source Collections`,
+    'captureEdit.collections.heading': `3. Target Collections`,
     'captureEdit.collectionSelector.heading': `Collection Selector`,
     'captureEdit.collectionSelector.instructions': `The collections bound to your existing capture. To update the configuration, please update the fields under the Config tab. To update the schema, click Edit under the Collection tab.`,
 

--- a/src/services/shared.ts
+++ b/src/services/shared.ts
@@ -30,7 +30,10 @@ export const logRocketConsole = (message: string, ...props: any[]) => {
 };
 
 export const FAILED_TO_FETCH = 'failed to fetch';
+export const RESPONSE_JSON_NOT_FN = 'response.json is not a function';
+
 export const RETRY_REASONS = [FAILED_TO_FETCH];
+export const NETWORK_ERRORS = [FAILED_TO_FETCH, RESPONSE_JSON_NOT_FN];
 
 export const checkErrorMessage = (
     checkingFor: string,
@@ -39,3 +42,7 @@ export const checkErrorMessage = (
 
 export const retryAfterFailure = (message?: string | null | undefined) =>
     RETRY_REASONS.some((el) => checkErrorMessage(el, message));
+
+export const showAsTechnicalDifficulties = (
+    message?: string | null | undefined
+) => NETWORK_ERRORS.some((el) => checkErrorMessage(el, message));

--- a/src/stores/DetailsForm/hooks.ts
+++ b/src/stores/DetailsForm/hooks.ts
@@ -30,6 +30,14 @@ export const useDetailsForm_connectorImage = () => {
     >(getStoreName(entityType), (state) => state.details.data.connectorImage);
 };
 
+export const useDetailsForm_unsupportedConnectorVersion = () => {
+    const entityType = useEntityType();
+    return useZustandStore<
+        DetailsFormState,
+        DetailsFormState['unsupportedConnectorVersion']
+    >(getStoreName(entityType), (state) => state.unsupportedConnectorVersion);
+};
+
 export const useDetailsForm_connectorImage_connectorId = () => {
     const entityType = useEntityType();
     return useZustandStore<

--- a/src/utils/table-utils.tsx
+++ b/src/utils/table-utils.tsx
@@ -1,3 +1,4 @@
+import { TableBody, TableCell, TableHead, TableRow } from '@mui/material';
 import MessageWithLink from 'components/content/MessageWithLink';
 import { FormattedMessage } from 'react-intl';
 import { Pagination } from 'services/supabase';
@@ -64,3 +65,32 @@ export const getColumnKeyList = (columns: TableColumns[]) =>
             (_, indexCount) => `${column.field}__${indexCount}-${index}`
         )
     );
+
+// TODO (typing) - how MUI does typing for tables
+// seems a bit wonky to me. I think you can override the component
+//  in the parent and this alters what type the component prop
+//  takes in children.
+export const getTableComponents = (
+    enableDivRendering?: boolean
+): {
+    theaderComponent: any;
+    tbodyComponent: any;
+    tdComponent: any;
+    trComponent: any;
+} => {
+    if (!enableDivRendering) {
+        return {
+            theaderComponent: TableHead,
+            tbodyComponent: TableBody,
+            tdComponent: TableCell,
+            trComponent: TableRow,
+        };
+    }
+
+    return {
+        theaderComponent: 'div',
+        tbodyComponent: 'div',
+        tdComponent: 'div',
+        trComponent: 'div',
+    };
+};


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/953
https://github.com/estuary/ui/issues/954

## Changes

### 953

- Updated content

### 954

- Set the `update_only` column based on if we are rediscovering
- Allow passing in settings for `update_only` when discovering

### Misc

- Resetting draft id when discover fails to prevent incorrect test/saves

## Tests

### Manually tested

- 953: viewed edit and create for capture

### Automated tests

- N/A

## Screenshots

Edit content updated
![image](https://github.com/estuary/ui/assets/270078/d71c37ff-b586-4b21-b4fc-a5e03a8534ed)

Create Content not changed
![image](https://github.com/estuary/ui/assets/270078/5faff904-6980-4bf2-9245-d0aadbb012ae)

Clicking the `refresh` button still wants to do a discover so the user can get new items
![image](https://github.com/estuary/ui/assets/270078/7e3eff74-5f12-4c7d-8c54-6d5516427602)

