### PR TITLE
Get endpoint config to read connector tag id from details

### DIFF
--- a/src/api/hydration.ts
+++ b/src/api/hydration.ts
@@ -24,15 +24,16 @@ type ConnectorTagEndpointData = Pick<
     'connector_id' | 'endpoint_spec_schema'
 >;
 
-export const getSchema_Endpoint = async (connectorId: string | null) => {
+export const getSchema_Endpoint = async (connectorTagId: string | null) => {
     const endpointSchema = await supabaseRetry(
         () =>
             supabaseClient
                 .from(TABLES.CONNECTOR_TAGS)
-                .select(`connector_id,endpoint_spec_schema`)
-                .eq('connector_id', connectorId),
+                .select(`endpoint_spec_schema`)
+                .eq('id', connectorTagId)
+                .single(),
         'getSchema_Endpoint'
-    ).then(handleSuccess<ConnectorTagEndpointData[]>, handleFailure);
+    ).then(handleSuccess<ConnectorTagEndpointData>, handleFailure);
 
     return endpointSchema;
 };

--- a/src/components/shared/Entity/DetailsForm/Form.tsx
+++ b/src/components/shared/Entity/DetailsForm/Form.tsx
@@ -63,8 +63,6 @@ function DetailsFormForm({ connectorTags, entityType, readOnly }: Props) {
     const formData = useDetailsForm_details();
     const { connectorImage: originalConnectorImage } = formData;
 
-    console.log('DetailsFormForm formData', formData);
-
     const connectorImagePath = useDetailsForm_connectorImage_imagePath();
     const connectorIdChanged = useDetailsForm_changed_connectorId();
 

--- a/src/components/shared/Entity/DetailsForm/Form.tsx
+++ b/src/components/shared/Entity/DetailsForm/Form.tsx
@@ -63,6 +63,8 @@ function DetailsFormForm({ connectorTags, entityType, readOnly }: Props) {
     const formData = useDetailsForm_details();
     const { connectorImage: originalConnectorImage } = formData;
 
+    console.log('DetailsFormForm formData', formData);
+
     const connectorImagePath = useDetailsForm_connectorImage_imagePath();
     const connectorIdChanged = useDetailsForm_changed_connectorId();
 
@@ -203,8 +205,6 @@ function DetailsFormForm({ connectorTags, entityType, readOnly }: Props) {
             if (details.data.connectorImage.connectorId === connectorId) {
                 setDetails_connector(details.data.connectorImage);
             } else {
-                // Set the details before navigating to reduce "flicker"
-                setDetails(details);
                 setEntityNameChanged(details.data.entityName);
 
                 navigateToCreate(

--- a/src/forms/renderers/ConnectorSelect/AutoComplete.tsx
+++ b/src/forms/renderers/ConnectorSelect/AutoComplete.tsx
@@ -80,6 +80,8 @@ export const ConnectorAutoComplete = (
         [data, options]
     );
 
+    console.log('ConnectorAutoComplete', { currentOption, inputValue });
+
     return (
         <Autocomplete
             options={options ?? []}

--- a/src/forms/renderers/ConnectorSelect/AutoComplete.tsx
+++ b/src/forms/renderers/ConnectorSelect/AutoComplete.tsx
@@ -80,8 +80,6 @@ export const ConnectorAutoComplete = (
         [data, options]
     );
 
-    console.log('ConnectorAutoComplete', { currentOption, inputValue });
-
     return (
         <Autocomplete
             options={options ?? []}

--- a/src/stores/EndpointConfig/Hydrator.tsx
+++ b/src/stores/EndpointConfig/Hydrator.tsx
@@ -33,7 +33,6 @@ export const EndpointConfigHydrator = ({ children }: BaseComponentProps) => {
             connectorTagId.length > 0 &&
             (entityType === 'capture' || entityType === 'materialization')
         ) {
-            console.log('hydrating');
             setRunHydration(false);
             setActive(true);
             hydrateState(entityType, workflow, connectorTagId).then(

--- a/src/stores/EndpointConfig/Hydrator.tsx
+++ b/src/stores/EndpointConfig/Hydrator.tsx
@@ -1,7 +1,8 @@
 import { useEntityType } from 'context/EntityContext';
 import { useEntityWorkflow } from 'context/Workflow';
-import { useEffectOnce } from 'react-use';
+import { useEffect, useState } from 'react';
 import { logRocketConsole } from 'services/shared';
+import { useDetailsForm_connectorImage_id } from 'stores/DetailsForm/hooks';
 import {
     useEndpointConfig_hydrated,
     useEndpointConfig_hydrateState,
@@ -15,19 +16,27 @@ export const EndpointConfigHydrator = ({ children }: BaseComponentProps) => {
     const entityType = useEntityType();
     const workflow = useEntityWorkflow();
 
+    const [runHydration, setRunHydration] = useState(true);
+
+    const connectorTagId = useDetailsForm_connectorImage_id();
+
     const hydrated = useEndpointConfig_hydrated();
     const setHydrated = useEndpointConfig_setHydrated();
     const setHydrationErrorsExist = useEndpointConfig_setHydrationErrorsExist();
     const hydrateState = useEndpointConfig_hydrateState();
     const setActive = useEndpointConfig_setActive();
 
-    useEffectOnce(() => {
+    useEffect(() => {
         if (
+            runHydration &&
             !hydrated &&
+            connectorTagId.length > 0 &&
             (entityType === 'capture' || entityType === 'materialization')
         ) {
+            console.log('hydrating');
+            setRunHydration(false);
             setActive(true);
-            hydrateState(entityType, workflow).then(
+            hydrateState(entityType, workflow, connectorTagId).then(
                 () => {
                     setHydrated(true);
                 },
@@ -42,7 +51,17 @@ export const EndpointConfigHydrator = ({ children }: BaseComponentProps) => {
                 }
             );
         }
-    });
+    }, [
+        connectorTagId,
+        entityType,
+        hydrateState,
+        hydrated,
+        runHydration,
+        setActive,
+        setHydrated,
+        setHydrationErrorsExist,
+        workflow,
+    ]);
 
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;

--- a/src/stores/EndpointConfig/Store.ts
+++ b/src/stores/EndpointConfig/Store.ts
@@ -192,9 +192,12 @@ const getInitialState = (
         );
     },
 
-    hydrateState: async (entityType, workflow): Promise<void> => {
+    hydrateState: async (
+        entityType,
+        workflow,
+        connectorTagId
+    ): Promise<void> => {
         const searchParams = new URLSearchParams(window.location.search);
-        const connectorId = searchParams.get(GlobalSearchParams.CONNECTOR_ID);
         const liveSpecId = searchParams.get(GlobalSearchParams.LIVE_SPEC_ID);
         const draftId = searchParams.get(GlobalSearchParams.DRAFT_ID);
 
@@ -207,16 +210,16 @@ const getInitialState = (
             get().setServerUpdateRequired(true);
         }
 
-        if (get().active && connectorId) {
-            const { data, error } = await getSchema_Endpoint(connectorId);
+        if (get().active && connectorTagId && connectorTagId.length > 0) {
+            const { data, error } = await getSchema_Endpoint(connectorTagId);
 
             if (error) {
                 get().setHydrationErrorsExist(true);
             }
 
-            if (get().active && data && data.length > 0) {
+            if (get().active && data) {
                 get().setEndpointSchema(
-                    data[0].endpoint_spec_schema as unknown as Schema
+                    data.endpoint_spec_schema as unknown as Schema
                 );
             }
         }

--- a/src/stores/EndpointConfig/types.ts
+++ b/src/stores/EndpointConfig/types.ts
@@ -47,7 +47,8 @@ export interface EndpointConfigState
     // Hydration
     hydrateState: (
         entityType: EntityWithCreateWorkflow,
-        workflow: EntityWorkflow | null
+        workflow: EntityWorkflow | null,
+        connectorTagId: string
     ) => Promise<void>;
 
     // Misc.


### PR DESCRIPTION
## Issues

issue called out in slack

## Changes

### misc

- get endpoint config loading similar to resource config
- there is a mild flash when changing connector the first time - but this happens in prod as well. however, removing the excess details setting to help reduce it.
- temporary until I build a new connectors store to manage this stuff

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

## Screenshots

n/a
