### PR TITLE
Enable connector type changes in create workflows

### DIFF
--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -99,19 +99,22 @@ function EndpointConfig({
 
     // Storing flag to handle knowing if a config changed
     //  during both create or edit.
-    const endpointSchemaChanged = useMemo(
+    const resetEndpointConfig = useMemo(
         () =>
-            connectorTag?.endpoint_spec_schema &&
-            !isEqual(connectorTag.endpoint_spec_schema, endpointSchema),
-        [connectorTag?.endpoint_spec_schema, endpointSchema]
+            editWorkflow && unsupportedConnectorVersion
+                ? true
+                : connectorTag?.endpoint_spec_schema &&
+                  !isEqual(connectorTag.endpoint_spec_schema, endpointSchema),
+        [
+            connectorTag?.endpoint_spec_schema,
+            editWorkflow,
+            endpointSchema,
+            unsupportedConnectorVersion,
+        ]
     );
 
     useEffect(() => {
-        if (
-            unsupportedConnectorVersion &&
-            connectorTag?.endpoint_spec_schema &&
-            endpointSchemaChanged
-        ) {
+        if (connectorTag?.endpoint_spec_schema && resetEndpointConfig) {
             // force some new data in
             setServerUpdateRequired(true);
             setEncryptedEndpointConfig({
@@ -130,15 +133,13 @@ function EndpointConfig({
         }
     }, [
         connectorTag?.endpoint_spec_schema,
-        endpointSchemaChanged,
+        resetEndpointConfig,
         setEncryptedEndpointConfig,
         setEndpointConfig,
         setEndpointSchema,
         setPreviousEndpointConfig,
         setServerUpdateRequired,
-        unsupportedConnectorVersion,
     ]);
-
     // Controlling if we need to show the generate button again
     const endpointConfigUpdated = useMemo(() => {
         return canBeEmpty

--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -101,6 +101,9 @@ function EndpointConfig({
     //  during both create or edit.
     const resetEndpointConfig = useMemo(
         () =>
+            // TODO (connectors) We need to break this single flag into at least two
+            //  1 - if we want to reset data (only should happen on create when connector changes)
+            //  2 - if we need to update the schema (can happen on create and in edit)
             editWorkflow && !unsupportedConnectorVersion
                 ? false
                 : connectorTag?.endpoint_spec_schema &&

--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -101,8 +101,8 @@ function EndpointConfig({
     //  during both create or edit.
     const resetEndpointConfig = useMemo(
         () =>
-            editWorkflow && unsupportedConnectorVersion
-                ? true
+            editWorkflow && !unsupportedConnectorVersion
+                ? false
                 : connectorTag?.endpoint_spec_schema &&
                   !isEqual(connectorTag.endpoint_spec_schema, endpointSchema),
         [


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/958

## Changes

### 958

The following features are included in this PR:

* Enable the connector type to be changed in create workflows.

## Tests

### Manually tested

The connectors used to test this PR locally are as follows: `source-postgres:dev`, `source-hello-world:dev`, `source-hello-world:v2`, `materialize-postgres:dev`, `materialize-postgres:v2`.

The connectors used to test this PR against production are as follows: `materialize-snowflake:v1`, `materialize-snowflake:v2`. It should be noted that the only valid Snowflake destination connector versions are `:v1` and `:v2`.

Approaches to testing are as follows:

* Capture Tests:

    * (L) Enter the capture create workflow, select a source connector which has multiple supported versions, complete the form, publish the capture, and observe that the capture uses the latest version of the source connector.

    * (L) Enter the capture create workflow, select a source connector which has multiple supported versions, change the selected connector in the _Details_ section of the form, and observe that the drafted specification uses the latest version of whichever connector is selected and the endpoint configuration form changed accordingly.
    
     * (P) Enter the capture create workflow, select a source connector, change the selected connector in the _Details_ section of the form, and observe that the endpoint configuration form changed accordingly.

    * (L) Enter the capture create workflow, select a source connector which has multiple supported versions, toggle the selected connector in the _Details_ section of the form (i.e., select a different connector then return to the initial connector selected), and observe that the drafted specification uses the latest version of whichever connector is selected and the endpoint configuration form changed accordingly.
    
    * (P) Enter the capture create workflow, select a source connector, toggle the selected connector in the _Details_ section of the form (i.e., select a different connector then return to the initial connector selected), and observe that the endpoint configuration form changed accordingly.

    * (L) Enter the edit workflow of a capture that uses an older version of a source connector, edit the resource configuration of an existing binding, observe that a LogRocket event was fired including the existing and evaluated connector tag IDs, edit the endpoint configuration, publish the altered specification, and observe that the version of the source connector was preserved.

* Materialization Tests:

    * (L) Enter the materialization create workflow, select a destination connector which has multiple supported versions, complete the form, publish the materialization, and observe that the materialization uses the latest version of the destination connector.

     * (P) Enter the materialization create workflow, select a destination connector, change the selected connector in the _Details_ section of the form, and observe that the drafted specification uses the latest version of whichever connector is selected and the endpoint configuration form changed accordingly.

    * (P) Enter the materialization create workflow, select a destination connector, toggle the selected connector in the _Details_ section of the form (i.e., select a different connector then return to the initial connector selected), and observe that the drafted specification uses the latest version of whichever connector is selected and the endpoint configuration form changed accordingly.

    * (P) Enter the edit workflow of a materialization that uses an older version of a destination connector, observe that the drafted specification uses the preserved the endpoint configuration of the existing materialization and the _Test_ and _Save and Publish_ CTAs are present.
    
    * (P) Enter the edit workflow of a materialization that uses the latest version of a destination connector, observe that the drafted specification uses the preserved the endpoint configuration of the existing materialization and the _Test_ and _Save and Publish_ CTAs are present.

**NOTE:** This PR must satisfy the defect [PR 951](https://github.com/estuary/ui/pull/951) intended to resolve: the endpoint configuration (and schema) were being reset in the edit workflow when the form was initialized. If a connector version is completely unsupported, this defect **will** still be encountered. This is expected.

### Automated tests

N/A

## Screenshots

N/A
