### PR TITLE
Make events always log so they are easy to find

### DIFF
--- a/src/services/shared.ts
+++ b/src/services/shared.ts
@@ -2,21 +2,6 @@ import LogRocket from 'logrocket';
 import { isProduction } from 'utils/env-utils';
 import { CustomEvents } from './types';
 
-export const logRocketEvent = (
-    event: CustomEvents | string,
-    eventProperties?: any
-) => {
-    // Just want to be very very safe
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (LogRocket?.track) {
-        LogRocket.track(event, eventProperties);
-    }
-
-    if (process.env.NODE_ENV === 'development') {
-        console.log(event, eventProperties);
-    }
-};
-
 export const logRocketConsole = (message: string, ...props: any[]) => {
     // Just want to be very very safe
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -27,6 +12,19 @@ export const logRocketConsole = (message: string, ...props: any[]) => {
     if (!isProduction) {
         console.log(message, props);
     }
+};
+
+export const logRocketEvent = (
+    event: CustomEvents | string,
+    eventProperties?: any
+) => {
+    // Just want to be very very safe
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (LogRocket?.track) {
+        LogRocket.track(event, eventProperties);
+    }
+
+    logRocketConsole(`Event Logging : ${event}`, eventProperties);
 };
 
 export const FAILED_TO_FETCH = 'FAILED TO FETCH';


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1052

## Changes

### 1052 / misc

- making it so when we fire a LR event we also just log that line to make these easier to find in sessions.

## Tests

### Manually tested

- N/A

### Automated tests

- N/A

## Screenshots

- N/A
