### PR TITLE
Using upperCase to prevent locale issues

### DIFF
--- a/src/services/shared.ts
+++ b/src/services/shared.ts
@@ -29,16 +29,17 @@ export const logRocketConsole = (message: string, ...props: any[]) => {
     }
 };
 
-export const FAILED_TO_FETCH = 'failed to fetch';
-export const RESPONSE_JSON_NOT_FN = 'response.json is not a function';
+export const FAILED_TO_FETCH = 'FAILED TO FETCH';
+export const RESPONSE_JSON_NOT_FN = 'RESPONSE.JSON IS NOT A FUNCTION';
+export const STATEMENT_TIMEOUT = 'STATEMENT TIMEOUT';
 
-export const RETRY_REASONS = [FAILED_TO_FETCH];
+export const RETRY_REASONS = [FAILED_TO_FETCH, STATEMENT_TIMEOUT];
 export const NETWORK_ERRORS = [FAILED_TO_FETCH, RESPONSE_JSON_NOT_FN];
 
 export const checkErrorMessage = (
     checkingFor: string,
     message?: string | null | undefined
-) => (message ? message.toLowerCase().includes(checkingFor) : false);
+) => (message ? message.toUpperCase().includes(checkingFor) : false);
 
 export const retryAfterFailure = (message?: string | null | undefined) =>
     RETRY_REASONS.some((el) => checkErrorMessage(el, message));


### PR DESCRIPTION
Adding retry for statement timeouts

## Issues

https://github.com/estuary/ui/issues/989

## Changes

### 989

-  Added the `statement timeout` error as one to retry

### Misc

-  Starting on converting lowerCase checks to uppserCase

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

## Screenshots

_If applicable - please include some screenshots of the new UI_
