### PR TITLE
prod: mirror specification binding order in client state

### DIFF
--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -18,7 +18,7 @@ import { useIntl } from 'react-intl';
 import { useUnmount } from 'react-use';
 import {
     useBinding_currentBindingUUID,
-    useBinding_sortedMappedBindings,
+    useBinding_resourceConfigs,
 } from 'stores/Binding/hooks';
 import { BindingState } from 'stores/Binding/types';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
@@ -96,7 +96,7 @@ function CollectionSelectorList({
 
     // Binding Store
     const currentBindingUUID = useBinding_currentBindingUUID();
-    const sortedBindings = useBinding_sortedMappedBindings();
+    const resourceConfigs = useBinding_resourceConfigs();
 
     // Form State Store
     const formStatus = useFormStateStore_status();
@@ -119,19 +119,24 @@ function CollectionSelectorList({
 
     const rows = useMemo(() => {
         // If we have no bindings we can just return an empty array
-        if (isEmpty(sortedBindings)) {
+        if (isEmpty(resourceConfigs)) {
             return [];
         }
 
         // We have bindings so need to format them in a format that mui
         //  datagrid will handle. At a minimum each object must have an
         //  `id` property.
-        return sortedBindings.map(([bindingUUID, collection]) => ({
-            [COLLECTION_SELECTOR_UUID_COL]: bindingUUID,
-            [COLLECTION_SELECTOR_NAME_COL]: collection,
-            [COLLECTION_SELECTOR_STRIPPED_PATH_NAME]: stripPathing(collection),
-        }));
-    }, [sortedBindings]);
+        return Object.entries(resourceConfigs).map(([bindingUUID, config]) => {
+            const collection = config.meta.collectionName;
+
+            return {
+                [COLLECTION_SELECTOR_UUID_COL]: bindingUUID,
+                [COLLECTION_SELECTOR_NAME_COL]: collection,
+                [COLLECTION_SELECTOR_STRIPPED_PATH_NAME]:
+                    stripPathing(collection),
+            };
+        });
+    }, [resourceConfigs]);
 
     const rowsEmpty = useMemo(() => !hasLength(rows), [rows]);
 

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -17,8 +17,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useUnmount } from 'react-use';
 import {
-    useBinding_bindings,
     useBinding_currentBindingUUID,
+    useBinding_sortedMappedBindings,
 } from 'stores/Binding/hooks';
 import { BindingState } from 'stores/Binding/types';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
@@ -96,7 +96,7 @@ function CollectionSelectorList({
 
     // Binding Store
     const currentBindingUUID = useBinding_currentBindingUUID();
-    const bindings = useBinding_bindings();
+    const sortedBindings = useBinding_sortedMappedBindings();
 
     // Form State Store
     const formStatus = useFormStateStore_status();
@@ -119,22 +119,19 @@ function CollectionSelectorList({
 
     const rows = useMemo(() => {
         // If we have no bindings we can just return an empty array
-        if (isEmpty(bindings)) {
+        if (isEmpty(sortedBindings)) {
             return [];
         }
 
         // We have bindings so need to format them in a format that mui
         //  datagrid will handle. At a minimum each object must have an
         //  `id` property.
-        return Object.entries(bindings).flatMap(([collection, bindingUUIDs]) =>
-            bindingUUIDs.map((bindingUUID) => ({
-                [COLLECTION_SELECTOR_UUID_COL]: bindingUUID,
-                [COLLECTION_SELECTOR_NAME_COL]: collection,
-                [COLLECTION_SELECTOR_STRIPPED_PATH_NAME]:
-                    stripPathing(collection),
-            }))
-        );
-    }, [bindings]);
+        return sortedBindings.map(([bindingUUID, collection]) => ({
+            [COLLECTION_SELECTOR_UUID_COL]: bindingUUID,
+            [COLLECTION_SELECTOR_NAME_COL]: collection,
+            [COLLECTION_SELECTOR_STRIPPED_PATH_NAME]: stripPathing(collection),
+        }));
+    }, [sortedBindings]);
 
     const rowsEmpty = useMemo(() => !hasLength(rows), [rows]);
 

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -579,9 +579,6 @@ const getInitialState = (
                     };
                 });
 
-                // TODO (resource sorting): Consider always selecting the first binding listed
-                //   given the changes to the binding sort order.
-
                 // If previous state had no collections set to first
                 // If selected item is removed set to first.
                 // If adding new ones set to last

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -70,11 +70,26 @@ const initializeBinding = (
     state.bindings[collection] = existingBindingUUIDs.concat(bindingUUID);
 };
 
+export const sortResourceConfigs = (
+    resourceConfigEntries: [string, ResourceConfig][]
+): [string, ResourceConfig][] => {
+    return orderBy(
+        resourceConfigEntries,
+        [
+            ([_uuid, config]) => config.meta.disable,
+            ([_uuid, config]) => config.meta.collectionName,
+        ],
+        ['desc', 'asc']
+    );
+};
+
 const initializeCurrentBinding = (
     state: BindingState,
     resourceConfigs: ResourceConfigDictionary
 ) => {
-    const initialConfig = Object.entries(resourceConfigs).at(0);
+    const initialConfig = sortResourceConfigs(
+        Object.entries(resourceConfigs)
+    ).at(0);
 
     if (initialConfig) {
         const [bindingUUID, resourceConfig] = initialConfig;
@@ -129,7 +144,7 @@ const populateResourceConfigErrors = (
     state.resourceConfigErrorsExist = hasErrors;
 };
 
-const sortBindings = (bindings: any) => {
+export const sortBindings = (bindings: any) => {
     return orderBy(
         bindings,
         ['disable', (binding) => getCollectionName(binding)],
@@ -400,13 +415,13 @@ const getInitialState = (
                         prefillBindingDependentState(
                             entityType,
                             liveSpecs[0].spec.bindings,
-                            sortBindings(draftSpecs[0].spec.bindings)
+                            draftSpecs[0].spec.bindings
                         );
                     }
                 } else {
                     prefillBindingDependentState(
                         entityType,
-                        sortBindings(liveSpecs[0].spec.bindings)
+                        liveSpecs[0].spec.bindings
                     );
                 }
             }

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -56,13 +56,13 @@ import {
 
 const STORE_KEY = 'Bindings';
 
-// const sortBindings = (bindings: any) => {
-//     return orderBy(
-//         bindings,
-//         ['disable', (binding) => getCollectionName(binding)],
-//         ['desc', 'asc']
-//     );
-// };
+const sortBindings = (bindings: any) => {
+    return orderBy(
+        bindings,
+        ['disable', (binding) => getCollectionName(binding)],
+        ['desc', 'asc']
+    );
+};
 
 const sortResourceConfigs = (resourceConfigs: ResourceConfigDictionary) => {
     const sortedResources: ResourceConfigDictionary = {};
@@ -338,25 +338,24 @@ const getInitialState = (
                 const discoveredBindings: any[] =
                     draftSpecResponse.data[0].spec.bindings;
 
-                discoveredBindings.forEach((binding: any, index) => {
-                    const collection = getCollectionName(binding);
-                    const UUID = crypto.randomUUID();
+                sortBindings(discoveredBindings).forEach(
+                    (binding: any, index) => {
+                        const collection = getCollectionName(binding);
+                        const UUID = crypto.randomUUID();
 
-                    initializeBinding(state, collection, UUID);
-                    initializeResourceConfig(state, binding, UUID, index);
-                });
+                        initializeBinding(state, collection, UUID);
+                        initializeResourceConfig(state, binding, UUID, index);
+                    }
+                );
 
                 state.discoveredCollections = Object.values(
                     state.resourceConfigs
                 ).map(({ meta }) => meta.collectionName);
 
-                const sortedResourceConfigs = sortResourceConfigs(
-                    state.resourceConfigs
-                );
-                populateResourceConfigErrors(state, sortedResourceConfigs);
+                populateResourceConfigErrors(state, state.resourceConfigs);
 
                 state.bindingErrorsExist = isEmpty(state.bindings);
-                initializeCurrentBinding(state, sortedResourceConfigs);
+                initializeCurrentBinding(state, state.resourceConfigs);
             }),
             false,
             'Discovered bindings evaluated'

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -1,7 +1,6 @@
 import { useZustandStore } from 'context/Zustand/provider';
 import { BindingStoreNames } from 'stores/names';
 import { useShallow } from 'zustand/react/shallow';
-import { sortResourceConfigs } from './Store';
 import { FullSource, FullSourceDictionary } from './slices/TimeTravel';
 import { BindingState, ResourceConfig } from './types';
 
@@ -156,20 +155,6 @@ export const useBinding_bindings = () => {
     return useZustandStore<BindingState, BindingState['bindings']>(
         BindingStoreNames.GENERAL,
         (state) => state.bindings
-    );
-};
-
-export const useBinding_sortedMappedBindings = () => {
-    return useZustandStore<BindingState, [string, string][]>(
-        BindingStoreNames.GENERAL,
-        useShallow((state) =>
-            sortResourceConfigs(Object.entries(state.resourceConfigs)).map(
-                ([bindingUUID, config]) => [
-                    bindingUUID,
-                    config.meta.collectionName,
-                ]
-            )
-        )
     );
 };
 

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -1,6 +1,7 @@
 import { useZustandStore } from 'context/Zustand/provider';
 import { BindingStoreNames } from 'stores/names';
 import { useShallow } from 'zustand/react/shallow';
+import { sortResourceConfigs } from './Store';
 import { FullSource, FullSourceDictionary } from './slices/TimeTravel';
 import { BindingState, ResourceConfig } from './types';
 
@@ -155,6 +156,20 @@ export const useBinding_bindings = () => {
     return useZustandStore<BindingState, BindingState['bindings']>(
         BindingStoreNames.GENERAL,
         (state) => state.bindings
+    );
+};
+
+export const useBinding_sortedMappedBindings = () => {
+    return useZustandStore<BindingState, [string, string][]>(
+        BindingStoreNames.GENERAL,
+        useShallow((state) =>
+            sortResourceConfigs(Object.entries(state.resourceConfigs)).map(
+                ([bindingUUID, config]) => [
+                    bindingUUID,
+                    config.meta.collectionName,
+                ]
+            )
+        )
     );
 };
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1047

## Changes

### 1047

* Order binding-related state objects so that the binding order aligns with that of the drafted specification. Previously, the binding-related state objects were being sorted on initialization which caused considerable downstream issues due to the changes in `useServerUpdatedRequiredMonitor` and ripple effects of `useFieldSelectionRefresh`.

* Create a hook to sort and map binding-related information for display in the binding editor.

## Tests

### Manually tested

-  Validate that the _Next_ CTA appears when the `disable` flag for a given binding has changed in value. The edit workflow for tasks with previously disabled bindings were an area of focus.

* Validate that the _Next_ CTA appears when the resource configuration for the selected binding has changed in value. The edit workflow for tasks with previously disabled bindings were an area of focus.

* Validate that the field selection table actions can be interacted with when the latest built specification contains the selected binding. This includes changing the selected binding in a number of patterns and validating table action interactions.

### Automated tests

-  N/A

## Screenshots

_If applicable - please include some screenshots of the new UI_
