### PR TITLE
Allow binding search to be clearable and pastable 

### DIFF
--- a/src/components/collection/Selector/List/Header/Name.tsx
+++ b/src/components/collection/Selector/List/Header/Name.tsx
@@ -18,7 +18,7 @@ function CollectionSelectorHeaderName({
 }: Props) {
     const intl = useIntl();
 
-    // Need a local copy as as the user types the component does not force the
+    // Need a local copy so as the user types the component does not force the
     //  input focus to the end of the string.
     const [localValue, setLocalValue] = useState(inputValue);
 

--- a/src/components/collection/Selector/List/Header/Name.tsx
+++ b/src/components/collection/Selector/List/Header/Name.tsx
@@ -1,5 +1,6 @@
 import { TextField } from '@mui/material';
 import ClearInput from 'components/shared/Input/Clear';
+import { useCallback, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 interface Props {
@@ -17,6 +18,20 @@ function CollectionSelectorHeaderName({
 }: Props) {
     const intl = useIntl();
 
+    // Need a local copy as as the user types the component does not force the
+    //  input focus to the end of the string.
+    const [localValue, setLocalValue] = useState(inputValue);
+
+    // Store off the update function to make sure both the onChange and onClear
+    //  update both the local and parent value
+    const updateParent = useCallback(
+        (newValue: any) => {
+            onChange(newValue);
+            setLocalValue(newValue);
+        },
+        [onChange]
+    );
+
     return (
         <TextField
             disabled={disabled}
@@ -30,18 +45,16 @@ function CollectionSelectorHeaderName({
             )}
             size="small"
             variant="outlined"
-            defaultValue={inputValue}
+            value={localValue}
             InputProps={{
                 endAdornment: (
                     <ClearInput
-                        show={Boolean(!disabled && inputValue)}
-                        onClear={onChange}
+                        show={Boolean(!disabled && localValue)}
+                        onClear={updateParent}
                     />
                 ),
             }}
-            onChange={(event) => {
-                onChange(event.target.value);
-            }}
+            onChange={(event) => updateParent(event.target.value)}
             sx={{
                 'width': '100%',
                 'my': 1,


### PR DESCRIPTION
## Issues

Fixes : https://github.com/estuary/ui/issues/1063

## Changes

### 1063

- Store a local copy so we can still manage the value manually 
    - Fixes the issue with clearing
    - Still allows users to type where ever they want

## Tests

### Manually tested

- Messed around with the input

### Automated tests

- N/A

## Screenshots

Filtering
![image](https://github.com/estuary/ui/assets/270078/29ba6806-4dfe-49fa-8bc7-180167caaf14)

Filtering and typing at the start of string
![image](https://github.com/estuary/ui/assets/270078/813921fb-8b15-4496-9232-7cfbfd2cf730)

Filtering and typing at the middle of stirng
![image](https://github.com/estuary/ui/assets/270078/3fe44a49-781e-4d18-a5d3-ba24c30d6980)

Filtering and typing at end
![image](https://github.com/estuary/ui/assets/270078/52a583a7-02c3-45a8-8f34-35118c1b0f14)

Clearing out the filter
![image](https://github.com/estuary/ui/assets/270078/50812766-579d-4a0e-ad08-ace59aad6682)
![image](https://github.com/estuary/ui/assets/270078/3879db73-9ee9-4bfa-92e0-32d98f98a0bd)

