### PR TITLE
Use utc time for the timestamp in logs

### DIFF
--- a/src/components/tables/cells/logs/TimestampCell.tsx
+++ b/src/components/tables/cells/logs/TimestampCell.tsx
@@ -7,9 +7,9 @@ interface Props {
 }
 
 function TimestampCell({ ts }: Props) {
-    const formattedDateTime = DateTime.fromISO(ts).toFormat(
-        'yyyy-LL-dd HH:mm:ss.SSS ZZZZ'
-    );
+    const formattedDateTime = DateTime.fromISO(ts, {
+        zone: 'UTC',
+    }).toFormat('yyyy-LL-dd HH:mm:ss.SSS ZZZZ');
 
     return (
         <TableCell sx={BaseCellSx} component="div">


### PR DESCRIPTION
## Issues

Requested in UI/UX meeting

## Changes

### issue_number

- using UTC when formatting the date

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/a805376e-9eff-48fb-9eb7-c1b0a23c8760)

