### PR TITLE
Do not show payment method warning for Google Marketplace users

### DIFF
--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -145,8 +145,9 @@ export const getPaymentMethodsForTenants = async (
 
     tenants.some((tenantDetail) => {
         if (
+            !tenantDetail.trial_start ||
             tenantDetail.payment_provider === 'external' ||
-            !tenantDetail.trial_start
+            tenantDetail.gcm_account_id
         ) {
             promises.push(
                 new Promise((resolve) => {

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -9,6 +9,7 @@ import { Tenants } from 'types';
 
 const COLUMNS = [
     'collections_quota',
+    'gcm_account_id',
     'payment_provider',
     'tasks_quota',
     'tenant',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,6 +164,7 @@ export interface Tenants {
     tenant: string;
     trial_start: string;
     updated_at: string;
+    gcm_account_id?: string | null;
 }
 
 export type Capability = 'admin' | 'read' | 'write';


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1037

## Changes

### 1037

- fetch the `gcm_account_id` when getting tenant details
- check if the account id exists and if so mark that as a valid payment method

## Tests

### Manually tested

- pointed to prod and ensure it was not broken

### Automated tests

- n/a

## Screenshots

n/a
