### PR TITLE
Logs (test/save & entity details) styling changes

### DIFF
--- a/src/components/logs/Line.tsx
+++ b/src/components/logs/Line.tsx
@@ -30,13 +30,13 @@ function LogLine({ line, lineNumber, disableSelect }: Props) {
         return parsedLine.spans.map(
             (span: any, index: number, array: any[]) => (
                 <LinePart
-                    key={`${span.text}-linePart-${index}`}
+                    key={`logs-linePart-${lineNumber}__${index}`}
                     parsedLine={span}
                     lastPart={index + 1 === array.length}
                 />
             )
         );
-    }, [parsedLine.spans]);
+    }, [lineNumber, parsedLine.spans]);
 
     return (
         <ListItem

--- a/src/components/logs/Line.tsx
+++ b/src/components/logs/Line.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import { ListItem, ListItemAvatar, ListItemText } from '@mui/material';
-import { parse } from 'ansicolor';
+import Ansi from 'ansicolor';
 import { defaultOutline } from 'context/Theme';
 import { useMemo } from 'react';
 import { ViewLogs_Line } from 'types';
@@ -23,9 +23,9 @@ function LogLine({ line, lineNumber, disableBorder, disableSelect }: Props) {
     let parsedLine: any;
 
     if (line instanceof Object) {
-        parsedLine = parse(line.log_line);
+        parsedLine = Ansi.parse(line.log_line);
     } else {
-        parsedLine = parse(line);
+        parsedLine = Ansi.parse(line);
     }
 
     const reneredParsedLine = useMemo(() => {
@@ -47,8 +47,9 @@ function LogLine({ line, lineNumber, disableBorder, disableSelect }: Props) {
                 'borderBottom': disableBorder
                     ? undefined
                     : (theme) => defaultOutline[theme.palette.mode],
-                'userSelect': disableSelect ? 'none' : undefined,
                 'py': 0.5,
+                'whiteSpace': 'normal',
+                'userSelect': disableSelect ? 'none' : undefined,
                 '&:hover': {
                     background: (theme) =>
                         theme.palette.mode === 'dark' ? '#222' : '#eee',
@@ -71,7 +72,8 @@ function LogLine({ line, lineNumber, disableBorder, disableSelect }: Props) {
             <ListItemText
                 disableTypography
                 sx={{
-                    display: 'flex',
+                    display: 'inline-block',
+                    wordWrap: 'break-word',
                     flexWrap: 'wrap',
                 }}
             >

--- a/src/components/logs/Line.tsx
+++ b/src/components/logs/Line.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import { ListItem, ListItemAvatar, ListItemText } from '@mui/material';
-import Ansi from 'ansicolor';
+import Ansi, { AnsiColored } from 'ansicolor';
 import { defaultOutline } from 'context/Theme';
 import { useMemo } from 'react';
 import { ViewLogs_Line } from 'types';
@@ -20,7 +20,7 @@ export const lineNumberColor = '#666';
 // };
 
 function LogLine({ line, lineNumber, disableBorder, disableSelect }: Props) {
-    let parsedLine: any;
+    let parsedLine: AnsiColored;
 
     if (line instanceof Object) {
         parsedLine = Ansi.parse(line.log_line);
@@ -29,15 +29,13 @@ function LogLine({ line, lineNumber, disableBorder, disableSelect }: Props) {
     }
 
     const reneredParsedLine = useMemo(() => {
-        return parsedLine.spans.map(
-            (span: any, index: number, array: any[]) => (
-                <LinePart
-                    key={`logs-linePart-${lineNumber}__${index}`}
-                    parsedLine={span}
-                    lastPart={index + 1 === array.length}
-                />
-            )
-        );
+        return parsedLine.spans.map((span, index, array) => (
+            <LinePart
+                key={`logs-linePart-${lineNumber}__${index}`}
+                parsedLine={span}
+                lastPart={index + 1 === array.length}
+            />
+        ));
     }, [lineNumber, parsedLine.spans]);
 
     return (

--- a/src/components/logs/Line.tsx
+++ b/src/components/logs/Line.tsx
@@ -1,5 +1,7 @@
-import { Box, ListItem, Stack } from '@mui/material';
+/* eslint-disable react/jsx-no-useless-fragment */
+import { ListItem, ListItemAvatar, ListItemText } from '@mui/material';
 import { parse } from 'ansicolor';
+import { useMemo } from 'react';
 import { ViewLogs_Line } from 'types';
 import LinePart from './LinePart';
 
@@ -16,7 +18,7 @@ export const lineNumberColor = '#666';
 // };
 
 function LogLine({ line, lineNumber, disableSelect }: Props) {
-    let parsedLine;
+    let parsedLine: any;
 
     if (line instanceof Object) {
         parsedLine = parse(line.log_line);
@@ -24,8 +26,21 @@ function LogLine({ line, lineNumber, disableSelect }: Props) {
         parsedLine = parse(line);
     }
 
+    const reneredParsedLine = useMemo(() => {
+        return parsedLine.spans.map(
+            (span: any, index: number, array: any[]) => (
+                <LinePart
+                    key={`${span.text}-linePart-${index}`}
+                    parsedLine={span}
+                    lastPart={index + 1 === array.length}
+                />
+            )
+        );
+    }, [parsedLine.spans]);
+
     return (
         <ListItem
+            alignItems="flex-start"
             sx={{
                 'userSelect': disableSelect ? 'none' : undefined,
                 'py': 0,
@@ -35,7 +50,30 @@ function LogLine({ line, lineNumber, disableSelect }: Props) {
                 },
             }}
         >
-            <Stack direction="row" spacing={2}>
+            <ListItemAvatar
+                sx={{
+                    alignItems: 'baseline',
+                    color: lineNumberColor,
+                    userSelect: 'none',
+                    minWidth: 50,
+                    textAlign: 'right',
+                    mr: 1,
+                    mt: 0.5,
+                }}
+            >
+                {lineNumber}
+            </ListItemAvatar>
+            <ListItemText
+                disableTypography
+                sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                }}
+            >
+                {reneredParsedLine}
+            </ListItemText>
+
+            {/*<Stack direction="row" spacing={2}>
                 <Box
                     sx={{
                         color: lineNumberColor,
@@ -57,7 +95,7 @@ function LogLine({ line, lineNumber, disableSelect }: Props) {
                         />
                     ))}
                 </Stack>
-            </Stack>
+            </Stack>*/}
         </ListItem>
     );
 }

--- a/src/components/logs/Line.tsx
+++ b/src/components/logs/Line.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import { ListItem, ListItemAvatar, ListItemText } from '@mui/material';
 import { parse } from 'ansicolor';
+import { defaultOutline } from 'context/Theme';
 import { useMemo } from 'react';
 import { ViewLogs_Line } from 'types';
 import LinePart from './LinePart';
@@ -8,6 +9,7 @@ import LinePart from './LinePart';
 interface Props {
     line: ViewLogs_Line | string;
     lineNumber: number | string | any;
+    disableBorder?: boolean;
     disableSelect?: boolean;
 }
 
@@ -17,7 +19,7 @@ export const lineNumberColor = '#666';
 //     return line.stream.slice(0, line.stream.lastIndexOf(':')) as ParsedStream;
 // };
 
-function LogLine({ line, lineNumber, disableSelect }: Props) {
+function LogLine({ line, lineNumber, disableBorder, disableSelect }: Props) {
     let parsedLine: any;
 
     if (line instanceof Object) {
@@ -42,8 +44,11 @@ function LogLine({ line, lineNumber, disableSelect }: Props) {
         <ListItem
             alignItems="flex-start"
             sx={{
+                'borderBottom': disableBorder
+                    ? undefined
+                    : (theme) => defaultOutline[theme.palette.mode],
                 'userSelect': disableSelect ? 'none' : undefined,
-                'py': 0,
+                'py': 0.5,
                 '&:hover': {
                     background: (theme) =>
                         theme.palette.mode === 'dark' ? '#222' : '#eee',
@@ -72,30 +77,6 @@ function LogLine({ line, lineNumber, disableSelect }: Props) {
             >
                 {reneredParsedLine}
             </ListItemText>
-
-            {/*<Stack direction="row" spacing={2}>
-                <Box
-                    sx={{
-                        color: lineNumberColor,
-                        userSelect: 'none',
-                        minWidth: 50,
-                        textAlign: 'right',
-                        pt: 0.5,
-                    }}
-                >
-                    {lineNumber}
-                </Box>
-
-                <Stack direction="row">
-                    {parsedLine.spans.map((span, index, array) => (
-                        <LinePart
-                            key={`${span.text}-linePart-${index}`}
-                            parsedLine={span}
-                            lastPart={index + 1 === array.length}
-                        />
-                    ))}
-                </Stack>
-            </Stack>*/}
         </ListItem>
     );
 }

--- a/src/components/logs/LinePart.tsx
+++ b/src/components/logs/LinePart.tsx
@@ -14,7 +14,7 @@ function LinePart({ parsedLine, lastPart }: Props) {
 
     return (
         <StyledLogLinePart
-            sx={{ whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}
+            sx={{ wordWrap: 'break-word', wordbreak: 'break-all' }}
         >
             {splitTextLines.map((lineText) => {
                 const formattedLine = unescapeString(

--- a/src/components/logs/LinePart.tsx
+++ b/src/components/logs/LinePart.tsx
@@ -1,6 +1,5 @@
-import { ListItemText, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import { ParsedSpan } from 'ansicolor';
-import { useMemo } from 'react';
 import { unescapeString } from 'utils/misc-utils';
 
 interface Props {
@@ -13,35 +12,17 @@ function LinePart({ parsedLine, lastPart }: Props) {
 
     const splitTextLines = parsedLine.text.split('\\n');
 
-    const linePartRendered = useMemo(() => {
-        return (
-            <>
-                {splitTextLines.map((lineText, index) => {
-                    const formattedLine = unescapeString(
-                        lastPart ? lineText.trimEnd() : lineText
-                    );
-
-                    return (
-                        <ListItemText
-                            key={`${lineText} - linePart - ${index}`}
-                            primary={formattedLine}
-                            disableTypography
-                        />
-                    );
-                })}
-            </>
-        );
-    }, [lastPart, splitTextLines]);
-
     return (
         <StyledLogLinePart
-            sx={{
-                '& .MuiListItemText-root + .MuiListItemText-root': {
-                    pl: 3,
-                },
-            }}
+            sx={{ whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}
         >
-            {linePartRendered}
+            {splitTextLines.map((lineText) => {
+                const formattedLine = unescapeString(
+                    lastPart ? lineText.trimEnd() : lineText
+                );
+
+                return formattedLine;
+            })}
         </StyledLogLinePart>
     );
 }

--- a/src/components/logs/Lines.tsx
+++ b/src/components/logs/Lines.tsx
@@ -32,8 +32,8 @@ function LogLines({ height, spinnerOptions }: Props) {
             variant="outlined"
             ref={scrollElementRef}
             sx={{
-                pt: 1,
-                pb: 2,
+                pt: 0,
+                pb: 1,
                 overflow: 'auto',
                 minHeight: height,
                 maxHeight: height,

--- a/src/components/logs/Lines.tsx
+++ b/src/components/logs/Lines.tsx
@@ -42,8 +42,6 @@ function LogLines({ height, spinnerOptions }: Props) {
             <List
                 dense
                 sx={{
-                    display: 'table',
-                    width: '100%',
                     fontFamily: `'Monaco', monospace`,
                     whiteSpace: 'pre',
                 }}

--- a/src/components/logs/Spinner.tsx
+++ b/src/components/logs/Spinner.tsx
@@ -34,6 +34,7 @@ function Spinner({ severity, runningKey, stoppedKey }: Props) {
 
     return (
         <LogLine
+            disableBorder
             disableSelect
             line={lineContent}
             lineNumber={<SpinnerIcon severity={severity} stopped={stopped} />}

--- a/src/components/tables/cells/logs/FieldsExpandedCell.tsx
+++ b/src/components/tables/cells/logs/FieldsExpandedCell.tsx
@@ -39,7 +39,9 @@ function FieldsExpandedCell({
                     opacity: heightChanging ? 0 : undefined,
                 }}
             >
-                <Typography sx={{ fontFamily: 'Monospace' }}>
+                <Typography
+                    sx={{ fontFamily: 'Monospace', whiteSpace: 'break-spaces' }}
+                >
                     {message}
                 </Typography>
 


### PR DESCRIPTION
## Issues

## Changes

### Save/Test Logs
- Make the text wrap

### Details Logs
- Added in support to keep white space in the expanded view of logs


## Tests

### Manually tested

- Hit the pages

### Automated tests

- n/a

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/4f04ce6d-814a-4c6a-8e39-186a8a180d52)

![image](https://github.com/estuary/ui/assets/270078/681fcd52-407e-4257-8733-63830ff15dd6)

![image](https://github.com/estuary/ui/assets/270078/a1f06b13-48e3-4379-b96e-df8e5da933a4)

