### PR TITLE
Have resource config read the connector tag id from details

### DIFF
--- a/src/api/hydration.ts
+++ b/src/api/hydration.ts
@@ -43,9 +43,10 @@ export const getSchema_Resource = async (connectorTagId: string | null) => {
             supabaseClient
                 .from(TABLES.CONNECTOR_TAGS)
                 .select(`resource_spec_schema`)
-                .eq('id', connectorTagId),
+                .eq('id', connectorTagId)
+                .single(),
         'getSchema_Resource'
-    ).then(handleSuccess<ConnectorTagResourceData[]>, handleFailure);
+    ).then(handleSuccess<ConnectorTagResourceData>, handleFailure);
 
     return resourceSchema;
 };

--- a/src/api/hydration.ts
+++ b/src/api/hydration.ts
@@ -37,13 +37,13 @@ export const getSchema_Endpoint = async (connectorId: string | null) => {
     return endpointSchema;
 };
 
-export const getSchema_Resource = async (connectorId: string | null) => {
+export const getSchema_Resource = async (connectorTagId: string | null) => {
     const resourceSchema = await supabaseRetry(
         () =>
             supabaseClient
                 .from(TABLES.CONNECTOR_TAGS)
-                .select(`connector_id,resource_spec_schema`)
-                .eq('connector_id', connectorId),
+                .select(`resource_spec_schema`)
+                .eq('id', connectorTagId),
         'getSchema_Resource'
     ).then(handleSuccess<ConnectorTagResourceData[]>, handleFailure);
 

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -9,26 +9,18 @@ import { useEntityType } from 'context/EntityContext';
 import { LocalZustandProvider } from 'context/LocalZustand';
 import { alternativeReflexContainerBackground } from 'context/Theme';
 import { useEntityWorkflow } from 'context/Workflow';
-import useGlobalSearchParams, {
-    GlobalSearchParams,
-} from 'hooks/searchParams/useGlobalSearchParams';
-import useConnectorTag from 'hooks/useConnectorTag';
+
 import { DraftSpecQuery } from 'hooks/useDraftSpecs';
 import { useServerUpdateRequiredMonitor } from 'hooks/useServerUpdateRequiredMonitor';
 import { ReactNode, useEffect, useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import {
-    useDetailsForm_connectorImage,
-    useDetailsForm_details_entityName,
-} from 'stores/DetailsForm/hooks';
+import { useDetailsForm_details_entityName } from 'stores/DetailsForm/hooks';
 import { useFormStateStore_messagePrefix } from 'stores/FormState/hooks';
 import {
     useResourceConfig_discoveredCollections,
     useResourceConfig_resetResourceConfigAndCollections,
-    useResourceConfig_setResourceSchema,
 } from 'stores/ResourceConfig/hooks';
 import { EditorStoreNames } from 'stores/names';
-import { Schema } from 'types';
 import Backfill from './Backfill';
 
 interface Props {
@@ -55,14 +47,11 @@ function BindingsMultiEditor({
         []
     );
 
-    const connectorId = useGlobalSearchParams(GlobalSearchParams.CONNECTOR_ID);
-
     const entityType = useEntityType();
     const workflow = useEntityWorkflow();
 
     // Details Form Store
     const catalogName = useDetailsForm_details_entityName();
-    const imageTag = useDetailsForm_connectorImage();
 
     // Form State Store
     const messagePrefix = useFormStateStore_messagePrefix();
@@ -70,28 +59,8 @@ function BindingsMultiEditor({
     // Resource Config Store
     const discoveredCollections = useResourceConfig_discoveredCollections();
 
-    const setResourceSchema = useResourceConfig_setResourceSchema();
-
     const resetResourceConfigAndCollections =
         useResourceConfig_resetResourceConfigAndCollections();
-
-    const { connectorTag } = useConnectorTag(imageTag.id);
-
-    useEffect(() => {
-        if (
-            connectorId !== connectorTag?.connector_id &&
-            connectorTag?.resource_spec_schema
-        ) {
-            setResourceSchema(
-                connectorTag.resource_spec_schema as unknown as Schema
-            );
-        }
-    }, [
-        setResourceSchema,
-        connectorId,
-        connectorTag?.connector_id,
-        connectorTag?.resource_spec_schema,
-    ]);
 
     const removeDiscoveredCollectionOptions = useMemo(() => {
         if (

--- a/src/hooks/billing/useTenantMissingPaymentMethodWarning.tsx
+++ b/src/hooks/billing/useTenantMissingPaymentMethodWarning.tsx
@@ -20,7 +20,7 @@ import { useEntitiesStore_hasSupportRole } from 'stores/Entities/hooks';
 
 const TRIAL_LENGTH = 30;
 
-// TODO (payment method notification) we should eventually more the "component type stuff" out of here
+// TODO (payment method notification) we should eventually move the "component type stuff" out of here
 //      and into a component that this hook can interact with. This should go into the PaymentMethodWarning.tsx file
 
 // TODO (store payment method info) we load the same thing twice for this and billing. Billing should try to pull these first

--- a/src/hooks/useConnectorTag.ts
+++ b/src/hooks/useConnectorTag.ts
@@ -18,14 +18,7 @@ export interface ConnectorTag {
 }
 
 export const CONNECTOR_TAG_QUERY = `
-    connectors(
-        image_name
-    ),
-    id,
-    connector_id,
-    image_tag,
     endpoint_spec_schema, 
-    resource_spec_schema, 
     documentation_url
 `;
 

--- a/src/stores/ResourceConfig/Hydrator.tsx
+++ b/src/stores/ResourceConfig/Hydrator.tsx
@@ -1,10 +1,9 @@
 import { useEntityType } from 'context/EntityContext';
 import { useEntityWorkflow, useEntityWorkflow_Editing } from 'context/Workflow';
 import invariableStores from 'context/Zustand/invariableStores';
-import useGlobalSearchParams, {
-    GlobalSearchParams,
-} from 'hooks/searchParams/useGlobalSearchParams';
+
 import { useEffectOnce, useUpdateEffect } from 'react-use';
+import { useDetailsForm_connectorImage_id } from 'stores/DetailsForm/hooks';
 import { BaseComponentProps } from 'types';
 import { useStore } from 'zustand';
 import {
@@ -16,12 +15,12 @@ import {
 } from './hooks';
 
 export const ResourceConfigHydrator = ({ children }: BaseComponentProps) => {
-    const connectorId = useGlobalSearchParams(GlobalSearchParams.CONNECTOR_ID);
-
     const entityType = useEntityType();
 
     const workflow = useEntityWorkflow();
     const editWorkflow = useEntityWorkflow_Editing();
+
+    const connectorTagId = useDetailsForm_connectorImage_id();
 
     const hydrated = useResourceConfig_hydrated();
     const setHydrated = useResourceConfig_setHydrated();
@@ -38,7 +37,12 @@ export const ResourceConfigHydrator = ({ children }: BaseComponentProps) => {
 
     const hydrateTheState = (rehydrating: boolean) => {
         setActive(true);
-        hydrateState(editWorkflow, entityType, rehydrating).then(
+        hydrateState(
+            editWorkflow,
+            entityType,
+            connectorTagId,
+            rehydrating
+        ).then(
             (response) => {
                 if (
                     response &&
@@ -66,7 +70,7 @@ export const ResourceConfigHydrator = ({ children }: BaseComponentProps) => {
 
     useUpdateEffect(() => {
         hydrateTheState(true);
-    }, [connectorId]);
+    }, [connectorTagId]);
 
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -740,9 +740,13 @@ const getInitialState = (
         );
     },
 
-    hydrateState: async (editWorkflow, entityType, rehydrating) => {
+    hydrateState: async (
+        editWorkflow,
+        entityType,
+        connectorTagId,
+        rehydrating
+    ) => {
         const searchParams = new URLSearchParams(window.location.search);
-        const connectorId = searchParams.get(GlobalSearchParams.CONNECTOR_ID);
         const draftId = searchParams.get(GlobalSearchParams.DRAFT_ID);
         const prefillLiveSpecIds = searchParams.getAll(
             GlobalSearchParams.PREFILL_LIVE_SPEC_ID
@@ -757,8 +761,8 @@ const getInitialState = (
         const { resetState, setHydrationErrorsExist } = get();
         resetState(materializationReydrating);
 
-        if (connectorId) {
-            const { data, error } = await getSchema_Resource(connectorId);
+        if (connectorTagId && connectorTagId.length > 0) {
+            const { data, error } = await getSchema_Resource(connectorTagId);
 
             if (error) {
                 setHydrationErrorsExist(true);

--- a/src/stores/ResourceConfig/Store.ts
+++ b/src/stores/ResourceConfig/Store.ts
@@ -766,11 +766,11 @@ const getInitialState = (
 
             if (error) {
                 setHydrationErrorsExist(true);
-            } else if (data && data.length > 0) {
+            } else if (data?.resource_spec_schema) {
                 const { setResourceSchema } = get();
 
                 setResourceSchema(
-                    data[0].resource_spec_schema as unknown as Schema
+                    data.resource_spec_schema as unknown as Schema
                 );
             }
         }

--- a/src/stores/ResourceConfig/types.ts
+++ b/src/stores/ResourceConfig/types.ts
@@ -83,6 +83,7 @@ export interface ResourceConfigState extends StoreWithHydration {
     hydrateState: (
         editWorkflow: boolean,
         entityType: Entity,
+        connectorTagId: string,
         rehydrating?: boolean
     ) => Promise<LiveSpecsExt_MaterializeCapture | null>;
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1012

## Changes

### 1012

- Update the Resource Schema hydration to fetch based on the `connector_tags` `id` column
- We read this `id` from the Details Form so that we know we're using the same settings that endpoint config is using

## Tests

### Manually tested

- Capture create/edit
- Materialization create/edit

### Automated tests

- n/a

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/1ba9a7bb-d8cd-48ed-9ce1-11efd2a933eb)

![image](https://github.com/estuary/ui/assets/270078/395d560a-4cf1-4fd6-baba-2d1931b837d2)

