### PR TITLE
Sort drafted bindings when hydrating binding store

### DIFF
--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -375,11 +375,9 @@ const getInitialState = (
             } else if (data?.resource_spec_schema) {
                 const { setResourceSchema } = get();
 
-                setResourceSchema(
+                await setResourceSchema(
                     data.resource_spec_schema as unknown as Schema
-                ).catch(() => {
-                    setHydrationErrorsExist(true);
-                });
+                );
             }
         }
 

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -377,7 +377,9 @@ const getInitialState = (
 
                 setResourceSchema(
                     data.resource_spec_schema as unknown as Schema
-                );
+                ).catch(() => {
+                    setHydrationErrorsExist(true);
+                });
             }
         }
 

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -400,7 +400,7 @@ const getInitialState = (
                         prefillBindingDependentState(
                             entityType,
                             liveSpecs[0].spec.bindings,
-                            draftSpecs[0].spec.bindings
+                            sortBindings(draftSpecs[0].spec.bindings)
                         );
                     }
                 } else {


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1042

## Changes

### 1042

The following features are included in this PR:

* Sort drafted bindings when hydrating the binding-dependent state of the binding store.

* Await the promise returned by `setResourceSchema` (in `hydrateState`).

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

N/A

## Screenshots

**Disable the first listed binding**

<img width="1029" alt="pr_screenshot-1041-sort_drafted_bindings-set_disabled" src="https://github.com/estuary/ui/assets/77648584/f9cfc4c5-8d7a-4b96-b2dd-2ba578b03f0d">

<br />
<br />

**After the page is refreshed**

<img width="1029" alt="pr_screenshot-1041-sort_drafted_bindings-refresh_page" src="https://github.com/estuary/ui/assets/77648584/d2ad7e77-b26c-43ad-a3d2-74521fcda34a">

