### PR TITLE
PROD: Adding in missing content for stats filter menu

### DIFF
--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -402,6 +402,9 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.data.sharedPrefix': `Shared Prefix`,
     'entityTable.data.sharedWith': `Shared With`,
 
+    'entityTable.stats.filter.label': `${
+        CommonMessages[`filter.time.label`]
+    } Menu`,
     'entityTable.stats.bytes_read': `Bytes Read`,
     'entityTable.stats.docs_read': `Docs Read`,
     'entityTable.stats.bytes_written': `Bytes Written`,


### PR DESCRIPTION
## Issues

from slack

## Changes

- add in content

## Tests

### Manually tested

- hit the Captures table

### Automated tests

- n/a

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/e31578be-7a56-41f3-851e-41c631371629)

