### PR TITLE
prod: correct deselected disabled styling for outlined toggle button

### DIFF
--- a/src/components/shared/OutlinedToggleButton.tsx
+++ b/src/components/shared/OutlinedToggleButton.tsx
@@ -7,6 +7,8 @@ import {
     useTheme,
 } from '@mui/material';
 import {
+    defaultOutline,
+    disabledButtonText,
     disabledButtonText_primary,
     intensifiedOutline,
     outlinedButtonBackground,
@@ -36,6 +38,19 @@ function OutlinedToggleButton({
 }: Props) {
     const theme = useTheme();
 
+    const defaultDisabledStateSx: SxProps<Theme> = selected
+        ? {
+              backgroundColor:
+                  outlinedButtonBackground_disabled[theme.palette.mode],
+              border: primaryColoredOutline_disabled[theme.palette.mode],
+              color: disabledButtonText_primary[theme.palette.mode],
+          }
+        : {
+              backgroundColor: 'none',
+              border: defaultOutline[theme.palette.mode],
+              color: disabledButtonText[theme.palette.mode],
+          };
+
     let sx: SxProps<Theme> = {
         px: '9px',
         py: '3px',
@@ -49,12 +64,8 @@ function OutlinedToggleButton({
                 border: primaryColoredOutline_hovered[theme.palette.mode],
             },
         },
-        [`&.${toggleButtonClasses.disabled}`]: disabledStateSx ?? {
-            backgroundColor:
-                outlinedButtonBackground_disabled[theme.palette.mode],
-            border: primaryColoredOutline_disabled[theme.palette.mode],
-            color: disabledButtonText_primary[theme.palette.mode],
-        },
+        [`&.${toggleButtonClasses.disabled}`]:
+            disabledStateSx ?? defaultDisabledStateSx,
     };
 
     if (defaultStateSx) {


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/973

## Changes

### 973

The following features are included in this PR:

* Correct the disabled state styling of the `OutlinedToggleButton` when deselected.

## Tests

### Manually tested

Approaches to testing are as follows:

-   Validate the disabled state styling of the backfill buttons when deselected.

-   Validate the disabled state styling of the backfill buttons when selected.

### Automated tests

N/A

## Screenshots

**Disabled primary colored outlined toggle button | Deselected**

<img width="966" alt="pr_screenshot-975-toggle_button_disabled-deselected" src="https://github.com/estuary/ui/assets/77648584/97592409-255d-477f-9532-de983d0cdf23">

<br />
<br />

**Disabled primary colored outlined toggle button | Selected**

<img width="972" alt="pr_screenshot-975-toggle_button_disabled-selected" src="https://github.com/estuary/ui/assets/77648584/349a9276-b4e3-4b09-ba03-98e865e40d38">
