### PR TITLE
PROD: fix resource hydration

### DIFF
--- a/src/stores/ResourceConfig/Hydrator.tsx
+++ b/src/stores/ResourceConfig/Hydrator.tsx
@@ -1,24 +1,21 @@
 import { useEntityType } from 'context/EntityContext';
 import { useEntityWorkflow, useEntityWorkflow_Editing } from 'context/Workflow';
 import invariableStores from 'context/Zustand/invariableStores';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
-import { useUpdateEffect } from 'react-use';
 import { useDetailsForm_connectorImage_id } from 'stores/DetailsForm/hooks';
 import { BaseComponentProps } from 'types';
 import { useStore } from 'zustand';
 import {
     useResourceConfig_hydrateState,
-    useResourceConfig_hydrated,
     useResourceConfig_setActive,
     useResourceConfig_setHydrated,
     useResourceConfig_setHydrationErrorsExist,
 } from './hooks';
 
 export const ResourceConfigHydrator = ({ children }: BaseComponentProps) => {
-    // We want to make sure we only start firing the initial hydrator once
-    //  Then after that we only want to run the "udpater" when the connector tag changes
-    const runUpdates = useRef(false);
+    // We want to manually control this in a REF to not fire extra effect calls
+    const rehydrating = useRef(false);
 
     const entityType = useEntityType();
 
@@ -27,7 +24,6 @@ export const ResourceConfigHydrator = ({ children }: BaseComponentProps) => {
 
     const connectorTagId = useDetailsForm_connectorImage_id();
 
-    const hydrated = useResourceConfig_hydrated();
     const setHydrated = useResourceConfig_setHydrated();
     const setActive = useResourceConfig_setActive();
     const setHydrationErrorsExist = useResourceConfig_setHydrationErrorsExist();
@@ -40,46 +36,46 @@ export const ResourceConfigHydrator = ({ children }: BaseComponentProps) => {
         }
     );
 
-    const hydrateTheState = (rehydrating: boolean) => {
-        setActive(true);
-        hydrateState(editWorkflow, entityType, connectorTagId, rehydrating)
-            .then(
-                (response) => {
-                    if (
-                        response &&
-                        response.length === 1 &&
-                        response[0].spec_type === 'capture' &&
-                        !editWorkflow
-                    ) {
-                        setPrefilledCapture(response[0].catalog_name);
-                    }
-                },
-                () => {
-                    setHydrationErrorsExist(true);
-                }
+    useEffect(() => {
+        if (workflow && connectorTagId.length > 0) {
+            setActive(true);
+            hydrateState(
+                editWorkflow,
+                entityType,
+                connectorTagId,
+                rehydrating.current
             )
-            .finally(() => {
-                runUpdates.current = true;
-                setHydrated(true);
-            });
-    };
-
-    useUpdateEffect(() => {
-        if (
-            !runUpdates.current &&
-            !hydrated &&
-            workflow &&
-            connectorTagId.length > 0
-        ) {
-            hydrateTheState(false);
+                .then(
+                    (response) => {
+                        if (
+                            response &&
+                            response.length === 1 &&
+                            response[0].spec_type === 'capture' &&
+                            !editWorkflow
+                        ) {
+                            setPrefilledCapture(response[0].catalog_name);
+                        }
+                    },
+                    () => {
+                        setHydrationErrorsExist(true);
+                    }
+                )
+                .finally(() => {
+                    rehydrating.current = true;
+                    setHydrated(true);
+                });
         }
-    }, [connectorTagId, hydrated, workflow]);
-
-    useUpdateEffect(() => {
-        if (runUpdates.current) {
-            hydrateTheState(true);
-        }
-    }, [connectorTagId]);
+    }, [
+        connectorTagId,
+        editWorkflow,
+        entityType,
+        hydrateState,
+        setActive,
+        setHydrated,
+        setHydrationErrorsExist,
+        setPrefilledCapture,
+        workflow,
+    ]);
 
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;

--- a/src/stores/ResourceConfig/Hydrator.tsx
+++ b/src/stores/ResourceConfig/Hydrator.tsx
@@ -66,14 +66,14 @@ export const ResourceConfigHydrator = ({ children }: BaseComponentProps) => {
 
     useUpdateEffect(() => {
         if (
-            workflow &&
-            connectorTagId.length > 0 &&
+            !runUpdates.current &&
             !hydrated &&
-            !runUpdates.current
+            workflow &&
+            connectorTagId.length > 0
         ) {
             hydrateTheState(false);
         }
-    }, [connectorTagId.length, hydrated, workflow]);
+    }, [connectorTagId, hydrated, workflow]);
 
     useUpdateEffect(() => {
         if (runUpdates.current) {


### PR DESCRIPTION
There is a possibility that two hydrate calls were made in quick succession and cause issues.

Now we will only run one effect at a time and wait until the first "hydrator" before we start running the "updater" effect.