### PR TITLE
Prevent spamming schema sync button

### DIFF
--- a/src/components/editor/Bindings/SchemaEdit/Commands/UpdateSchemaButton.tsx
+++ b/src/components/editor/Bindings/SchemaEdit/Commands/UpdateSchemaButton.tsx
@@ -1,5 +1,8 @@
 import { Box, Button } from '@mui/material';
-import { useBindingsEditorStore_updateSchema } from 'components/editor/Bindings/Store/hooks';
+import {
+    useBindingsEditorStore_schemaUpdating,
+    useBindingsEditorStore_updateSchema,
+} from 'components/editor/Bindings/Store/hooks';
 import { useEditorStore_persistedDraftId } from 'components/editor/Store/hooks';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -7,13 +10,11 @@ import { useUnmount } from 'react-use';
 import { useBinding_currentCollection } from 'stores/Binding/hooks';
 
 function UpdateSchemaButton() {
-    // Binding Store
     const currentCollection = useBinding_currentCollection();
 
-    // Bindings Editor Store
     const updateSchema = useBindingsEditorStore_updateSchema();
+    const schemaUpdating = useBindingsEditorStore_schemaUpdating();
 
-    // Draft Editor Store
     const persistedDraftId = useEditorStore_persistedDraftId();
 
     // TODO (optimization): Equip stores with the proper tools to clean up after themselves; this includes managing the promises they create.
@@ -36,7 +37,11 @@ function UpdateSchemaButton() {
 
     return (
         <Box sx={{ mt: 5, display: 'flex', justifyContent: 'flex-end' }}>
-            <Button variant="outlined" onClick={updateCollectionSchema}>
+            <Button
+                variant="outlined"
+                onClick={updateCollectionSchema}
+                disabled={schemaUpdating}
+            >
                 <FormattedMessage id="workflows.collectionSelector.schemaEdit.cta.syncSchema" />
             </Button>
         </Box>

--- a/src/components/editor/Bindings/Store/__tests__/__snapshots__/create.test.ts.snap
+++ b/src/components/editor/Bindings/Store/__tests__/__snapshots__/create.test.ts.snap
@@ -22,6 +22,7 @@ exports[`useBindingsEditorStore > store will default itself properly 1`] = `
   "schemaInferenceDisabled": false,
   "schemaUpdateErrored": false,
   "schemaUpdated": true,
+  "schemaUpdating": false,
   "setCollectionData": [Function],
   "setCollectionInitializationAlert": [Function],
   "setDocumentsRead": [Function],
@@ -33,6 +34,7 @@ exports[`useBindingsEditorStore > store will default itself properly 1`] = `
   "setSchemaInferenceDisabled": [Function],
   "setSchemaUpdateErrored": [Function],
   "setSchemaUpdated": [Function],
+  "setSchemaUpdating": [Function],
   "updateSchema": [Function],
 }
 `;

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -157,6 +157,7 @@ const getInitialMiscData = (): Pick<
     | 'schemaInferenceDisabled'
     | 'schemaUpdateErrored'
     | 'schemaUpdated'
+    | 'schemaUpdating'
     | 'editModeEnabled'
     | 'inferSchemaResponse'
     | 'inferSchemaResponseError'
@@ -175,6 +176,7 @@ const getInitialMiscData = (): Pick<
     schemaInferenceDisabled: false,
     schemaUpdateErrored: false,
     schemaUpdated: true,
+    schemaUpdating: false,
     editModeEnabled: false,
     inferSchemaResponse: null,
     inferSchemaResponse_Keys: [],
@@ -363,6 +365,16 @@ const getInitialState = (
         );
     },
 
+    setSchemaUpdating: (value) => {
+        set(
+            produce((state: BindingsEditorState) => {
+                state.schemaUpdating = value;
+            }),
+            false,
+            'Schema Updating Set'
+        );
+    },
+
     // TODO (optimization): Equip stores with the proper tools to clean up after themselves; this includes managing the promises they create.
     updateSchema: (currentCollection, persistedDraftId) => {
         const {
@@ -370,11 +382,13 @@ const getInitialState = (
             schemaUpdateErrored,
             setSchemaUpdateErrored,
             setSchemaUpdated,
+            setSchemaUpdating,
             setCollectionData,
         } = get();
 
         if (currentCollection && collectionData) {
             setSchemaUpdated(false);
+            setSchemaUpdating(true);
 
             return evaluateCollectionData(
                 persistedDraftId,
@@ -388,10 +402,12 @@ const getInitialState = (
                     setCollectionData(response);
 
                     setSchemaUpdated(true);
+                    setSchemaUpdating(false);
                 },
                 () => {
                     setSchemaUpdateErrored(true);
                     setSchemaUpdated(true);
+                    setSchemaUpdating(false);
                 }
             );
         } else {

--- a/src/components/editor/Bindings/Store/hooks.ts
+++ b/src/components/editor/Bindings/Store/hooks.ts
@@ -73,6 +73,10 @@ export const useBindingsEditorStore_updateSchema = () => {
     return useBindingsEditorStore((state) => state.updateSchema);
 };
 
+export const useBindingsEditorStore_schemaUpdating = () => {
+    return useBindingsEditorStore((state) => state.schemaUpdating);
+};
+
 export const useBindingsEditorStore_schemaUpdated = () => {
     return useBindingsEditorStore((state) => state.schemaUpdated);
 };

--- a/src/components/editor/Bindings/Store/types.ts
+++ b/src/components/editor/Bindings/Store/types.ts
@@ -22,6 +22,9 @@ export interface BindingsEditorState {
         persistedDraftId: string | null
     ) => Promise<void> | null;
 
+    schemaUpdating: boolean;
+    setSchemaUpdating: (value: BindingsEditorState['schemaUpdating']) => void;
+
     schemaUpdated: boolean;
     setSchemaUpdated: (value: BindingsEditorState['schemaUpdated']) => void;
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/456

## Changes

### 456

- Just added a basic `disabled` setting. A user could still spam this button but it is better now. Especially if the call is taking awhile.

## Tests

### Manually tested

- Tried spamming the button in different settings. Throttled network, blocked URL, and normal

### Automated tests

- n/a

## Screenshots

normal: 3 clicks
![image](https://github.com/estuary/ui/assets/270078/327d81fe-cb75-40ed-b859-f5f7aabfd9d4)

throttled (fast 3g): 3 clicks
![image](https://github.com/estuary/ui/assets/270078/4bcb9433-f468-48ef-aac5-099f7afcc33e)


blocked: 3 clicks
![image](https://github.com/estuary/ui/assets/270078/d0bb589a-33de-4aee-90c2-89ac37266186)
