### PR TITLE
have job status poller clean itself up

### DIFF
--- a/src/components/capture/useDiscoverStartSubscription.ts
+++ b/src/components/capture/useDiscoverStartSubscription.ts
@@ -12,7 +12,6 @@ import { CustomEvents } from 'services/types';
 import {
     DEFAULT_POLLER_ERROR,
     JOB_STATUS_POLLER_ERROR,
-    jobStatusPoller,
     TABLES,
     DEFAULT_FILTER,
 } from 'services/supabase';
@@ -24,6 +23,7 @@ import {
 import { useFormStateStore_setFormState } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
 import { Entity } from 'types';
+import useJobStatusPoller from 'hooks/useJobStatusPoller';
 
 const trackEvent = (payload: any) => {
     logRocketEvent(CustomEvents.CAPTURE_DISCOVER, {
@@ -39,6 +39,8 @@ function useDiscoverStartSubscription(entityType: Entity) {
     const postGenerateMutate = useMutateDraftSpec();
 
     const supabaseClient = useClient();
+
+    const { jobStatusPoller } = useJobStatusPoller();
 
     const { callFailed } = useEntityWorkflowHelpers();
 
@@ -133,6 +135,7 @@ function useDiscoverStartSubscription(entityType: Entity) {
             callFailed,
             entityType,
             jobFailed,
+            jobStatusPoller,
             postGenerateMutate,
             setDiscoveredDraftId,
             setDraftId,

--- a/src/components/hero/AcceptDemoInvitation.tsx
+++ b/src/components/hero/AcceptDemoInvitation.tsx
@@ -5,8 +5,8 @@ import useDirectiveGuard from 'app/guards/hooks';
 import MessageWithButton from 'components/content/MessageWithButton';
 import Error from 'components/shared/Error';
 import { jobStatusQuery, trackEvent } from 'directives/shared';
+import useJobStatusPoller from 'hooks/useJobStatusPoller';
 import { Dispatch, SetStateAction, useState } from 'react';
-import { jobStatusPoller } from 'services/supabase';
 import { useEntitiesStore_mutate } from 'stores/Entities/hooks';
 
 interface Props {
@@ -29,6 +29,8 @@ function AcceptDemoInvitation({
     const { directive, mutate } = useDirectiveGuard(directiveName, {
         hideAlert: true,
     });
+
+    const { jobStatusPoller } = useJobStatusPoller();
 
     const mutateAuthRoles = useEntitiesStore_mutate();
 

--- a/src/components/shared/Entity/Actions/SchemaEvolution.tsx
+++ b/src/components/shared/Entity/Actions/SchemaEvolution.tsx
@@ -13,6 +13,7 @@ import { buttonSx } from 'components/shared/Entity/Header';
 import { useEntityType } from 'context/EntityContext';
 import { useEntityWorkflow_Editing } from 'context/Workflow';
 import useClient from 'hooks/supabase-swr/hooks/useClient';
+import useJobStatusPoller from 'hooks/useJobStatusPoller';
 import useStoreDiscoveredCaptures from 'hooks/useStoreDiscoveredCaptures';
 import { useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -22,7 +23,6 @@ import {
     JOB_STATUS_COLUMNS,
     JOB_STATUS_POLLER_ERROR,
     TABLES,
-    jobStatusPoller,
 } from 'services/supabase';
 import {
     useFormStateStore_isActive,
@@ -38,6 +38,8 @@ interface Props {
 function SchemaEvolution({ onFailure }: Props) {
     const supabaseClient = useClient();
     const storeDiscoveredCollections = useStoreDiscoveredCaptures();
+
+    const { jobStatusPoller } = useJobStatusPoller();
 
     const entityType = useEntityType();
     const editingEntity = useEntityWorkflow_Editing();

--- a/src/components/shared/Entity/Actions/useSave.ts
+++ b/src/components/shared/Entity/Actions/useSave.ts
@@ -14,15 +14,11 @@ import {
 } from 'components/editor/Store/hooks';
 import useEntityWorkflowHelpers from 'components/shared/Entity/hooks/useEntityWorkflowHelpers';
 import useClient from 'hooks/supabase-swr/hooks/useClient';
+import useJobStatusPoller from 'hooks/useJobStatusPoller';
 import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 import { logRocketEvent } from 'services/shared';
-import {
-    DEFAULT_FILTER,
-    JOB_STATUS_COLUMNS,
-    TABLES,
-    jobStatusPoller,
-} from 'services/supabase';
+import { DEFAULT_FILTER, JOB_STATUS_COLUMNS, TABLES } from 'services/supabase';
 import { CustomEvents } from 'services/types';
 import { useDetailsForm_details_description } from 'stores/DetailsForm/hooks';
 import {
@@ -56,6 +52,8 @@ function useSave(
     const intl = useIntl();
     const supabaseClient = useClient();
     const { closeLogs } = useEntityWorkflowHelpers();
+
+    const { jobStatusPoller } = useJobStatusPoller();
 
     const status = dryRun ? FormStatus.TESTING : FormStatus.SAVING;
 
@@ -163,6 +161,7 @@ function useSave(
             dryRun,
             forceLogsClosed,
             intl,
+            jobStatusPoller,
             logEvent,
             messagePrefix,
             mutateDraftSpecs,

--- a/src/context/Zustand/provider.tsx
+++ b/src/context/Zustand/provider.tsx
@@ -1,6 +1,7 @@
 import { createContext as createReactContext, useContext } from 'react';
 import { StoreName } from 'stores/names';
-import { StoreApi, useStore } from 'zustand';
+import { StoreApi } from 'zustand';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
 import invariableStores from './invariableStores';
 import { ZustandProviderProps } from './types';
 
@@ -26,7 +27,7 @@ export const useZustandStore = <S extends Object, U>(
     const storeOptions = useContext(ZustandContext);
     const store = storeOptions[storeName];
 
-    return useStore<StoreApi<S>, ReturnType<typeof selector>>(
+    return useStoreWithEqualityFn<StoreApi<S>, ReturnType<typeof selector>>(
         store,
         selector,
         equalityFn

--- a/src/context/Zustand/provider.tsx
+++ b/src/context/Zustand/provider.tsx
@@ -1,7 +1,6 @@
 import { createContext as createReactContext, useContext } from 'react';
 import { StoreName } from 'stores/names';
-import { StoreApi } from 'zustand';
-import { useStoreWithEqualityFn } from 'zustand/traditional';
+import { StoreApi, useStore } from 'zustand';
 import invariableStores from './invariableStores';
 import { ZustandProviderProps } from './types';
 
@@ -27,7 +26,7 @@ export const useZustandStore = <S extends Object, U>(
     const storeOptions = useContext(ZustandContext);
     const store = storeOptions[storeName];
 
-    return useStoreWithEqualityFn<StoreApi<S>, ReturnType<typeof selector>>(
+    return useStore<StoreApi<S>, ReturnType<typeof selector>>(
         store,
         selector,
         equalityFn

--- a/src/directives/AcceptGrant.tsx
+++ b/src/directives/AcceptGrant.tsx
@@ -6,9 +6,9 @@ import AlertBox from 'components/shared/AlertBox';
 import { defaultOutline } from 'context/Theme';
 import { jobStatusQuery, trackEvent } from 'directives/shared';
 import { SuccessResponse } from 'hooks/supabase-swr';
+import useJobStatusPoller from 'hooks/useJobStatusPoller';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { jobStatusPoller } from 'services/supabase';
 import { KeyedMutator } from 'swr';
 import { AppliedDirective, JoinedAppliedDirective } from 'types';
 
@@ -27,6 +27,8 @@ function AcceptGrant({
     grantedPrefix,
     grantedCapability,
 }: Props) {
+    const { jobStatusPoller } = useJobStatusPoller();
+
     const [saving, setSaving] = useState(false);
     const [serverError, setServerError] = useState<string | null>(null);
 

--- a/src/directives/BetaOnboard.tsx
+++ b/src/directives/BetaOnboard.tsx
@@ -21,11 +21,11 @@ import {
     useOnboardingStore_surveyResponse,
 } from 'directives/Onboard/Store/hooks';
 import OnboardingSurvey from 'directives/Onboard/Survey';
+import useJobStatusPoller from 'hooks/useJobStatusPoller';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useMount, useUnmount } from 'react-use';
 import { fireGtmEvent } from 'services/gtm';
-import { jobStatusPoller } from 'services/supabase';
 import { hasLength } from 'utils/misc-utils';
 import { jobStatusQuery, trackEvent } from './shared';
 import { DirectiveProps } from './types';
@@ -48,6 +48,8 @@ const submit_onboard = async (
 const BetaOnboard = ({ directive, mutate }: DirectiveProps) => {
     const theme = useTheme();
     const belowMd = useMediaQuery(theme.breakpoints.down('md'));
+
+    const { jobStatusPoller } = useJobStatusPoller();
 
     // Onboarding Store
     const requestedTenant = useOnboardingStore_requestedTenant();

--- a/src/directives/ClickToAccept.tsx
+++ b/src/directives/ClickToAccept.tsx
@@ -10,10 +10,10 @@ import { PostgrestError } from '@supabase/postgrest-js';
 import { submitDirective } from 'api/directives';
 import AlertBox from 'components/shared/AlertBox';
 import ExternalLink from 'components/shared/ExternalLink';
+import useJobStatusPoller from 'hooks/useJobStatusPoller';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useMount } from 'react-use';
-import { jobStatusPoller } from 'services/supabase';
 import { getUrls } from 'utils/env-utils';
 import {
     CLICK_TO_ACCEPT_LATEST_VERSION,
@@ -34,6 +34,8 @@ const submit_clickToAccept = async (directive: any) => {
 };
 
 const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
+    const { jobStatusPoller } = useJobStatusPoller();
+
     const [acknowledgedDocuments, setAcknowledgedDocuments] =
         useState<boolean>(false);
     const [saving, setSaving] = useState(false);

--- a/src/hooks/useJobStatusPoller.ts
+++ b/src/hooks/useJobStatusPoller.ts
@@ -1,0 +1,132 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useUnmount } from 'react-use';
+import { logRocketConsole, retryAfterFailure } from 'services/shared';
+import {
+    DEFAULT_POLLING_INTERVAL,
+    handleFailure,
+    JOB_STATUS_POLLER_ERROR,
+    JOB_STATUS_SUCCESS,
+    PollerTimeout,
+} from 'services/supabase';
+import { hasLength, incrementInterval, timeoutCleanUp } from 'utils/misc-utils';
+
+function useJobStatusPoller() {
+    const interval = useRef(DEFAULT_POLLING_INTERVAL);
+    const [attempts, setAttempts] = useState<number>(0);
+    const [pollerTimeout, setPollerTimeout] =
+        useState<PollerTimeout>(undefined);
+
+    const jobStatusPoller = useCallback(
+        (
+            query: any,
+            success: Function,
+            failure: Function,
+            initWait?: number
+        ) => {
+            const makeApiCall = () => {
+                logRocketConsole('Poller : start ', { pollerTimeout });
+
+                return query.throwOnError().then(
+                    (payload: any) => {
+                        logRocketConsole('Poller : response');
+                        timeoutCleanUp(pollerTimeout);
+
+                        if (payload.error) {
+                            failure(handleFailure(payload.error));
+                        } else {
+                            const response =
+                                (payload &&
+                                    hasLength(payload.data) &&
+                                    payload.data[0]) ??
+                                null;
+                            if (
+                                response?.job_status?.type &&
+                                response.job_status.type !== 'queued'
+                            ) {
+                                logRocketConsole(
+                                    `Poller : response : ${response.job_status.type}`,
+                                    response
+                                );
+
+                                if (
+                                    JOB_STATUS_SUCCESS.includes(
+                                        response.job_status.type
+                                    )
+                                ) {
+                                    success(response);
+                                } else {
+                                    failure(response);
+                                }
+                            } else {
+                                logRocketConsole(
+                                    'Poller : response : trying again'
+                                );
+
+                                interval.current = incrementInterval(
+                                    interval.current
+                                );
+                                setPollerTimeout(
+                                    window.setTimeout(
+                                        makeApiCall,
+                                        interval.current
+                                    )
+                                );
+                            }
+                        }
+                    },
+                    (error: any) => {
+                        logRocketConsole('Poller : error : ', error);
+
+                        if (
+                            attempts === 0 &&
+                            typeof error?.message === 'string' &&
+                            retryAfterFailure(error.message)
+                        ) {
+                            logRocketConsole('Poller : error : trying again');
+                            setAttempts((previous) => {
+                                return (previous += 1);
+                            });
+
+                            // We do not update the interval here like we do up above
+                            //  because we just want this one time to wait a bit longer
+                            setPollerTimeout(
+                                window.setTimeout(
+                                    makeApiCall,
+                                    incrementInterval(interval.current)
+                                )
+                            );
+                        } else {
+                            logRocketConsole(
+                                'Poller : error : returning failure'
+                            );
+                            timeoutCleanUp(pollerTimeout);
+                            failure(handleFailure(JOB_STATUS_POLLER_ERROR));
+                        }
+                    }
+                );
+            };
+
+            logRocketConsole('Poller : init ');
+
+            setPollerTimeout(
+                window.setTimeout(
+                    makeApiCall,
+                    initWait ?? DEFAULT_POLLING_INTERVAL * 2
+                )
+            );
+        },
+        [attempts, pollerTimeout]
+    );
+
+    useUnmount(() => {
+        logRocketConsole('clean up pollerTimeout = ', pollerTimeout);
+        timeoutCleanUp(pollerTimeout);
+    });
+
+    return useMemo(
+        () => ({ attempts, jobStatusPoller }),
+        [attempts, jobStatusPoller]
+    );
+}
+
+export default useJobStatusPoller;

--- a/src/hooks/useJobStatusPoller.ts
+++ b/src/hooks/useJobStatusPoller.ts
@@ -12,7 +12,6 @@ import { hasLength, incrementInterval, timeoutCleanUp } from 'utils/misc-utils';
 
 function useJobStatusPoller() {
     const interval = useRef(DEFAULT_POLLING_INTERVAL);
-    const [attempts, setAttempts] = useState<number>(0);
     const [pollerTimeout, setPollerTimeout] =
         useState<PollerTimeout>(undefined);
 
@@ -23,6 +22,7 @@ function useJobStatusPoller() {
             failure: Function,
             initWait?: number
         ) => {
+            let attempts = 0;
             const makeApiCall = () => {
                 logRocketConsole('Poller : start ', { pollerTimeout });
 
@@ -83,9 +83,7 @@ function useJobStatusPoller() {
                             retryAfterFailure(error.message)
                         ) {
                             logRocketConsole('Poller : error : trying again');
-                            setAttempts((previous) => {
-                                return (previous += 1);
-                            });
+                            attempts += 1;
 
                             // We do not update the interval here like we do up above
                             //  because we just want this one time to wait a bit longer
@@ -115,7 +113,7 @@ function useJobStatusPoller() {
                 )
             );
         },
-        [attempts, pollerTimeout]
+        [pollerTimeout]
     );
 
     useUnmount(() => {
@@ -123,10 +121,7 @@ function useJobStatusPoller() {
         timeoutCleanUp(pollerTimeout);
     });
 
-    return useMemo(
-        () => ({ attempts, jobStatusPoller }),
-        [attempts, jobStatusPoller]
-    );
+    return useMemo(() => ({ jobStatusPoller }), [jobStatusPoller]);
 }
 
 export default useJobStatusPoller;

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -79,7 +79,7 @@ export const base64RemovePadding = (state: string | null) => {
     return state ? state.replace(/[=]{1,2}$/, '') : state;
 };
 
-export const timeoutCleanUp = (pollerTimeout: number | undefined) => {
+export const timeoutCleanUp = (pollerTimeout: number | null | undefined) => {
     if (pollerTimeout) {
         window.clearInterval(pollerTimeout);
     }


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/988

## Changes

### 988

- Move `jobStatusPoller` out of a function and into a hook so it can be cleaned up

## Tests

### Manually tested

- Beta onboard
- Accepting terms
- Discovering capture
- Saving capture create/edit
- Saving materialization create/edit

### Automated tests

-   unit testing covered

## Screenshots

_If applicable - please include some screenshots of the new UI_
