### PR TITLE
Preparing ops logs for public release

### DIFF
--- a/src/components/collection/DataPreview/ListView.tsx
+++ b/src/components/collection/DataPreview/ListView.tsx
@@ -8,7 +8,8 @@ import {
     jsonViewTheme,
     semiTransparentBackground,
 } from 'context/Theme';
-import { JournalRecord, useJournalData } from 'hooks/journals/useJournalData';
+import { JournalRecord } from 'hooks/journals/types';
+import { useJournalData } from 'hooks/journals/useJournalData';
 import { LiveSpecsQuery_spec } from 'hooks/useLiveSpecs';
 import { JsonPointer } from 'json-ptr';
 import { isEmpty } from 'lodash';

--- a/src/components/tables/Logs/Body.tsx
+++ b/src/components/tables/Logs/Body.tsx
@@ -129,7 +129,7 @@ function LogsTableBody({ outerRef, tableScroller, virtualRows }: Props) {
                                         : DEFAULT_ROW_HEIGHT;
                                 }}
                                 overscanCount={10}
-                                style={{ paddingBottom: 10, paddingTop: 10 }}
+                                style={{ paddingBottom: 11, paddingTop: 11 }}
                                 width={width}
                             >
                                 {renderRow}

--- a/src/components/tables/Logs/Body.tsx
+++ b/src/components/tables/Logs/Body.tsx
@@ -54,7 +54,7 @@ function LogsTableBody({ outerRef, tableScroller, virtualRows }: Props) {
                     _meta: {
                         uuid: UUID_OLDEST_LOG,
                     },
-                    level: 'waiting',
+                    level: 'ui_waiting',
                     message: '',
                     ts: '',
                 },
@@ -63,7 +63,7 @@ function LogsTableBody({ outerRef, tableScroller, virtualRows }: Props) {
                     _meta: {
                         uuid: UUID_NEWEST_LOG,
                     },
-                    level: 'waiting',
+                    level: 'ui_waiting',
                     message: '',
                     ts: '',
                 },
@@ -119,7 +119,7 @@ function LogsTableBody({ outerRef, tableScroller, virtualRows }: Props) {
                                         return 0;
                                     }
 
-                                    if (row.level === 'waiting') {
+                                    if (row.level === 'ui_waiting') {
                                         return WAITING_ROW_HEIGHT;
                                     }
 

--- a/src/components/tables/Logs/Body.tsx
+++ b/src/components/tables/Logs/Body.tsx
@@ -19,6 +19,7 @@ import {
     UUID_NEWEST_LOG,
     UUID_OLDEST_LOG,
     VIRTUAL_TABLE_BODY_PADDING,
+    WAITING_ROW_HEIGHT,
 } from './shared';
 import useLogColumns from './useLogColumns';
 import { LogsTableRow } from './Row';
@@ -116,6 +117,10 @@ function LogsTableBody({ outerRef, tableScroller, virtualRows }: Props) {
                                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                                     if (!row) {
                                         return 0;
+                                    }
+
+                                    if (row.level === 'waiting') {
+                                        return WAITING_ROW_HEIGHT;
                                     }
 
                                     const customHeight =

--- a/src/components/tables/Logs/Body.tsx
+++ b/src/components/tables/Logs/Body.tsx
@@ -119,6 +119,7 @@ function LogsTableBody({ outerRef, tableScroller, virtualRows }: Props) {
                                         return 0;
                                     }
 
+                                    // Due to the intersection observer we need to force a specific height
                                     if (row.level === 'ui_waiting') {
                                         return WAITING_ROW_HEIGHT;
                                     }

--- a/src/components/tables/Logs/Body.tsx
+++ b/src/components/tables/Logs/Body.tsx
@@ -18,6 +18,7 @@ import {
     DEFAULT_ROW_HEIGHT_WITHOUT_FIELDS,
     UUID_NEWEST_LOG,
     UUID_OLDEST_LOG,
+    VIRTUAL_TABLE_BODY_PADDING,
 } from './shared';
 import useLogColumns from './useLogColumns';
 import { LogsTableRow } from './Row';
@@ -129,7 +130,10 @@ function LogsTableBody({ outerRef, tableScroller, virtualRows }: Props) {
                                         : DEFAULT_ROW_HEIGHT;
                                 }}
                                 overscanCount={10}
-                                style={{ paddingBottom: 11, paddingTop: 11 }}
+                                style={{
+                                    paddingBottom: VIRTUAL_TABLE_BODY_PADDING,
+                                    paddingTop: VIRTUAL_TABLE_BODY_PADDING,
+                                }}
                                 width={width}
                             >
                                 {renderRow}

--- a/src/components/tables/Logs/Row.tsx
+++ b/src/components/tables/Logs/Row.tsx
@@ -10,8 +10,8 @@ import WaitingForNewLogsRow from './WaitingForRow/NewLogs';
 
 interface RowProps {
     row: OpsLogFlowDocument;
-    rowExpanded: (height: number) => void;
-    rowOpened: (isOpen: boolean) => void;
+    rowExpanded: (uuid: string, height: number) => void;
+    rowOpened: (uuid: string, isOpen: boolean) => void;
     style: CSSProperties;
     renderOpen?: boolean;
 }
@@ -26,6 +26,7 @@ export function LogsTableRow({
     const theme = useTheme();
     const renderedHeight = style.height;
 
+    const uuid = useRef(row._meta.uuid);
     const previousHeight = useRef(renderedHeight);
     const [open, setOpen] = useState(renderOpen);
     const [heightChanging, setHeightChanging] = useState(false);
@@ -39,7 +40,7 @@ export function LogsTableRow({
         }
 
         previousHeight.current = rowSizeHeight;
-        rowExpanded(rowSizeHeight);
+        rowExpanded(uuid.current, rowSizeHeight);
         setHeightChanging(false);
     }, [rowExpanded, rowSizeHeight]);
 
@@ -48,19 +49,17 @@ export function LogsTableRow({
 
         setHeightChanging(true);
         setOpen(newVal);
-        rowOpened(newVal);
+        rowOpened(uuid.current, newVal);
     };
 
-    const uuid = row._meta.uuid;
     const WaitingComponent =
-        uuid === UUID_NEWEST_LOG
+        uuid.current === UUID_NEWEST_LOG
             ? WaitingForNewLogsRow
-            : uuid === UUID_OLDEST_LOG
+            : uuid.current === UUID_OLDEST_LOG
             ? WaitingForOldLogsRow
             : null;
 
     if (WaitingComponent) {
-        // The fields thing is pretty janky and hacky but it worked and made this much easier
         return <WaitingComponent style={style} sizeRef={sizeRef} />;
     }
 

--- a/src/components/tables/Logs/Row.tsx
+++ b/src/components/tables/Logs/Row.tsx
@@ -24,10 +24,10 @@ export function LogsTableRow({
     style,
 }: RowProps) {
     const theme = useTheme();
-    const renderedHeight = style.height;
 
     const uuid = useRef(row._meta.uuid);
-    const previousHeight = useRef(renderedHeight);
+    const previousHeight = useRef(style.height);
+
     const [open, setOpen] = useState(renderOpen);
     const [heightChanging, setHeightChanging] = useState(false);
 

--- a/src/components/tables/Logs/WaitingForRow/Base.tsx
+++ b/src/components/tables/Logs/WaitingForRow/Base.tsx
@@ -25,8 +25,6 @@ interface Props extends WaitingForRowProps {
 }
 
 function WaitingForRowBase({ disabled, fetchOption, sizeRef, style }: Props) {
-    console.log('WaitingForRowBase disabled = ', disabled);
-
     const theme = useTheme();
 
     const runFetch = useRef(true);
@@ -37,7 +35,7 @@ function WaitingForRowBase({ disabled, fetchOption, sizeRef, style }: Props) {
     const intersection = useIntersection(intersectionRef, {
         root: null,
         rootMargin: '0px',
-        threshold: 0.8,
+        threshold: 0.5,
     });
 
     const messageKey = `ops.logsTable.waitingForLogs.${fetchOption}`;
@@ -80,7 +78,6 @@ function WaitingForRowBase({ disabled, fetchOption, sizeRef, style }: Props) {
     ]);
 
     useEffect(() => {
-        console.log('effect', { fetchingMore, lastFetchFailed, disabled });
         if (
             !fetchingMore &&
             !lastFetchFailed &&

--- a/src/components/tables/Logs/WaitingForRow/Base.tsx
+++ b/src/components/tables/Logs/WaitingForRow/Base.tsx
@@ -39,7 +39,7 @@ function WaitingForRowBase({
     const intersection = useIntersection(intersectionRef, {
         root: null,
         rootMargin: '0px',
-        threshold: 0.8,
+        threshold: 0.7,
     });
 
     const messageKey = `ops.logsTable.waitingForLogs.${fetchOption}`;

--- a/src/components/tables/Logs/WaitingForRow/Base.tsx
+++ b/src/components/tables/Logs/WaitingForRow/Base.tsx
@@ -13,7 +13,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useIntersection } from 'react-use';
 import {
-    useJournalDataLogsStore_fetchingMore,
     useJournalDataLogsStore_fetchMoreLogs,
     useJournalDataLogsStore_lastFetchFailed,
 } from 'stores/JournalData/Logs/hooks';
@@ -42,13 +41,9 @@ function WaitingForRowBase({ disabled, fetchOption, sizeRef, style }: Props) {
 
     const lastFetchFailed = useJournalDataLogsStore_lastFetchFailed();
     const fetchMoreLogs = useJournalDataLogsStore_fetchMoreLogs();
-    const fetchingMore = useJournalDataLogsStore_fetchingMore();
 
     const fetchMore = useCallback(() => {
-        if (lastFetchFailed) {
-            return;
-        }
-        if (!fetchingMore && intersection?.isIntersecting) {
+        if (intersection?.isIntersecting) {
             runFetch.current = false;
 
             // When checking for new ones fall back to give some time
@@ -60,13 +55,7 @@ function WaitingForRowBase({ disabled, fetchOption, sizeRef, style }: Props) {
         } else {
             runFetch.current = true;
         }
-    }, [
-        fetchMoreLogs,
-        fetchOption,
-        fetchingMore,
-        intersection?.isIntersecting,
-        lastFetchFailed,
-    ]);
+    }, [fetchMoreLogs, fetchOption, intersection?.isIntersecting]);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const debouncedFetch = useCallback(debounce(fetchMore, intervalLength), [

--- a/src/components/tables/Logs/WaitingForRow/Base.tsx
+++ b/src/components/tables/Logs/WaitingForRow/Base.tsx
@@ -67,6 +67,7 @@ function WaitingForRowBase({ disabled, fetchOption, sizeRef, style }: Props) {
     ]);
 
     useEffect(() => {
+        console.log('effect', { fetchingMore, lastFetchFailed, disabled });
         if (
             !fetchingMore &&
             !lastFetchFailed &&

--- a/src/components/tables/Logs/WaitingForRow/Base.tsx
+++ b/src/components/tables/Logs/WaitingForRow/Base.tsx
@@ -16,6 +16,7 @@ import {
     useJournalDataLogsStore_fetchMoreLogs,
     useJournalDataLogsStore_lastFetchFailed,
 } from 'stores/JournalData/Logs/hooks';
+import { VIRTUAL_TABLE_BODY_PADDING } from '../shared';
 import { FetchMoreLogsOptions, WaitingForRowProps } from '../types';
 
 interface Props extends WaitingForRowProps {
@@ -38,7 +39,7 @@ function WaitingForRowBase({
     const intersectionRef = useRef<HTMLElement>(null);
     const intersection = useIntersection(intersectionRef, {
         root: null,
-        rootMargin: '0px',
+        rootMargin: `${VIRTUAL_TABLE_BODY_PADDING}px`,
         threshold: 0.7,
     });
 
@@ -109,7 +110,7 @@ function WaitingForRowBase({
                     lastFetchFailed || disabled || intersection?.isIntersecting
                         ? 1
                         : 0,
-                transition: 'all 50ms ease-in-out',
+                transition: 'all 100ms ease-in-out',
             }}
         >
             <Box ref={intersectionRef}>

--- a/src/components/tables/Logs/WaitingForRow/Base.tsx
+++ b/src/components/tables/Logs/WaitingForRow/Base.tsx
@@ -69,6 +69,8 @@ function WaitingForRowBase({
         }
     }, [debouncedFetch, intersection?.isIntersecting]);
 
+    // Keeping all this logic in a stand alone effect/state because we might
+    //  need to expand this beyond just checking some simple booleans
     useEffect(() => {
         setAllowFetch(
             Boolean(

--- a/src/components/tables/Logs/WaitingForRow/NewLogs.tsx
+++ b/src/components/tables/Logs/WaitingForRow/NewLogs.tsx
@@ -1,8 +1,16 @@
+import { DEFAULT_POLLING } from 'context/SWR';
 import { WaitingForRowProps } from '../types';
 import WaitingForRowBase from './Base';
 
 function WaitingForNewLogsRow(props: WaitingForRowProps) {
-    return <WaitingForRowBase {...props} fetchOption="new" disabled={false} />;
+    return (
+        <WaitingForRowBase
+            {...props}
+            fetchOption="new"
+            disabled={false}
+            interval={DEFAULT_POLLING}
+        />
+    );
 }
 
 export default WaitingForNewLogsRow;

--- a/src/components/tables/Logs/shared.ts
+++ b/src/components/tables/Logs/shared.ts
@@ -14,3 +14,5 @@ export const UUID_OLDEST_LOG = 'UI-oldest-log-line';
 export const UUID_NEWEST_LOG = 'UI-newest-log-line';
 
 export const EXPAND_ROW_TRANSITION = 200;
+
+export const VIRTUAL_TABLE_BODY_PADDING = 10;

--- a/src/components/tables/Logs/shared.ts
+++ b/src/components/tables/Logs/shared.ts
@@ -8,6 +8,7 @@ export const maxBytes = Math.round(MEGABYTE / 10);
 //  row should render expanded
 export const DEFAULT_ROW_HEIGHT = 55;
 export const DEFAULT_ROW_HEIGHT_WITHOUT_FIELDS = 35;
+export const WAITING_ROW_HEIGHT = 37; // This is just a bit taller due to the spinner used
 
 export const UUID_START_OF_LOGS = 'UI-start-of-logs';
 export const UUID_OLDEST_LOG = 'UI-oldest-log-line';

--- a/src/components/tables/Logs/types.ts
+++ b/src/components/tables/Logs/types.ts
@@ -1,4 +1,4 @@
-import { LoadDocumentsOffsets } from 'hooks/journals/shared';
+import { LoadDocumentsOffsets } from 'hooks/journals/types';
 import { CSSProperties, RefCallback } from 'react';
 
 export type FetchMoreLogsOptions = 'old' | 'new';

--- a/src/components/tables/Logs/types.ts
+++ b/src/components/tables/Logs/types.ts
@@ -10,3 +10,11 @@ export interface WaitingForRowProps {
 }
 
 export type RefreshLogsFunction = (newOffset?: LoadDocumentsOffsets) => void;
+
+export type LogLevels =
+    | 'error'
+    | 'warn'
+    | 'debug'
+    | 'trace'
+    | 'done'
+    | 'ui_waiting';

--- a/src/components/tables/cells/logs/LevelIcon.tsx
+++ b/src/components/tables/cells/logs/LevelIcon.tsx
@@ -1,4 +1,5 @@
 import { Tooltip, Typography, useTheme } from '@mui/material';
+import { LogLevels } from 'components/tables/Logs/types';
 import {
     CheckCircle,
     Circle,
@@ -9,10 +10,8 @@ import {
 } from 'iconoir-react';
 import { BaseTypographySx } from './shared';
 
-type Levels = 'error' | 'warn' | 'debug' | 'trace' | 'done' | any;
-
 interface Props {
-    level: Levels;
+    level: LogLevels;
 }
 
 // TODO (icons)

--- a/src/components/transformation/create/Schema/SQLDataPreview/Dialog/DataPreview.tsx
+++ b/src/components/transformation/create/Schema/SQLDataPreview/Dialog/DataPreview.tsx
@@ -1,6 +1,6 @@
 import { DataGrid } from '@mui/x-data-grid';
 import { dataGridListStyling } from 'context/Theme';
-import { JournalRecord } from 'hooks/journals/useJournalData';
+import { JournalRecord } from 'hooks/journals/types';
 import { JsonPointer } from 'json-ptr';
 
 const sampleSpec = {

--- a/src/hooks/journals/shared.ts
+++ b/src/hooks/journals/shared.ts
@@ -1,9 +1,189 @@
-import { OpsLogFlowDocument } from 'types';
+/* eslint-disable no-await-in-loop */
+import { parseJournalDocuments } from 'data-plane-gateway';
+import { ProtocolReadResponse } from 'data-plane-gateway/types/gen/broker/protocol/broker';
+import { logRocketConsole } from 'services/shared';
+import { CustomEvents } from 'services/types';
+import { INCREMENT } from 'utils/dataPlane-utils';
+import { journalStatusIsError } from 'utils/misc-utils';
+import {
+    AttemptToReadResponse,
+    JournalByteRange,
+    JournalRecord,
+    LoadDocumentsProps,
+    LoadDocumentsResponse,
+} from './types';
 
-export interface LoadDocumentsOffsets {
-    offset: number;
-    endOffset: number;
+function isJournalRecord(val: any): val is JournalRecord {
+    return val?._meta?.uuid;
 }
 
-export type JournalByteRange = [startingByte: number, endingByte: number];
-export type UseOpsLogsDocs = [JournalByteRange, OpsLogFlowDocument[] | null];
+export async function* streamAsyncIterator<T>(stream: ReadableStream<T>) {
+    // Get a lock on the stream
+    const reader = stream.getReader();
+
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        while (true) {
+            // Read from the stream
+            const { done, value } = await reader.read();
+
+            // Exit if we're done
+            if (done) return;
+
+            // Else yield the chunk
+            yield value;
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+export async function readAllDocuments<T>(stream: ReadableStream<T>) {
+    const accum: T[] = [];
+
+    for await (const item of streamAsyncIterator(stream)) {
+        accum.push(item);
+    }
+
+    return accum;
+}
+
+export async function loadDocuments({
+    journalName,
+    client,
+    documentCount,
+    maxBytes,
+    offsets,
+}: LoadDocumentsProps): Promise<LoadDocumentsResponse> {
+    if (!client || !journalName) {
+        console.warn('Cannot load documents without client and journal');
+        return {
+            documents: [],
+            tooFewDocuments: false,
+            tooManyBytes: false,
+        };
+    }
+
+    const metaInfo = (
+        await client.read({
+            metadataOnly: true,
+            journal: journalName,
+        })
+    ).unwrap();
+
+    const generator = streamAsyncIterator<ProtocolReadResponse>(metaInfo);
+
+    const metadataResponse = (await generator.next()).value;
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!metadataResponse?.writeHead) {
+        throw new Error('Unable to load metadata');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (journalStatusIsError(metadataResponse?.status)) {
+        throw new Error(metadataResponse.status);
+    }
+
+    const head = parseInt(metadataResponse.writeHead, 10);
+    const providedStart = offsets?.offset && offsets.offset > 0;
+
+    const end =
+        offsets?.endOffset && offsets.endOffset > 0 ? offsets.endOffset : head;
+    let start = providedStart ? offsets.offset : end;
+
+    // let docsMetaResponse: any; //ProtocolReadResponse
+    let range: JournalByteRange = [-1, -1];
+    let documents: JournalRecord[] = [];
+    let attempt = 0;
+
+    // TODO (gross)
+    // This is bad and I feel bad. The function uses references to vars up above.
+    //   It was done so we could quickly add the ability to read based only on data size.
+    // Future work is needed to full break this hook up into the stand alone pieces that are needed.
+    //  More than likely we can have a hook for "readingByDoc" and one for "readingByByte" and have those
+    //  share common functions
+    const attemptToRead = async (
+        readStart: number,
+        readEnd: number
+    ): Promise<AttemptToReadResponse> => {
+        const stream = (
+            await client.read({
+                journal: journalName,
+                offset: `${readStart}`,
+                endOffset: `${readEnd}`,
+            })
+        ).unwrap();
+
+        // Read all the documents
+        const allDocs = await readAllDocuments(parseJournalDocuments(stream));
+
+        // TODO: Instead of inefficiently re-reading until we get the desired row count,
+        // we should accumulate documents and shift `head` backwards using `ProtocolReadResponse.offset`
+        return {
+            range: [readStart, readEnd],
+            allDocs: allDocs
+                .filter(isJournalRecord)
+                .filter(
+                    (record) =>
+                        !(record._meta as unknown as { ack: boolean }).ack
+                ),
+        };
+    };
+
+    const getDocumentMinCount = async (
+        minDocCount: number,
+        returnAllDocs?: boolean
+    ) => {
+        while (
+            documents.length < minDocCount &&
+            start > 0 &&
+            head - start <= maxBytes
+        ) {
+            attempt += 1;
+            start = Math.max(0, start - INCREMENT * attempt);
+            const readResponse = await attemptToRead(start, end);
+            range = readResponse.range;
+            documents = returnAllDocs
+                ? readResponse.allDocs
+                : readResponse.allDocs.slice(minDocCount * -1);
+        }
+    };
+
+    if (!documentCount) {
+        // If we have provided a start we do not want to mess with it. Otherwise, we might
+        //  end up fetching data that was already previously fetched.
+        start = providedStart ? start : Math.max(0, start - maxBytes);
+
+        // Make sure we are actually trying to load data. If the start and end are the same
+        //  that usually means we are loading newer documents but there is nothing newer to load
+        if (start !== end) {
+            const readResponse = await attemptToRead(start, end);
+            range = readResponse.range;
+            documents = readResponse.allDocs;
+
+            if (documents.length === 0) {
+                logRocketConsole(
+                    CustomEvents.JOURNAL_DATA_MAX_BYTES_NOT_ENOUGH
+                );
+                // If we didn't get anything go ahead and try to keep reading more data until we get something back
+                await getDocumentMinCount(1, true);
+            }
+        }
+    } else {
+        await getDocumentMinCount(documentCount, false);
+    }
+
+    return {
+        documents,
+        meta: {
+            // We passed the entire meta back but replaced with the simpler
+            //  ranges. Might need to add this back later for smarter parsing.
+            // metadataResponse,
+            // docsMetaResponse,
+            range,
+        },
+        tooFewDocuments: documentCount ? start <= 0 : false,
+        tooManyBytes: head - start >= maxBytes,
+    };
+}

--- a/src/hooks/journals/shared.ts
+++ b/src/hooks/journals/shared.ts
@@ -5,4 +5,10 @@ export interface LoadDocumentsOffsets {
     endOffset: number;
 }
 
-export type UseOpsLogsDocs = OpsLogFlowDocument[] | null;
+export type startingByte = number;
+export type endingByte = number;
+export type UseOpsLogsDocs = [
+    startingByte,
+    endingByte,
+    OpsLogFlowDocument[] | null,
+];

--- a/src/hooks/journals/shared.ts
+++ b/src/hooks/journals/shared.ts
@@ -5,7 +5,5 @@ export interface LoadDocumentsOffsets {
     endOffset: number;
 }
 
-export type StartingByte = number;
-export type EndingByte = number;
-export type Range = [StartingByte, EndingByte];
-export type UseOpsLogsDocs = [Range, OpsLogFlowDocument[] | null];
+export type JournalByteRange = [startingByte: number, endingByte: number];
+export type UseOpsLogsDocs = [JournalByteRange, OpsLogFlowDocument[] | null];

--- a/src/hooks/journals/shared.ts
+++ b/src/hooks/journals/shared.ts
@@ -5,10 +5,7 @@ export interface LoadDocumentsOffsets {
     endOffset: number;
 }
 
-export type startingByte = number;
-export type endingByte = number;
-export type UseOpsLogsDocs = [
-    startingByte,
-    endingByte,
-    OpsLogFlowDocument[] | null,
-];
+export type StartingByte = number;
+export type EndingByte = number;
+export type Range = [StartingByte, EndingByte];
+export type UseOpsLogsDocs = [Range, OpsLogFlowDocument[] | null];

--- a/src/hooks/journals/shared.ts
+++ b/src/hooks/journals/shared.ts
@@ -1,4 +1,3 @@
-import { FetchMoreLogsOptions } from 'components/tables/Logs/types';
 import { OpsLogFlowDocument } from 'types';
 
 export interface LoadDocumentsOffsets {
@@ -6,6 +5,4 @@ export interface LoadDocumentsOffsets {
     endOffset: number;
 }
 
-export type AddingLogTypes = FetchMoreLogsOptions | 'init';
-
-export type UseOpsLogsDocs = [AddingLogTypes, OpsLogFlowDocument[] | null];
+export type UseOpsLogsDocs = OpsLogFlowDocument[] | null;

--- a/src/hooks/journals/shared.ts
+++ b/src/hooks/journals/shared.ts
@@ -1,4 +1,11 @@
+import { FetchMoreLogsOptions } from 'components/tables/Logs/types';
+import { OpsLogFlowDocument } from 'types';
+
 export interface LoadDocumentsOffsets {
     offset: number;
     endOffset: number;
 }
+
+export type AddingLogTypes = FetchMoreLogsOptions | 'init';
+
+export type UseOpsLogsDocs = [AddingLogTypes, OpsLogFlowDocument[] | null];

--- a/src/hooks/journals/types.ts
+++ b/src/hooks/journals/types.ts
@@ -1,0 +1,37 @@
+import { JournalClient } from 'data-plane-gateway';
+import { OpsLogFlowDocument } from 'types';
+
+export type JournalRecord<B extends {} = Record<string, any>> = B & {
+    _meta: {
+        uuid: string;
+    };
+};
+
+export type JournalByteRange = [startingByte: number, endingByte: number];
+export type UseOpsLogsDocs = [JournalByteRange, OpsLogFlowDocument[] | null];
+export interface LoadDocumentsOffsets {
+    offset: number;
+    endOffset: number;
+}
+
+export interface LoadDocumentsProps {
+    offsets?: LoadDocumentsOffsets;
+    journalName?: string;
+    client?: JournalClient;
+    documentCount?: number;
+    maxBytes: number;
+}
+
+export interface LoadDocumentsResponse {
+    documents: any[];
+    tooFewDocuments: boolean;
+    tooManyBytes: boolean;
+    meta?: {
+        range: JournalByteRange;
+    };
+}
+
+export interface AttemptToReadResponse {
+    range: JournalByteRange;
+    allDocs: JournalRecord<Record<string, any>>[];
+}

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -260,6 +260,12 @@ async function loadDocuments({
         await getDocumentMinCount(documentCount, false);
     }
 
+    console.log('docsMetaResponse', docsMetaResponse);
+    console.log('ranges', {
+        end,
+        start,
+    });
+
     return {
         documents,
         meta: {

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -265,6 +265,10 @@ async function loadDocuments({
         meta: {
             metadataResponse,
             docsMetaResponse,
+            ranges: {
+                end,
+                start,
+            },
         },
         adjustedBytes: head - start,
         tooFewDocuments: documentCount ? start <= 0 : false,

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -1,25 +1,17 @@
-/* eslint-disable no-await-in-loop */
 import { Auth } from '@supabase/ui';
 import { singleCallSettings } from 'context/SWR';
-import {
-    JournalClient,
-    JournalSelector,
-    parseJournalDocuments,
-} from 'data-plane-gateway';
+import { JournalClient, JournalSelector } from 'data-plane-gateway';
 import useGatewayAuthToken from 'hooks/useGatewayAuthToken';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useCounter } from 'react-use';
-import { logRocketConsole } from 'services/shared';
-import { CustomEvents } from 'services/types';
 import useSWR from 'swr';
 import {
     dataPlaneFetcher_list,
-    INCREMENT,
     MAX_DOCUMENT_SIZE,
     shouldRefreshToken,
 } from 'utils/dataPlane-utils';
-import { journalStatusIsError } from 'utils/misc-utils';
-import { JournalByteRange, LoadDocumentsOffsets } from './shared';
+import { loadDocuments } from './shared';
+import { LoadDocumentsOffsets } from './types';
 
 const errorRetryCount = 2;
 
@@ -108,193 +100,6 @@ const useJournalsForCollection = (collectionName: string | undefined) => {
         },
     };
 };
-
-async function* streamAsyncIterator<T>(stream: ReadableStream<T>) {
-    // Get a lock on the stream
-    const reader = stream.getReader();
-
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        while (true) {
-            // Read from the stream
-            const { done, value } = await reader.read();
-
-            // Exit if we're done
-            if (done) return;
-
-            // Else yield the chunk
-            yield value;
-        }
-    } finally {
-        reader.releaseLock();
-    }
-}
-
-async function readAllDocuments<T>(stream: ReadableStream<T>) {
-    const accum: T[] = [];
-
-    for await (const item of streamAsyncIterator(stream)) {
-        accum.push(item);
-    }
-
-    return accum;
-}
-
-interface LoadDocumentsProps {
-    offsets?: LoadDocumentsOffsets;
-    journalName?: string;
-    client?: JournalClient;
-    documentCount?: number;
-    maxBytes: number;
-}
-
-interface LoadDocumentsResponse {
-    documents: any[];
-    tooFewDocuments: boolean;
-    tooManyBytes: boolean;
-    meta?: {
-        range: JournalByteRange;
-    };
-}
-
-async function loadDocuments({
-    journalName,
-    client,
-    documentCount,
-    maxBytes,
-    offsets,
-}: LoadDocumentsProps): Promise<LoadDocumentsResponse> {
-    if (!client || !journalName) {
-        console.warn('Cannot load documents without client and journal');
-        return {
-            documents: [],
-            tooFewDocuments: false,
-            tooManyBytes: false,
-        };
-    }
-
-    const metaInfo = (
-        await client.read({
-            metadataOnly: true,
-            journal: journalName,
-        })
-    ).unwrap();
-
-    const generator = streamAsyncIterator(metaInfo);
-
-    const metadataResponse = (await generator.next()).value;
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (!metadataResponse?.writeHead) {
-        throw new Error('Unable to load metadata');
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (journalStatusIsError(metadataResponse?.status)) {
-        throw new Error(metadataResponse.status);
-    }
-
-    const head = parseInt(metadataResponse.writeHead, 10);
-    const providedStart = offsets?.offset && offsets.offset > 0;
-
-    const end =
-        offsets?.endOffset && offsets.endOffset > 0 ? offsets.endOffset : head;
-    let start = providedStart ? offsets.offset : end;
-
-    // let docsMetaResponse: any; //ProtocolReadResponse
-    let documents: JournalRecord[] = [];
-    let attempt = 0;
-
-    // TODO (gross)
-    // This is bad and I feel bad. The function uses references to vars up above.
-    //   It was done so we could quickly add the ability to read based only on data size.
-    // Future work is needed to full break this hook up into the stand alone pieces that are needed.
-    //  More than likely we can have a hook for "readingByDoc" and one for "readingByByte" and have those
-    //  share common functions
-    const attemptToRead = async () => {
-        const stream = (
-            await client.read({
-                journal: journalName,
-                offset: `${start}`,
-                endOffset: `${end}`,
-            })
-        ).unwrap();
-
-        // Read all the documents
-        const allDocs = await readAllDocuments(parseJournalDocuments(stream));
-
-        // TODO: Instead of inefficiently re-reading until we get the desired row count,
-        // we should accumulate documents and shift `head` backwards using `ProtocolReadResponse.offset`
-        return allDocs
-            .filter(isJournalRecord)
-            .filter(
-                (record) => !(record._meta as unknown as { ack: boolean }).ack
-            );
-    };
-
-    const getDocumentMinCount = async (
-        minDocCount: number,
-        returnAllDocs?: boolean
-    ) => {
-        while (
-            documents.length < minDocCount &&
-            start > 0 &&
-            head - start <= maxBytes
-        ) {
-            attempt += 1;
-            start = Math.max(0, start - INCREMENT * attempt);
-            const readDocuments = await attemptToRead();
-            documents = returnAllDocs
-                ? readDocuments
-                : readDocuments.slice(minDocCount * -1);
-        }
-    };
-
-    if (!documentCount) {
-        // If we have provided a start we do not want to mess with it. Otherwise, we might
-        //  end up fetching data that was already previously fetched.
-        start = providedStart ? start : Math.max(0, start - maxBytes);
-
-        // Make sure we are actually trying to load data. If the start and end are the same
-        //  that usually means we are loading newer documents but there is nothing newer to load
-        if (start !== end) {
-            documents = await attemptToRead();
-
-            if (documents.length === 0) {
-                logRocketConsole(
-                    CustomEvents.JOURNAL_DATA_MAX_BYTES_NOT_ENOUGH
-                );
-                // If we didn't get anything go ahead and try to keep reading more data until we get something back
-                await getDocumentMinCount(1, true);
-            }
-        }
-    } else {
-        await getDocumentMinCount(documentCount, false);
-    }
-
-    return {
-        documents,
-        meta: {
-            // We passed the entire meta back but replaced with the simpler
-            //  ranges. Might need to add this back later for smarter parsing.
-            // metadataResponse,
-            // docsMetaResponse,
-            range: [start, end],
-        },
-        tooFewDocuments: documentCount ? start <= 0 : false,
-        tooManyBytes: head - start >= maxBytes,
-    };
-}
-
-export type JournalRecord<B extends {} = Record<string, any>> = B & {
-    _meta: {
-        uuid: string;
-    };
-};
-
-function isJournalRecord(val: any): val is JournalRecord {
-    return val?._meta?.uuid;
-}
 
 interface UseJournalDataSettings {
     // If you want a specific amount we'll keep making calls to get that many docs.

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -321,15 +321,12 @@ const useJournalData = (
 
     const refreshData = useCallback(
         async (offsets?: LoadDocumentsOffsets) => {
-            console.log('refreshData');
             if (
                 !loading &&
                 failures.current < 2 &&
                 journalName &&
                 journalClient
             ) {
-                console.log('refreshData running');
-
                 try {
                     setLoading(true);
                     const docs = await loadDocuments({

--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -270,10 +270,7 @@ async function loadDocuments({
         meta: {
             metadataResponse,
             docsMetaResponse,
-            ranges: {
-                end,
-                start,
-            },
+            ranges: [start, end], // Range
         },
         tooFewDocuments: documentCount ? start <= 0 : false,
         tooManyBytes: head - start >= maxBytes,

--- a/src/hooks/journals/useJournalNameForLogs.ts
+++ b/src/hooks/journals/useJournalNameForLogs.ts
@@ -9,6 +9,7 @@ function useJournalNameForLogs(entityName: string, region: number = 0) {
     const entityType = useEntityType();
 
     return useMemo(() => {
+        console.log('useJournalNameForLogs');
         const collectionName = `ops.${REGIONS[region]}.v1/logs`;
 
         return [

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -3,13 +3,13 @@ import { useJournalData } from 'hooks/journals/useJournalData';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { OpsLogFlowDocument } from 'types';
 import { maxBytes } from 'components/tables/Logs/shared';
-import { LoadDocumentsOffsets } from './shared';
+import { LoadDocumentsOffsets, UseOpsLogsDocs } from './shared';
 
 function useOpsLogs(name: string, collectionName: string) {
     const [nothingInLastFetch, setNothingInLastFetch] = useState(false);
     const [oldestParsed, setOldestParsed] = useState<number>(-1);
     const [newestParsed, setNewestParsed] = useState<number>(-1);
-    const [docs, setDocs] = useState<OpsLogFlowDocument[] | null>(null);
+    const [docs, setDocs] = useState<UseOpsLogsDocs>([-1, -1, null]);
 
     const { data, error, loading, refresh } = useJournalData(
         name,
@@ -34,8 +34,6 @@ function useOpsLogs(name: string, collectionName: string) {
         // We parsed something so now let's check the ranges
         const end = meta?.ranges.end ?? null;
         const start = meta?.ranges.start ?? null;
-
-        console.log('meta stuff', { start, end, meta });
 
         if (
             end === null ||
@@ -67,7 +65,7 @@ function useOpsLogs(name: string, collectionName: string) {
                     ? end
                     : previousNewestParsed
             );
-            setDocs(documents);
+            setDocs([start, end, documents]);
             setNothingInLastFetch(false);
         } else {
             setNothingInLastFetch(true);

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -35,12 +35,15 @@ function useOpsLogs(name: string, collectionName: string) {
         const end = meta?.ranges[1] ?? null;
         const start = meta?.ranges[0] ?? null;
 
-        if (
-            end === null ||
-            start === null ||
-            !documents ||
-            documents.length <= 0
-        ) {
+        // Handles while we are doing the initial loading
+        if (end === null || start === null) {
+            return;
+        }
+
+        // This means there was nothing new to fetch and the fetching was skipped
+        //  Usually because we are fetching newer logs and there is nothing new written
+        if (end === start) {
+            setNothingInLastFetch(true);
             return;
         }
 

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -9,7 +9,7 @@ function useOpsLogs(name: string, collectionName: string) {
     const [nothingInLastFetch, setNothingInLastFetch] = useState(false);
     const [oldestParsed, setOldestParsed] = useState<number>(-1);
     const [newestParsed, setNewestParsed] = useState<number>(-1);
-    const [docs, setDocs] = useState<UseOpsLogsDocs>([-1, -1, null]);
+    const [docs, setDocs] = useState<UseOpsLogsDocs>([[-1, -1], null]);
 
     const { data, error, loading, refresh } = useJournalData(
         name,
@@ -32,8 +32,8 @@ function useOpsLogs(name: string, collectionName: string) {
         const meta = data?.meta;
 
         // We parsed something so now let's check the ranges
-        const end = meta?.ranges.end ?? null;
-        const start = meta?.ranges.start ?? null;
+        const end = meta?.ranges[1] ?? null;
+        const start = meta?.ranges[0] ?? null;
 
         if (
             end === null ||
@@ -65,7 +65,7 @@ function useOpsLogs(name: string, collectionName: string) {
                     ? end
                     : previousNewestParsed
             );
-            setDocs([start, end, documents]);
+            setDocs([[start, end], documents]);
             setNothingInLastFetch(false);
         } else {
             setNothingInLastFetch(true);

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -3,7 +3,7 @@ import { useJournalData } from 'hooks/journals/useJournalData';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { OpsLogFlowDocument } from 'types';
 import { maxBytes } from 'components/tables/Logs/shared';
-import { LoadDocumentsOffsets, UseOpsLogsDocs } from './shared';
+import { LoadDocumentsOffsets, UseOpsLogsDocs } from './types';
 
 function useOpsLogs(name: string, collectionName: string) {
     const [nothingInLastFetch, setNothingInLastFetch] = useState(false);

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -11,8 +11,6 @@ function useOpsLogs(name: string, collectionName: string) {
     const [newestParsed, setNewestParsed] = useState<number>(-1);
     const [docs, setDocs] = useState<OpsLogFlowDocument[] | null>(null);
 
-    // TODO (typing)
-    //  need to handle typing
     const { data, error, loading, refresh } = useJournalData(
         name,
         collectionName,

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -3,15 +3,13 @@ import { useJournalData } from 'hooks/journals/useJournalData';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { OpsLogFlowDocument } from 'types';
 import { maxBytes } from 'components/tables/Logs/shared';
-import { AddingLogTypes, LoadDocumentsOffsets } from './shared';
+import { LoadDocumentsOffsets } from './shared';
 
 function useOpsLogs(name: string, collectionName: string) {
     const [nothingInLastFetch, setNothingInLastFetch] = useState(false);
     const [oldestParsed, setOldestParsed] = useState<number>(-1);
     const [newestParsed, setNewestParsed] = useState<number>(-1);
-    const [docs, setDocs] = useState<
-        [AddingLogTypes, OpsLogFlowDocument[] | null]
-    >(['init', null]);
+    const [docs, setDocs] = useState<OpsLogFlowDocument[] | null>(null);
 
     const [bytes, setBytes] = useState(maxBytes);
 
@@ -47,6 +45,8 @@ function useOpsLogs(name: string, collectionName: string) {
         const end = meta?.ranges.end ?? null;
         const start = meta?.ranges.start ?? null;
 
+        console.log('meta stuff', { start, end, meta });
+
         if (
             end === null ||
             start === null ||
@@ -77,14 +77,7 @@ function useOpsLogs(name: string, collectionName: string) {
                     ? end
                     : previousNewestParsed
             );
-
-            // Now set a flag so we know where to put the logs in the store
-            const addType: AddingLogTypes = initialLoading
-                ? 'init'
-                : loadingOlder
-                ? 'old'
-                : 'new';
-            setDocs([addType, documents]);
+            setDocs(documents);
             setNothingInLastFetch(false);
         } else {
             setNothingInLastFetch(true);

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -32,8 +32,8 @@ function useOpsLogs(name: string, collectionName: string) {
         const meta = data?.meta;
 
         // We parsed something so now let's check the ranges
-        const end = meta?.ranges[1] ?? null;
-        const start = meta?.ranges[0] ?? null;
+        const end = meta?.range[1] ?? null;
+        const start = meta?.range[0] ?? null;
 
         // Handles while we are doing the initial loading
         if (end === null || start === null) {

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -73,7 +73,7 @@ function useOpsLogs(name: string, collectionName: string) {
             );
 
             setNewestParsed((previousNewestParsed) =>
-                initialLoading || end < previousNewestParsed
+                initialLoading || end > previousNewestParsed
                     ? end
                     : previousNewestParsed
             );

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -11,15 +11,13 @@ function useOpsLogs(name: string, collectionName: string) {
     const [newestParsed, setNewestParsed] = useState<number>(-1);
     const [docs, setDocs] = useState<OpsLogFlowDocument[] | null>(null);
 
-    const [bytes, setBytes] = useState(maxBytes);
-
     // TODO (typing)
     //  need to handle typing
     const { data, error, loading, refresh } = useJournalData(
         name,
         collectionName,
         {
-            maxBytes: bytes,
+            maxBytes,
         }
     );
 
@@ -30,12 +28,6 @@ function useOpsLogs(name: string, collectionName: string) {
 
         return null;
     }, [data?.documents, error]);
-
-    useEffect(() => {
-        if (data?.adjustedBytes && data.adjustedBytes > 0) {
-            setBytes(data.adjustedBytes);
-        }
-    }, [bytes, data?.adjustedBytes]);
 
     useEffect(() => {
         // Get the mete data out of the response

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -55,26 +55,32 @@ function useOpsLogs(name: string, collectionName: string) {
         // Since journalData is read kinda async we need to wait to
         //  update documents until we know the meta data changed
         if (parsedEnd !== lastParsed) {
-            // If the parsed is lower than the other
+            // Check if we are still going through the init
             const initialLoading = lastParsed === -1;
+
+            // If we're already loaded once see if these logs are from farther back
             const olderLogs = !initialLoading && parsedEnd < lastParsed;
+
+            // Now set a flag so we know where to put the logs in the store
             const addType: AddingLogTypes = initialLoading
                 ? 'init'
                 : olderLogs
                 ? 'old'
                 : 'new';
 
-            console.log('~olderLogs', { addType, olderLogs });
+            console.log('~ addType =', addType);
+            console.log('~ parsedEnd =', parsedEnd);
+            console.log('~ lastParsed =', lastParsed);
 
             setNothingInLastFetch(false);
-            setDocs([
-                // TODO (typing) - hacky work around
-                addType,
-                documents,
-            ]);
+            setDocs([addType, documents]);
 
             // Keep track of where we last read data from so we can keep stepping backwards through the file
-            setLastParsed(parsedEnd);
+            setLastParsed((previousLastParsed) =>
+                initialLoading || parsedEnd < previousLastParsed
+                    ? parsedEnd
+                    : previousLastParsed
+            );
 
             // If we have hit 0 then we now we hit the start of the data any nothing older is available
             if (parsedEnd === 0) {

--- a/src/hooks/journals/useOpsLogs.ts
+++ b/src/hooks/journals/useOpsLogs.ts
@@ -7,8 +7,8 @@ import { AddingLogTypes, LoadDocumentsOffsets } from './shared';
 
 function useOpsLogs(name: string, collectionName: string) {
     const [nothingInLastFetch, setNothingInLastFetch] = useState(false);
-    const [olderFinished, setOlderFinished] = useState(false);
-    const [lastParsed, setLastParsed] = useState<number>(-1);
+    const [oldestParsed, setOldestParsed] = useState<number>(-1);
+    const [newestParsed, setNewestParsed] = useState<number>(-1);
     const [docs, setDocs] = useState<
         [AddingLogTypes, OpsLogFlowDocument[] | null]
     >(['init', null]);
@@ -43,53 +43,53 @@ function useOpsLogs(name: string, collectionName: string) {
         // Get the mete data out of the response
         const meta = data?.meta;
 
-        // Figure out what the last document offset is
-        const parsedEnd = meta?.docsMetaResponse.offset
-            ? parseInt(meta.docsMetaResponse.offset, 10)
-            : null;
+        // We parsed something so now let's check the ranges
+        const end = meta?.ranges.end ?? null;
+        const start = meta?.ranges.start ?? null;
 
-        if (!parsedEnd || !documents || documents.length <= 0) {
+        if (
+            end === null ||
+            start === null ||
+            !documents ||
+            documents.length <= 0
+        ) {
             return;
         }
 
-        // Since journalData is read kinda async we need to wait to
-        //  update documents until we know the meta data changed
-        if (parsedEnd !== lastParsed) {
-            // Check if we are still going through the init
-            const initialLoading = lastParsed === -1;
+        // Check if we're doing an init, new, or old
+        const initialLoading = oldestParsed === -1 && newestParsed === -1;
+        const loadingOlder = !initialLoading && start < oldestParsed;
+        const loadingNewer = !initialLoading && end > newestParsed;
 
-            // If we're already loaded once see if these logs are from farther back
-            const olderLogs = !initialLoading && parsedEnd < lastParsed;
+        // Since journalData always returns an array for docs we
+        //  only know to update the logs when we have a new
+        //  oldest/newest range returned
+        if (initialLoading || loadingOlder || loadingNewer) {
+            // Keep track of where we last read data from so we can keep stepping backwards through the file
+            setOldestParsed((previousOldestParsed) =>
+                initialLoading || start < previousOldestParsed
+                    ? start
+                    : previousOldestParsed
+            );
+
+            setNewestParsed((previousNewestParsed) =>
+                initialLoading || end < previousNewestParsed
+                    ? end
+                    : previousNewestParsed
+            );
 
             // Now set a flag so we know where to put the logs in the store
             const addType: AddingLogTypes = initialLoading
                 ? 'init'
-                : olderLogs
+                : loadingOlder
                 ? 'old'
                 : 'new';
-
-            console.log('~ addType =', addType);
-            console.log('~ parsedEnd =', parsedEnd);
-            console.log('~ lastParsed =', lastParsed);
-
-            setNothingInLastFetch(false);
             setDocs([addType, documents]);
-
-            // Keep track of where we last read data from so we can keep stepping backwards through the file
-            setLastParsed((previousLastParsed) =>
-                initialLoading || parsedEnd < previousLastParsed
-                    ? parsedEnd
-                    : previousLastParsed
-            );
-
-            // If we have hit 0 then we now we hit the start of the data any nothing older is available
-            if (parsedEnd === 0) {
-                setOlderFinished(true);
-            }
-        } else if (lastParsed > 0) {
+            setNothingInLastFetch(false);
+        } else {
             setNothingInLastFetch(true);
         }
-    }, [data?.meta, documents, lastParsed]);
+    }, [data?.meta, documents, newestParsed, oldestParsed]);
 
     const runRefresh = useCallback(
         (newOffset?: LoadDocumentsOffsets) => {
@@ -103,19 +103,19 @@ function useOpsLogs(name: string, collectionName: string) {
         () => ({
             docs,
             error,
-            lastParsed,
+            newestParsed,
+            oldestParsed,
             loading,
             nothingInLastFetch,
-            olderFinished,
             refresh: runRefresh,
         }),
         [
             docs,
             error,
-            lastParsed,
             loading,
+            newestParsed,
             nothingInLastFetch,
-            olderFinished,
+            oldestParsed,
             runRefresh,
         ]
     );

--- a/src/stores/JournalData/Logs/Hydrator.tsx
+++ b/src/stores/JournalData/Logs/Hydrator.tsx
@@ -49,6 +49,13 @@ export const JournalDataLogsHydrator = ({
         if (loading) {
             return;
         }
+        console.log('keeping updated', {
+            docs,
+            refresh,
+            olderFinished,
+            lastParsed,
+            error,
+        });
         hydrate(docs, refresh, olderFinished, lastParsed, error);
     }, [docs, error, hydrate, lastParsed, loading, olderFinished, refresh]);
 

--- a/src/stores/JournalData/Logs/Hydrator.tsx
+++ b/src/stores/JournalData/Logs/Hydrator.tsx
@@ -6,8 +6,7 @@ import {
     useJournalDataLogsStore_hydrate,
     useJournalDataLogsStore_resetState,
     useJournalDataLogsStore_setActive,
-    useJournalDataLogsStore_setFetchingOlder,
-    useJournalDataLogsStore_setFetchingNewer,
+    useJournalDataLogsStore_setFetchingMore,
 } from './hooks';
 
 interface Props extends BaseComponentProps {
@@ -24,8 +23,7 @@ export const JournalDataLogsHydrator = ({
     const setActive = useJournalDataLogsStore_setActive();
     const hydrate = useJournalDataLogsStore_hydrate();
 
-    const setFetchingOlder = useJournalDataLogsStore_setFetchingOlder();
-    const setFetchingNewer = useJournalDataLogsStore_setFetchingNewer();
+    const setFetchingMore = useJournalDataLogsStore_setFetchingMore();
 
     const {
         docs,
@@ -58,10 +56,9 @@ export const JournalDataLogsHydrator = ({
     //  so that the waiting rows can kick off another poll
     useEffect(() => {
         if (nothingInLastFetch) {
-            setFetchingNewer(false);
-            setFetchingOlder(false);
+            setFetchingMore(false);
         }
-    }, [nothingInLastFetch, setFetchingNewer, setFetchingOlder]);
+    }, [nothingInLastFetch, setFetchingMore]);
 
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;

--- a/src/stores/JournalData/Logs/Hydrator.tsx
+++ b/src/stores/JournalData/Logs/Hydrator.tsx
@@ -6,7 +6,6 @@ import {
     useJournalDataLogsStore_hydrate,
     useJournalDataLogsStore_resetState,
     useJournalDataLogsStore_setActive,
-    useJournalDataLogsStore_setFetchingMore,
 } from './hooks';
 
 interface Props extends BaseComponentProps {
@@ -23,17 +22,8 @@ export const JournalDataLogsHydrator = ({
     const setActive = useJournalDataLogsStore_setActive();
     const hydrate = useJournalDataLogsStore_hydrate();
 
-    const setFetchingMore = useJournalDataLogsStore_setFetchingMore();
-
-    const {
-        docs,
-        error,
-        loading,
-        lastParsed,
-        nothingInLastFetch,
-        olderFinished,
-        refresh,
-    } = useOpsLogs(name, collectionName);
+    const { docs, error, loading, oldestParsed, newestParsed, refresh } =
+        useOpsLogs(name, collectionName);
 
     // More mount/unmount for store
     useEffect(() => {
@@ -49,23 +39,8 @@ export const JournalDataLogsHydrator = ({
         if (loading) {
             return;
         }
-        console.log('keeping updated', {
-            docs,
-            refresh,
-            olderFinished,
-            lastParsed,
-            error,
-        });
-        hydrate(docs, refresh, olderFinished, lastParsed, error);
-    }, [docs, error, hydrate, lastParsed, loading, olderFinished, refresh]);
-
-    // If there was nothing in the last fetch go ahead and reset the fetching flags
-    //  so that the waiting rows can kick off another poll
-    useEffect(() => {
-        if (nothingInLastFetch) {
-            setFetchingMore(false);
-        }
-    }, [nothingInLastFetch, setFetchingMore]);
+        hydrate(docs, refresh, oldestParsed, newestParsed, error);
+    }, [docs, error, hydrate, loading, newestParsed, oldestParsed, refresh]);
 
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;

--- a/src/stores/JournalData/Logs/Hydrator.tsx
+++ b/src/stores/JournalData/Logs/Hydrator.tsx
@@ -22,8 +22,7 @@ export const JournalDataLogsHydrator = ({
     const setActive = useJournalDataLogsStore_setActive();
     const hydrate = useJournalDataLogsStore_hydrate();
 
-    const { docs, error, loading, oldestParsed, newestParsed, refresh } =
-        useOpsLogs(name, collectionName);
+    const { docs, error, loading, refresh } = useOpsLogs(name, collectionName);
 
     // More mount/unmount for store
     useEffect(() => {
@@ -39,8 +38,8 @@ export const JournalDataLogsHydrator = ({
         if (loading) {
             return;
         }
-        hydrate(docs, refresh, oldestParsed, newestParsed, error);
-    }, [docs, error, hydrate, loading, newestParsed, oldestParsed, refresh]);
+        hydrate(docs, refresh, error);
+    }, [docs, error, hydrate, loading, refresh]);
 
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;

--- a/src/stores/JournalData/Logs/Store.ts
+++ b/src/stores/JournalData/Logs/Store.ts
@@ -95,13 +95,13 @@ const getInitialState = (
 
             if (error) {
                 setNetworkFailed(error.message);
-                addNewDocuments([], true, 0);
+                addNewDocuments('init', [], true, 0);
                 return;
             }
         }
 
         setRefresh(refresh);
-        addNewDocuments(docs, olderFinished, lastParsed, error);
+        addNewDocuments(docs[0], docs[1], olderFinished, lastParsed, error);
     },
 
     fetchMoreLogs: (option) => {
@@ -136,7 +136,7 @@ const getInitialState = (
         }
     },
 
-    addNewDocuments: (docs, olderFinished, lastParsed, error) => {
+    addNewDocuments: (typeOfAdd, docs, olderFinished, lastParsed, error) => {
         set(
             produce((state: JournalDataLogsState) => {
                 if (!docs) {
@@ -149,7 +149,12 @@ const getInitialState = (
                     return;
                 }
 
-                if (state.fetchingOlder) {
+                if (lastParsed === state.lastParsed) {
+                    console.log('we already parsed this');
+                    return;
+                }
+
+                if (typeOfAdd === 'old') {
                     if (error) {
                         state.lastFetchFailed = true;
                     } else {
@@ -160,7 +165,7 @@ const getInitialState = (
                         state.fetchingOlder = false;
                         state.lastFetchFailed = false;
                     }
-                } else if (state.fetchingNewer) {
+                } else if (typeOfAdd === 'new') {
                     if (error) {
                         state.lastFetchFailed = true;
                     } else {
@@ -179,7 +184,7 @@ const getInitialState = (
                         state.fetchingNewer = false;
                         state.lastFetchFailed = false;
                     }
-                } else {
+                } else if (docs.length > 0) {
                     // Initial hydration we want to set the array and scroll to near the bottom
                     state.scrollToWhenDone = [
                         Math.round(docs.length * 0.95),

--- a/src/stores/JournalData/Logs/Store.ts
+++ b/src/stores/JournalData/Logs/Store.ts
@@ -141,17 +141,10 @@ const getInitialState = (
             produce((state: JournalDataLogsState) => {
                 const { 0: start, 1: end } = data[0];
                 const docs = data[1];
-
-                console.log('addNewDocuments', {
-                    docs,
-                    start,
-                    end,
-                });
                 // Check if we hit the oldest byte
                 const olderFinished = start === 0;
 
                 if (!docs) {
-                    console.log('no docs');
                     const { hydrated, noData } = getReadyToRenderFlags(
                         docs,
                         olderFinished
@@ -169,17 +162,9 @@ const getInitialState = (
                 const loadingNewer =
                     !initialLoading && state.newestParsed < end;
 
-                console.log('loading...', {
-                    loadingOlder,
-                    loadingNewer,
-                    initialLoading,
-                    start,
-                    end,
-                });
-
                 if (!initialLoading && !loadingOlder && !loadingNewer) {
-                    // If we are not initing if we are here then it means the same range of
-                    //  data is being passed in. Usually means are are polling for newer
+                    // If we are not init-ing and we are here then it means the same range of
+                    //  data is being passed in. Usually this is when we are polling for newer
                     //  logs and nothing is being written to them.
                     state.fetchingMore = false;
                     return;

--- a/src/stores/JournalData/Logs/Store.ts
+++ b/src/stores/JournalData/Logs/Store.ts
@@ -163,6 +163,10 @@ const getInitialState = (
                     !initialLoading && state.newestParsed < end;
 
                 if (!initialLoading && !loadingOlder && !loadingNewer) {
+                    if (error) {
+                        state.lastFetchFailed = true;
+                    }
+
                     // If we are not init-ing and we are here then it means the same range of
                     //  data is being passed in. Usually this is when we are polling for newer
                     //  logs and nothing is being written to them.

--- a/src/stores/JournalData/Logs/Store.ts
+++ b/src/stores/JournalData/Logs/Store.ts
@@ -41,8 +41,7 @@ const getInitialStateData = (): Pick<
     JournalDataLogsState,
     | 'allowFetchingMore'
     | 'documents'
-    | 'fetchingNewer'
-    | 'fetchingOlder'
+    | 'fetchingMore'
     | 'lastCount'
     | 'lastFetchFailed'
     | 'lastParsed'
@@ -55,8 +54,7 @@ const getInitialStateData = (): Pick<
 > => ({
     allowFetchingMore: false,
     documents: null,
-    fetchingNewer: false,
-    fetchingOlder: false,
+    fetchingMore: false,
     lastCount: -1,
     lastFetchFailed: false,
     lastParsed: -1,
@@ -107,31 +105,25 @@ const getInitialState = (
     fetchMoreLogs: (option) => {
         const {
             allowFetchingMore,
-            fetchingNewer,
-            fetchingOlder,
+            fetchingMore,
             lastParsed,
             olderFinished,
             refresh,
-            setFetchingOlder,
-            setFetchingNewer,
+            setFetchingMore,
         } = get();
 
-        if (!allowFetchingMore || !refresh || fetchingNewer || fetchingOlder) {
+        if (!allowFetchingMore || !refresh || fetchingMore) {
             return;
         }
 
-        if (option === 'old') {
-            if (olderFinished) {
-                return;
-            }
-
-            setFetchingOlder(true);
+        if (option === 'old' && !olderFinished) {
+            setFetchingMore(true);
             refresh({
                 offset: 0,
                 endOffset: lastParsed,
             });
         } else {
-            setFetchingNewer(true);
+            setFetchingMore(true);
             refresh();
         }
     },
@@ -162,7 +154,6 @@ const getInitialState = (
                         //  and then add the new to the start of the list
                         state.scrollToWhenDone = [docs.length + 1, 'start'];
                         state.documents = [...docs, ...(state.documents ?? [])];
-                        state.fetchingOlder = false;
                         state.lastFetchFailed = false;
                     }
                 } else if (typeOfAdd === 'new') {
@@ -181,7 +172,6 @@ const getInitialState = (
                                 'start',
                             ];
                         }
-                        state.fetchingNewer = false;
                         state.lastFetchFailed = false;
                     }
                 } else if (docs.length > 0) {
@@ -256,23 +246,13 @@ const getInitialState = (
         );
     },
 
-    setFetchingNewer: (newState) => {
+    setFetchingMore: (newState) => {
         set(
             produce((state: JournalDataLogsState) => {
-                state.fetchingNewer = newState;
+                state.fetchingMore = newState;
             }),
             false,
-            'JournalsData:Logs: Fetching Newer Set'
-        );
-    },
-
-    setFetchingOlder: (newState) => {
-        set(
-            produce((state: JournalDataLogsState) => {
-                state.fetchingOlder = newState;
-            }),
-            false,
-            'JournalsData:Logs: Fetching Older Set'
+            'JournalsData:Logs: Fetching More Set'
         );
     },
 

--- a/src/stores/JournalData/Logs/Store.ts
+++ b/src/stores/JournalData/Logs/Store.ts
@@ -76,7 +76,7 @@ const getInitialState = (
     ...getInitialHydrationData(),
     ...getStoreWithHydrationSettings('JournalsData:Logs', set),
 
-    hydrate: async (docs, refresh, oldestParsed, newestParsed, error) => {
+    hydrate: async (docs, refresh, error) => {
         const {
             active,
             addNewDocuments,
@@ -95,7 +95,7 @@ const getInitialState = (
 
             if (error) {
                 setNetworkFailed(error.message);
-                addNewDocuments([0, 0, []]);
+                addNewDocuments([[0, 0], []]);
                 return;
             }
         }
@@ -139,9 +139,8 @@ const getInitialState = (
     addNewDocuments: (data, error) => {
         set(
             produce((state: JournalDataLogsState) => {
-                const start = data[0];
-                const end = data[1];
-                const docs = data[2];
+                const { 0: start, 1: end } = data[0];
+                const docs = data[1];
 
                 console.log('addNewDocuments', {
                     docs,

--- a/src/stores/JournalData/Logs/Store.ts
+++ b/src/stores/JournalData/Logs/Store.ts
@@ -121,7 +121,7 @@ const getInitialState = (
         if (option === 'old' && !olderFinished) {
             setFetchingMore(true);
             refresh({
-                offset: 0,
+                offset: -1,
                 endOffset: oldestParsed,
             });
         } else {

--- a/src/stores/JournalData/Logs/hooks.ts
+++ b/src/stores/JournalData/Logs/hooks.ts
@@ -79,18 +79,18 @@ export const useJournalDataLogsStore_setAllowFetchingMore = () => {
     >(JournalDataStoreNames.LOGS, (state) => state.setAllowFetchingMore);
 };
 
-export const useJournalDataLogsStore_setFetchingOlder = () => {
+export const useJournalDataLogsStore_fetchingMore = () => {
     return useZustandStore<
         JournalDataLogsState,
-        JournalDataLogsState['setFetchingOlder']
-    >(JournalDataStoreNames.LOGS, (state) => state.setFetchingOlder);
+        JournalDataLogsState['fetchingMore']
+    >(JournalDataStoreNames.LOGS, (state) => state.fetchingMore);
 };
 
-export const useJournalDataLogsStore_setFetchingNewer = () => {
+export const useJournalDataLogsStore_setFetchingMore = () => {
     return useZustandStore<
         JournalDataLogsState,
-        JournalDataLogsState['setFetchingNewer']
-    >(JournalDataStoreNames.LOGS, (state) => state.setFetchingNewer);
+        JournalDataLogsState['setFetchingMore']
+    >(JournalDataStoreNames.LOGS, (state) => state.setFetchingMore);
 };
 
 export const useJournalDataLogsStore_tailNewLogs = () => {
@@ -126,11 +126,4 @@ export const useJournalDataLogsStore_lastFetchFailed = () => {
         JournalDataLogsState,
         JournalDataLogsState['lastFetchFailed']
     >(JournalDataStoreNames.LOGS, (state) => state.lastFetchFailed);
-};
-
-export const useJournalDataLogsStore_fetchingMore = () => {
-    return useZustandStore<JournalDataLogsState, boolean>(
-        JournalDataStoreNames.LOGS,
-        (state) => state.fetchingNewer || state.fetchingOlder
-    );
 };

--- a/src/stores/JournalData/Logs/hooks.ts
+++ b/src/stores/JournalData/Logs/hooks.ts
@@ -86,13 +86,6 @@ export const useJournalDataLogsStore_fetchingMore = () => {
     >(JournalDataStoreNames.LOGS, (state) => state.fetchingMore);
 };
 
-export const useJournalDataLogsStore_setFetchingMore = () => {
-    return useZustandStore<
-        JournalDataLogsState,
-        JournalDataLogsState['setFetchingMore']
-    >(JournalDataStoreNames.LOGS, (state) => state.setFetchingMore);
-};
-
 export const useJournalDataLogsStore_tailNewLogs = () => {
     return useZustandStore<
         JournalDataLogsState,

--- a/src/stores/JournalData/Logs/types.ts
+++ b/src/stores/JournalData/Logs/types.ts
@@ -22,11 +22,8 @@ export interface JournalDataLogsState extends StoreWithHydration {
     lastCount: number;
     setLastCount: (val: JournalDataLogsState['lastCount']) => void;
 
-    fetchingNewer: boolean;
-    setFetchingNewer: (val: JournalDataLogsState['fetchingNewer']) => void;
-
-    fetchingOlder: boolean;
-    setFetchingOlder: (val: JournalDataLogsState['fetchingOlder']) => void;
+    fetchingMore: boolean;
+    setFetchingMore: (val: JournalDataLogsState['fetchingMore']) => void;
 
     olderFinished: boolean;
     setOlderFinished: (val: JournalDataLogsState['olderFinished']) => void;

--- a/src/stores/JournalData/Logs/types.ts
+++ b/src/stores/JournalData/Logs/types.ts
@@ -13,8 +13,8 @@ export interface JournalDataLogsState extends StoreWithHydration {
     addNewDocuments: (
         typeOfAdd: AddingLogTypes,
         val: OpsLogFlowDocument[] | null,
-        olderFinished: boolean,
-        lastParsed: number,
+        oldestParsed: number,
+        newestParsed: number,
         error?: any
     ) => void;
     noData: boolean;
@@ -38,15 +38,16 @@ export interface JournalDataLogsState extends StoreWithHydration {
         val: JournalDataLogsState['allowFetchingMore']
     ) => void;
 
-    lastParsed: number;
+    newestParsed: number;
+    oldestParsed: number;
     lastTopUuid: string | null;
     scrollToWhenDone: [number, Align];
 
     hydrate: (
         documents: UseOpsLogsDocs,
         refresh: (newOffset?: LoadDocumentsOffsets) => void,
-        olderFinished: boolean,
-        lastParsed: number,
+        oldestParsed: number,
+        newestParsed: number,
         error?: any
     ) => void;
     refresh: ((newOffset?: LoadDocumentsOffsets) => void) | null;

--- a/src/stores/JournalData/Logs/types.ts
+++ b/src/stores/JournalData/Logs/types.ts
@@ -1,5 +1,5 @@
 import { FetchMoreLogsFunction } from 'components/tables/Logs/types';
-import { LoadDocumentsOffsets, UseOpsLogsDocs } from 'hooks/journals/shared';
+import { LoadDocumentsOffsets, UseOpsLogsDocs } from 'hooks/journals/types';
 import { Align } from 'react-window';
 import { StoreWithHydration } from 'stores/extensions/Hydration';
 import { OpsLogFlowDocument } from 'types';

--- a/src/stores/JournalData/Logs/types.ts
+++ b/src/stores/JournalData/Logs/types.ts
@@ -1,9 +1,5 @@
 import { FetchMoreLogsFunction } from 'components/tables/Logs/types';
-import {
-    AddingLogTypes,
-    LoadDocumentsOffsets,
-    UseOpsLogsDocs,
-} from 'hooks/journals/shared';
+import { LoadDocumentsOffsets, UseOpsLogsDocs } from 'hooks/journals/shared';
 import { Align } from 'react-window';
 import { StoreWithHydration } from 'stores/extensions/Hydration';
 import { OpsLogFlowDocument } from 'types';
@@ -11,7 +7,6 @@ import { OpsLogFlowDocument } from 'types';
 export interface JournalDataLogsState extends StoreWithHydration {
     documents: OpsLogFlowDocument[] | null;
     addNewDocuments: (
-        typeOfAdd: AddingLogTypes,
         val: OpsLogFlowDocument[] | null,
         oldestParsed: number,
         newestParsed: number,

--- a/src/stores/JournalData/Logs/types.ts
+++ b/src/stores/JournalData/Logs/types.ts
@@ -1,5 +1,9 @@
 import { FetchMoreLogsFunction } from 'components/tables/Logs/types';
-import { LoadDocumentsOffsets } from 'hooks/journals/shared';
+import {
+    AddingLogTypes,
+    LoadDocumentsOffsets,
+    UseOpsLogsDocs,
+} from 'hooks/journals/shared';
 import { Align } from 'react-window';
 import { StoreWithHydration } from 'stores/extensions/Hydration';
 import { OpsLogFlowDocument } from 'types';
@@ -7,6 +11,7 @@ import { OpsLogFlowDocument } from 'types';
 export interface JournalDataLogsState extends StoreWithHydration {
     documents: OpsLogFlowDocument[] | null;
     addNewDocuments: (
+        typeOfAdd: AddingLogTypes,
         val: OpsLogFlowDocument[] | null,
         olderFinished: boolean,
         lastParsed: number,
@@ -41,7 +46,7 @@ export interface JournalDataLogsState extends StoreWithHydration {
     scrollToWhenDone: [number, Align];
 
     hydrate: (
-        documents: OpsLogFlowDocument[] | null,
+        documents: UseOpsLogsDocs,
         refresh: (newOffset?: LoadDocumentsOffsets) => void,
         olderFinished: boolean,
         lastParsed: number,

--- a/src/stores/JournalData/Logs/types.ts
+++ b/src/stores/JournalData/Logs/types.ts
@@ -36,8 +36,6 @@ export interface JournalDataLogsState extends StoreWithHydration {
     hydrate: (
         documents: UseOpsLogsDocs,
         refresh: (newOffset?: LoadDocumentsOffsets) => void,
-        oldestParsed: number,
-        newestParsed: number,
         error?: any
     ) => void;
     refresh: ((newOffset?: LoadDocumentsOffsets) => void) | null;

--- a/src/stores/JournalData/Logs/types.ts
+++ b/src/stores/JournalData/Logs/types.ts
@@ -6,12 +6,7 @@ import { OpsLogFlowDocument } from 'types';
 
 export interface JournalDataLogsState extends StoreWithHydration {
     documents: OpsLogFlowDocument[] | null;
-    addNewDocuments: (
-        val: OpsLogFlowDocument[] | null,
-        oldestParsed: number,
-        newestParsed: number,
-        error?: any
-    ) => void;
+    addNewDocuments: (documents: UseOpsLogsDocs, error?: any) => void;
     noData: boolean;
 
     lastCount: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 import { JsonFormsCore } from '@jsonforms/core';
 import { TableCellProps } from '@mui/material';
 import { PostgrestError } from '@supabase/supabase-js';
+import { LogLevels } from 'components/tables/Logs/types';
 import { ReactNode } from 'react';
 
 export type fake = 'fake';
@@ -392,7 +393,7 @@ export interface DataProcessingAlert {
 export interface OpsLogFlowDocument {
     _meta: Meta;
     ts: string; //time stamp string
-    level: string;
+    level: LogLevels;
     message: string;
     shard?: Shard;
     fields?: Schema;


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/887

## Changes

### 887

- Passed the parsed bytes along with the docs so we know if we need to put the docs at the start or end
- No longer mess with the `offset` if provided so loading newer logs would not sometimes load older logs

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

## Screenshots

_If applicable - please include some screenshots of the new UI_
