### PR TITLE
Making detail searchable for connectors

### DIFF
--- a/src/api/connectors.ts
+++ b/src/api/connectors.ts
@@ -11,6 +11,7 @@ import {
     handleSuccess,
     supabaseClient,
     supabaseRetry,
+    CONNECTOR_DETAILS,
 } from 'services/supabase';
 import { SortDirection } from 'types';
 
@@ -26,7 +27,7 @@ const getConnectors = (
 
     queryBuilder = defaultTableFilter<ConnectorWithTagDetailQuery>(
         queryBuilder,
-        [CONNECTOR_NAME],
+        [CONNECTOR_NAME, CONNECTOR_DETAILS],
         searchQuery,
         [
             {

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -5,6 +5,7 @@ import {
     CONNECTOR_TITLE,
     defaultTableFilter,
     distributedTableFilter,
+    escapeReservedCharacters,
     handleFailure,
     handleSuccess,
     QUERY_PARAM_CONNECTOR_TITLE,
@@ -337,7 +338,7 @@ const getLiveSpecsByConnectorId = async (
             queryBuilder = queryBuilder.not(
                 'catalog_name',
                 'ilike',
-                `${prefix}/%`
+                `${escapeReservedCharacters(prefix)}/%`
             );
         });
     }

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -15,6 +15,7 @@ import {
 import { UTCDate } from '@date-fns/utc';
 import {
     defaultTableFilter,
+    escapeReservedCharacters,
     handleFailure,
     handleSuccess,
     SortingProps,
@@ -197,7 +198,10 @@ const getStatsByName = (names: string[], filter?: StatsFilter) => {
 
 const getStatsForBilling = (tenants: string[], startDate: AllowedDates) => {
     const subjectRoleFilters = tenants
-        .map((tenant) => `catalog_name.ilike.${tenant}%`)
+        .map(
+            (tenant) =>
+                `catalog_name.ilike.${escapeReservedCharacters(tenant)}%`
+        )
         .join(',');
 
     const today = new Date();
@@ -268,7 +272,10 @@ const getStatsForBillingHistoryTable = (
     sorting: SortingProps<any>[]
 ): PostgrestFilterBuilder<CatalogStats_Billing> => {
     const subjectRoleFilters = tenants
-        .map((tenant) => `catalog_name.ilike.${tenant}%`)
+        .map(
+            (tenant) =>
+                `catalog_name.ilike.${escapeReservedCharacters(tenant)}%`
+        )
         .join(',');
 
     const today = new Date();

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -27,6 +27,7 @@ const supabaseSettings = {
 
 // Little helper string that fetches the name from open graph
 export const CONNECTOR_NAME = `title->>en-US`;
+export const CONNECTOR_DETAILS = `detail`;
 export const CONNECTOR_RECOMMENDED = `recommended`;
 export const CONNECTOR_TITLE = `title:connector_title->>en-US`;
 export const CONNECTOR_IMAGE = `image:connector_logo_url->>en-US`;

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -131,6 +131,7 @@ function encodeRFC3986URIComponent(str: string) {
     );
 }
 
+// TODO (PostgREST)
 // A query of ilike.*,* will still fail. Not 100% sure why but this does make
 //  things a bit safer.
 export const escapeReservedCharacters = (val: string) => {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1004

## Changes

### 1004

- Added `detail` column to the table filter for connectors

### Misc
- Start working on better escaping even though it is not all done yet

## Tests

### Manually tested

- Ran search on captures, materializations, admin

### Automated tests

- N/A

## Screenshots

Added a fake detail
![image](https://github.com/estuary/ui/assets/270078/52f77686-6e30-4ee2-bc29-53de9d8b1844)

Search works on admin
![image](https://github.com/estuary/ui/assets/270078/aa0b82db-a8b8-446a-a855-3a25ae08e9a3)

Search works on capture
![image](https://github.com/estuary/ui/assets/270078/53aa796d-d782-4598-8e90-80d37c359f8d)

Still filters based on type
![image](https://github.com/estuary/ui/assets/270078/91a921dd-cfa5-4715-9279-eca149b66072)

Tests against prod
![image](https://github.com/estuary/ui/assets/270078/75666ce9-bc3c-4727-a175-6816553070d5)

![image](https://github.com/estuary/ui/assets/270078/8c6a57f0-1cfe-401d-a0ef-905256e9569c)
