### PR TITLE
Getting the JSON themes to match

### DIFF
--- a/src/components/tables/cells/logs/MessageCell.tsx
+++ b/src/components/tables/cells/logs/MessageCell.tsx
@@ -30,17 +30,19 @@ function MessageCell({ fields, message }: Props) {
                         // The object preview does not accept themeing so manually setting these on the wrapper
                         //  obviously these are fairly brittle. They prevent some styling to come through (like color for types of data)
                         //  but I think that is okay given
-                        '& > span span:first-child': {
+                        '& > span span:first-of-type': {
                             color: (theme) =>
                                 `${
                                     jsonObjectPreview_key[theme.palette.mode]
                                 } !important`,
-                        },
-                        '& > span span:first-child + span': {
-                            color: (theme) =>
-                                `${
-                                    jsonObjectPreview_value[theme.palette.mode]
-                                } !important`,
+                            [`& + span`]: {
+                                color: (theme) =>
+                                    `${
+                                        jsonObjectPreview_value[
+                                            theme.palette.mode
+                                        ]
+                                    } !important`,
+                            },
                         },
                     }}
                 >

--- a/src/components/tables/cells/logs/MessageCell.tsx
+++ b/src/components/tables/cells/logs/MessageCell.tsx
@@ -1,4 +1,5 @@
 import { TableCell, Typography } from '@mui/material';
+import { jsonObjectPreview_key, jsonObjectPreview_value } from 'context/Theme';
 import { isEmpty } from 'lodash';
 import { ObjectPreview } from 'react-inspector';
 import { BaseTypographySx } from './shared';
@@ -22,7 +23,27 @@ function MessageCell({ fields, message }: Props) {
             </Typography>
 
             {!isEmpty(fields) ? (
-                <Typography component="div" sx={{ ...BaseTypographySx }}>
+                <Typography
+                    component="div"
+                    sx={{
+                        ...BaseTypographySx,
+                        // The object preview does not accept themeing so manually setting these on the wrapper
+                        //  obviously these are fairly brittle. They prevent some styling to come through (like color for types of data)
+                        //  but I think that is okay given
+                        '& > span span:first-child': {
+                            color: (theme) =>
+                                `${
+                                    jsonObjectPreview_key[theme.palette.mode]
+                                } !important`,
+                        },
+                        '& > span span:first-child + span': {
+                            color: (theme) =>
+                                `${
+                                    jsonObjectPreview_value[theme.palette.mode]
+                                } !important`,
+                        },
+                    }}
+                >
                     <ObjectPreview data={fields} />
                 </Typography>
             ) : null}

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -259,6 +259,16 @@ export const jsonViewTheme: {
     dark: `bright`,
 };
 
+// Based on the colors in the theme above
+export const jsonObjectPreview_key = {
+    light: `rgb(26, 25, 26)`,
+    dark: `rgb(255, 255, 255)`,
+};
+export const jsonObjectPreview_value = {
+    light: `rgb(246, 103, 30)`,
+    dark: `rgb(252, 109, 36)`,
+};
+
 // Styles
 
 export const tableAlternateRowsSx: SxProps<Theme> = {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/887

## Changes

### 887

- Set so the preview colors match the inspector colors match a bit better. This will work when the value is a string. If it is a number or something else the colors will not match.

## Tests

### Manually tested

- viewed the logs

### Automated tests

- n/a

## Screenshots

The two JSON views now match
![image](https://github.com/estuary/ui/assets/270078/d0fe706c-b1ab-41ae-8cf1-2cc711c66fd1)

