### PR TITLE
Correct catalog name validation in details form store

### DIFF
--- a/src/components/inputs/PrefixedName/shared.ts
+++ b/src/components/inputs/PrefixedName/shared.ts
@@ -8,7 +8,7 @@ export const validateCatalogName = (
 ): PrefixedName_Errors => {
     const isBlank = !hasLength(value);
 
-    // See iff this field is allowed to be blank
+    // See if this field is allowed to be blank
     if (!allowBlank && isBlank) {
         return ['missing'];
     }

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -1307,6 +1307,7 @@ const PrefixedName: ResolvedIntlConfig['messages'] = {
 const CustomErrors: ResolvedIntlConfig['messages'] = {
     'custom.prefixedName.noAccessGrants': `You do not have the necessary ${CommonMessages['terms.permissions']}. Please contact an administrator.`,
     'custom.prefixedName.prefix.missing': `please select an organization`,
+    'custom.prefixedName.prefix.invalid': `may only include ${CommonMessages['catalogName.limitations']} separated by forward slashes`,
     'custom.prefixedName.name.missing': `please provide a name`,
     'custom.prefixedName.name.unclean': `cannot contain ./ or ../`,
     'custom.prefixedName.name.endingSlash': `cannot end with /`,

--- a/src/stores/DetailsForm/Store.ts
+++ b/src/stores/DetailsForm/Store.ts
@@ -1,6 +1,5 @@
 import { getConnectors_detailsForm } from 'api/connectors';
 import { getLiveSpecs_detailsForm } from 'api/liveSpecsExt';
-import { validateCatalogName } from 'components/inputs/PrefixedName/shared';
 import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
 import produce from 'immer';
 import { isEmpty, isEqual } from 'lodash';
@@ -19,6 +18,7 @@ import {
     getStoreWithHydrationSettings,
 } from 'stores/extensions/Hydration';
 import { DetailsFormStoreNames } from 'stores/names';
+import { PREFIX_NAME_PATTERN } from 'utils/misc-utils';
 import { devtoolsOptions } from 'utils/store-utils';
 import {
     ConnectorVersionEvaluationOptions,
@@ -115,12 +115,18 @@ export const getInitialState = (
                 // Run validation on the name. This is done inside the input but
                 //  having the input set custom errors causes issues as we basically
                 //  make two near identical calls to the store and that causes problems.
-                const nameValidation = validateCatalogName(
-                    state.details.data.entityName
+                const NAME_RE = new RegExp(
+                    `^(${PREFIX_NAME_PATTERN}/)+${PREFIX_NAME_PATTERN}$`
                 );
 
+                const nameValidation = NAME_RE.test(
+                    state.details.data.entityName
+                )
+                    ? null
+                    : ['invalid'];
+
                 // We only have custom errors to handle name validation so it is okay
-                //  to totally clear out customErrors and not inteligently update it
+                //  to totally clear out customErrors and not intelligently update it
                 // As of Q3 2023
                 // TODO (intl) need to get a way for this kind of error to be translated
                 //  and passed into the store

--- a/src/stores/DetailsForm/Store.ts
+++ b/src/stores/DetailsForm/Store.ts
@@ -18,7 +18,7 @@ import {
     getStoreWithHydrationSettings,
 } from 'stores/extensions/Hydration';
 import { DetailsFormStoreNames } from 'stores/names';
-import { PREFIX_NAME_PATTERN } from 'utils/misc-utils';
+import { CATALOG_NAME_PATTERN } from 'utils/misc-utils';
 import { devtoolsOptions } from 'utils/store-utils';
 import {
     ConnectorVersionEvaluationOptions,
@@ -115,9 +115,7 @@ export const getInitialState = (
                 // Run validation on the name. This is done inside the input but
                 //  having the input set custom errors causes issues as we basically
                 //  make two near identical calls to the store and that causes problems.
-                const NAME_RE = new RegExp(
-                    `^(${PREFIX_NAME_PATTERN}/)+${PREFIX_NAME_PATTERN}$`
-                );
+                const NAME_RE = new RegExp(CATALOG_NAME_PATTERN);
 
                 const nameValidation = NAME_RE.test(
                     state.details.data.entityName

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -4,6 +4,7 @@ import { createSearchParams } from 'react-router-dom';
 // Based on pattern taken from
 //  https://github.com/estuary/animated-carnival/blob/main/supabase/migrations/03_catalog-types.sql
 export const PREFIX_NAME_PATTERN = `[a-zA-Z0-9-_.]+`;
+export const CATALOG_NAME_PATTERN = `^(${PREFIX_NAME_PATTERN}/)+${PREFIX_NAME_PATTERN}$`;
 
 // Based on the patterns connectors use for date time
 // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/963

## Changes

### 963

The following features are included in this PR:

* Display an error icon to the left of the _Details_ form section header.

* Display a page-level, error identifying the error in the details form section after the user clicks the _Next_ CTA and this error should completely block downstream service calls.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

N/A

## Screenshots

**Capture create | Before clicking the _Next_ CTA with error**

<img width="1024" alt="pr_screenshot-974-details_form_error-capture-pre_next" src="https://github.com/estuary/ui/assets/77648584/3186b17f-9bfa-4bfa-b6d9-4f37ac5571bd">

<br />
<br />

**Capture create | After clicking the _Next_ CTA with error**

<img width="1024" alt="pr_screenshot-974-details_form_error-capture-post_next" src="https://github.com/estuary/ui/assets/77648584/d4c1e303-7b8a-4172-ae95-a13766e3a7c0">

<br />
<br />

**Capture create | Tenant selected**

<img width="1024" alt="pr_screenshot-974-details_form_error-capture-corrected" src="https://github.com/estuary/ui/assets/77648584/833f6f6f-afe9-4693-a8aa-0a6c5f692a54">

<br />
<br />

**Capture create | Drafted specification updated**

<img width="1024" alt="pr_screenshot-974-details_form_error-capture-succeeded" src="https://github.com/estuary/ui/assets/77648584/40759a86-c3f6-44ef-9b9c-de4c0b52d01e">