### PR TITLE
Display units in quantity column of billing invoice table

### DIFF
--- a/src/components/tables/BillLineItems/Rows.tsx
+++ b/src/components/tables/BillLineItems/Rows.tsx
@@ -1,6 +1,7 @@
 import { TableCell, TableRow, Typography } from '@mui/material';
 import { InvoiceLineItem } from 'api/billing';
 import MonetaryValue from 'components/tables/cells/MonetaryValue';
+import DataVolume from '../cells/billing/DataVolume';
 
 interface RowProps {
     row: InvoiceLineItem;
@@ -16,9 +17,8 @@ function Row({ row }: RowProps) {
             <TableCell>
                 <Typography>{row.description}</Typography>
             </TableCell>
-            <TableCell>
-                <Typography>{row.count}</Typography>
-            </TableCell>
+
+            <DataVolume volumeInGB={row.count} />
 
             <MonetaryValue amount={row.rate} />
             <MonetaryValue amount={row.subtotal} />


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/906

## Changes

### 906

The following features are included in this PR:

* Use the shared, `DataVolume` billing table cell component to render the quantity column of the billing invoice table.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

N/A

## Screenshots

_pending_

