### PR TITLE
[NPM Audit] update use of `ip` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9381,11 +9381,18 @@
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/ip": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-            "dev": true
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dev": true,
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
@@ -9833,6 +9840,12 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+            "dev": true
         },
         "node_modules/jsdom": {
             "version": "24.0.0",
@@ -14429,16 +14442,16 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+            "integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
             "dev": true,
             "dependencies": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 10.0.0",
                 "npm": ">= 3.0.0"
             }
         },
@@ -14551,6 +14564,12 @@
                 "spdx-compare": "^1.0.0",
                 "spdx-ranges": "^2.0.0"
             }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "dev": true
         },
         "node_modules/ssri": {
             "version": "10.0.5",


### PR DESCRIPTION
Need to fix some audit issues

### `npm audit` output:

```sh
# npm audit report

ip  *
Severity: high
NPM IP package vulnerable to Server-Side Request Forgery (SSRF) attacks - https://github.com/advisories/GHSA-78xj-cgh5-2h22
fix available via `npm audit fix`
node_modules/ip
  socks  1.0.0 - 2.7.1
  Depends on vulnerable versions of ip
  node_modules/socks

2 high severity vulnerabilities

To address all issues, run:
  npm audit fix

```