### PR TITLE
Making things a bit safer with details form

### DIFF
--- a/src/components/inputs/PrefixedName/index.tsx
+++ b/src/components/inputs/PrefixedName/index.tsx
@@ -266,7 +266,13 @@ function PrefixedName({
                     handlers.setName(event.target.value);
                 }}
                 startAdornment={
-                    <InputAdornment position="start">
+                    <InputAdornment
+                        //  This makes it so if a user clicks on the tenant name the input gets focus
+                        style={
+                            singleOption ? { pointerEvents: 'none' } : undefined
+                        }
+                        position="start"
+                    >
                         {singleOption ? (
                             prefix
                         ) : (

--- a/src/components/shared/Entity/DetailsForm/Form.tsx
+++ b/src/components/shared/Entity/DetailsForm/Form.tsx
@@ -101,8 +101,13 @@ function DetailsFormForm({ connectorTags, entityType, readOnly }: Props) {
     const versionEvaluationOptions:
         | ConnectorVersionEvaluationOptions
         | undefined = useMemo(() => {
-        const imageTagStartIndex = connectorImagePath.indexOf(':');
+        // This is rare but can happen so being safe.
+        // If you remove the connector id from the create URL
+        if (!connectorImagePath) {
+            return undefined;
+        }
 
+        const imageTagStartIndex = connectorImagePath.indexOf(':');
         return isEdit && hasLength(connectorId) && imageTagStartIndex > 0
             ? {
                   connectorId,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/985

## Changes

### 985

- Since there was an exception on `indexOf` adding some super safe code in hopes this helps

### Misc
- Allowing people to click on the tenant name (with there is no option) to focus on the input

## Tests

### Manually tested

- Just loaded create and edit
- Clicked on the name inputs on create, edit, tenant creation, alerts, etc.

### Automated tests

- None

## Screenshots

N/A
