### PR TITLE
Make connector search also search descriptions & Remove "sort" option

### DIFF
--- a/src/components/connectors/ConnectorTiles.tsx
+++ b/src/components/connectors/ConnectorTiles.tsx
@@ -18,7 +18,6 @@ import { checkErrorMessage, FAILED_TO_FETCH } from 'services/shared';
 
 import {
     EntityWithCreateWorkflow,
-    SortDirection,
     TableIntlConfig,
     TableState,
     TableStatuses,
@@ -55,15 +54,14 @@ function ConnectorTiles({
         protocolPreset ?? null
     );
     const [searchQuery, setSearchQuery] = useState<string | null>(null);
-    const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
 
     const [tableState, setTableState] = useState<TableState>({
         status: TableStatuses.LOADING,
     });
 
     const query = useMemo(() => {
-        return getConnectors(searchQuery, sortDirection, protocol);
-    }, [searchQuery, sortDirection, protocol]);
+        return getConnectors(searchQuery, 'asc', protocol);
+    }, [searchQuery, protocol]);
 
     const {
         data: useSelectResponse,
@@ -111,7 +109,6 @@ function ConnectorTiles({
                     gridSpacing={2}
                     hideProtocol={!!protocolPreset}
                     setProtocol={setProtocol}
-                    setSortDirection={setSortDirection}
                     setSearchQuery={setSearchQuery}
                 />
             </Grid>

--- a/src/components/connectors/ConnectorToolbar.tsx
+++ b/src/components/connectors/ConnectorToolbar.tsx
@@ -10,7 +10,7 @@ import {
     useRef,
 } from 'react';
 import { useIntl } from 'react-intl';
-import { Entity, SortDirection } from 'types';
+import { Entity } from 'types';
 import useConstant from 'use-constant';
 
 interface Props {
@@ -18,7 +18,6 @@ interface Props {
     gridSpacing: number;
     hideProtocol?: boolean;
     setProtocol: Dispatch<SetStateAction<string | null>>;
-    setSortDirection: Dispatch<SetStateAction<SortDirection>>;
     setSearchQuery: Dispatch<SetStateAction<string | null>>;
 }
 
@@ -32,7 +31,6 @@ function ConnectorToolbar({
     gridSpacing,
     hideProtocol,
     setProtocol,
-    setSortDirection,
     setSearchQuery,
 }: Props) {
     const intl = useIntl();
@@ -59,24 +57,6 @@ function ConnectorToolbar({
         },
     ]);
 
-    const sortDirectionOptions: {
-        direction: SortDirection;
-        message: string;
-    }[] = useConstant(() => [
-        {
-            direction: 'asc',
-            message: intl.formatMessage({
-                id: 'sortDirection.ascending',
-            }),
-        },
-        {
-            direction: 'desc',
-            message: intl.formatMessage({
-                id: 'sortDirection.descending',
-            }),
-        },
-    ]);
-
     const handlers = {
         setProtocol: (_event: SyntheticEvent, value: string | null) => {
             const selectedProtocol = protocolOptions.find(
@@ -84,13 +64,6 @@ function ConnectorToolbar({
             )?.protocol;
 
             setProtocol(selectedProtocol ? selectedProtocol : null);
-        },
-        switchSortDirection: (_event: SyntheticEvent, value: string | null) => {
-            const selectedDirection = sortDirectionOptions.find(
-                (option) => option.message === value
-            )?.direction;
-
-            setSortDirection(selectedDirection ? selectedDirection : 'asc');
         },
         filterTiles: debounce(
             (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -119,28 +92,13 @@ function ConnectorToolbar({
                     justifyContent: 'flex-end',
                 }}
             >
-                <Grid item xs={12} md={hideProtocol ? 6 : 4}>
+                <Grid item xs={12} md={hideProtocol ? 12 : 6}>
                     <SearchField
                         label={intl.formatMessage({
                             id: 'connectorTable.filterLabel',
                         })}
                         changeHandler={handlers.filterTiles}
                         autoFocus={true}
-                    />
-                </Grid>
-
-                <Grid item xs={hideProtocol ? 6 : 4} md={2}>
-                    <AutocompletedField
-                        label={intl.formatMessage({
-                            id: 'connectorTable.label.sortDirection',
-                        })}
-                        options={sortDirectionOptions.map(
-                            ({ message }) => message
-                        )}
-                        defaultValue={intl.formatMessage({
-                            id: 'sortDirection.ascending',
-                        })}
-                        changeHandler={handlers.switchSortDirection}
                     />
                 </Grid>
 

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -597,7 +597,6 @@ const ConnectorsPage: ResolvedIntlConfig['messages'] = {
     'connectorTable.title': `Installed ${CommonMessages['terms.connectors']}`,
     'connectorTable.title.aria': `Table of all installed ${CommonMessages['terms.connectors']}`,
     'connectorTable.filterLabel': `Search connectors`,
-    'connectorTable.label.sortDirection': `Sort Name`,
     'connectorTable.data.title': `Name`,
     'connectorTable.data.detail': `Details`,
     'connectorTable.data.protocol': `Protocol`,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1055

## Changes
### 1055

- removed the sorting dropdown
- hardcoded to `asc` sorting

## Tests

### Manually tested

- Admin connectors, create Capture/Materialization

### Automated tests

- Updated snapshots

## Screenshots

small
![image](https://github.com/estuary/ui/assets/270078/5ba36bc2-27ff-47e5-8e35-047034c80249)

medium-ish
![image](https://github.com/estuary/ui/assets/270078/f8db7137-c1f7-44af-90d5-78225c7aa905)

large
![image](https://github.com/estuary/ui/assets/270078/5b795dd2-99e9-4896-afa5-c558ec92d569)

