### PR TITLE
Update endpointconfig store to be used directly

### DIFF
--- a/src/context/Zustand/invariableStores.ts
+++ b/src/context/Zustand/invariableStores.ts
@@ -8,7 +8,6 @@ import {
     collectionDetailsForm,
     materializationDetailsForm,
 } from 'stores/DetailsForm/Store';
-import { createEndpointConfigStore } from 'stores/EndpointConfig/Store';
 import { createEntitiesStore } from 'stores/Entities/Store';
 import { createFormStateStore } from 'stores/FormState/Store';
 import { createJournalDataLogsStore } from 'stores/JournalData/Logs/Store';
@@ -19,7 +18,6 @@ import {
     BindingStoreNames,
     DetailsFormStoreNames,
     EditorStoreNames,
-    EndpointConfigStoreNames,
     ExistingEntityStoreNames,
     FormStateStoreNames,
     GlobalStoreNames,
@@ -64,11 +62,6 @@ const invariableStores = {
     ),
     [EditorStoreNames.MATERIALIZATION]: createEditorStore(
         EditorStoreNames.MATERIALIZATION
-    ),
-
-    // Endpoint Config Store
-    [EndpointConfigStoreNames.GENERAL]: createEndpointConfigStore(
-        EndpointConfigStoreNames.GENERAL
     ),
 
     // Existing Entity Store - used only in create workflows

--- a/src/forms/renderers/OAuth/index.tsx
+++ b/src/forms/renderers/OAuth/index.tsx
@@ -9,6 +9,8 @@ import { useEffect, useMemo } from 'react';
 import GoogleButton from 'react-google-button';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useMount } from 'react-use';
+import { logRocketEvent } from 'services/shared';
+import { CustomEvents } from 'services/types';
 import { useEndpointConfigStore_setCustomErrors } from 'stores/EndpointConfig/hooks';
 import { generateCustomError } from 'stores/extensions/CustomErrors';
 import { Options } from 'types/jsonforms';
@@ -117,6 +119,12 @@ const OAuthproviderRenderer = ({
                 ...tokenResponse.data,
             };
 
+            logRocketEvent(CustomEvents.OAUTH_SUCCESS_HANDLER, {
+                discriminatorProperty,
+                discriminatorExists: Boolean(
+                    updatedCredentials[discriminatorProperty]
+                ),
+            });
             handleChange(onChangePath, updatedCredentials);
         }
     );

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -40,6 +40,7 @@ export enum CustomEvents {
     MATERIALIZATION_TEST = 'Materialization_Test',
     MATERIALIZATION_TEST_BACKGROUND = 'Materialization_Test_Background',
     NOTIFICATION_NETWORK_WARNING = 'Notification_Network_Warning',
+    OAUTH_SUCCESS_HANDLER = 'Oauth_Success_Handler',
     OAUTH_WINDOW_OPENER = 'Oauth_Window_Opener',
     STRIPE_FORM_LOADING_FAILED = 'Stripe_Form_Loading_Failed',
     SUPABASE_CALL_FAILED = 'Supabase_Call_Failed',

--- a/src/stores/EndpointConfig/Store.ts
+++ b/src/stores/EndpointConfig/Store.ts
@@ -132,6 +132,10 @@ const getInitialState = (
                     ? createJSONFormDefaults(state.endpointSchema)
                     : encryptedEndpointConfig;
 
+                // TODO (endpoint config)
+                // I have NO clue why this is passing the encryptedConfig that is becing passed in and
+                //  not what is set to the state. Especially since it could end up with setting defaults to
+                //  the state value
                 populateErrors(
                     encryptedEndpointConfig,
                     state.customErrors,

--- a/src/stores/EndpointConfig/Store.ts
+++ b/src/stores/EndpointConfig/Store.ts
@@ -15,7 +15,6 @@ import {
     getInitialHydrationData,
     getStoreWithHydrationSettings,
 } from 'stores/extensions/Hydration';
-import { EndpointConfigStoreNames } from 'stores/names';
 import { JsonFormsData, Schema } from 'types';
 import {
     configCanBeEmpty,
@@ -280,8 +279,9 @@ const getInitialState = (
     },
 });
 
-export const createEndpointConfigStore = (key: EndpointConfigStoreNames) => {
-    return create<EndpointConfigState>()(
-        devtools((set, get) => getInitialState(set, get), devtoolsOptions(key))
-    );
-};
+export const useEnpointConfigStore = create<EndpointConfigState>()(
+    devtools(
+        (set, get) => getInitialState(set, get),
+        devtoolsOptions('general-endpoint-config')
+    )
+);

--- a/src/stores/EndpointConfig/Store.ts
+++ b/src/stores/EndpointConfig/Store.ts
@@ -87,11 +87,9 @@ const getInitialState = (
                 state.customErrors = val;
                 state.customErrorsExist = hasLength(val);
 
-                const { endpointConfig } = get();
-
                 // Setting this so that if there is a custom error then the
                 //  generate button will not proceed
-                populateErrors(endpointConfig, val, state);
+                populateErrors(state.endpointConfig, val, state);
             }),
             false,
             'Endpoint Custom Errors Set'
@@ -109,9 +107,7 @@ const getInitialState = (
                 state.endpointSchema = resolved;
                 state.endpointCanBeEmpty = configCanBeEmpty(resolved);
 
-                const { endpointConfig, customErrors } = get();
-
-                populateErrors(endpointConfig, customErrors, state);
+                populateErrors(state.endpointConfig, state.customErrors, state);
             }),
             false,
             'Endpoint Schema Set'
@@ -121,10 +117,8 @@ const getInitialState = (
     setPublishedEndpointConfig: (encryptedEndpointConfig) => {
         set(
             produce((state: EndpointConfigState) => {
-                const { endpointSchema } = get();
-
                 state.publishedEndpointConfig = isEmpty(encryptedEndpointConfig)
-                    ? createJSONFormDefaults(endpointSchema)
+                    ? createJSONFormDefaults(state.endpointSchema)
                     : encryptedEndpointConfig;
             }),
             false,
@@ -135,13 +129,15 @@ const getInitialState = (
     setEncryptedEndpointConfig: (encryptedEndpointConfig) => {
         set(
             produce((state: EndpointConfigState) => {
-                const { endpointSchema, customErrors } = get();
-
                 state.encryptedEndpointConfig = isEmpty(encryptedEndpointConfig)
-                    ? createJSONFormDefaults(endpointSchema)
+                    ? createJSONFormDefaults(state.endpointSchema)
                     : encryptedEndpointConfig;
 
-                populateErrors(encryptedEndpointConfig, customErrors, state);
+                populateErrors(
+                    encryptedEndpointConfig,
+                    state.customErrors,
+                    state
+                );
             }),
             false,
             'Encrypted Endpoint Config Set'
@@ -151,10 +147,8 @@ const getInitialState = (
     setPreviousEndpointConfig: (endpointConfig) => {
         set(
             produce((state: EndpointConfigState) => {
-                const { endpointSchema } = get();
-
                 state.previousEndpointConfig = isEmpty(endpointConfig)
-                    ? createJSONFormDefaults(endpointSchema)
+                    ? createJSONFormDefaults(state.endpointSchema)
                     : endpointConfig;
             }),
             false,
@@ -165,13 +159,11 @@ const getInitialState = (
     setEndpointConfig: (endpointConfig) => {
         set(
             produce((state: EndpointConfigState) => {
-                const { endpointSchema, customErrors } = get();
-
                 state.endpointConfig = isEmpty(endpointConfig)
-                    ? createJSONFormDefaults(endpointSchema)
+                    ? createJSONFormDefaults(state.endpointSchema)
                     : endpointConfig;
 
-                populateErrors(state.endpointConfig, customErrors, state);
+                populateErrors(state.endpointConfig, state.customErrors, state);
             }),
             false,
             'Endpoint Config Changed'
@@ -181,11 +173,9 @@ const getInitialState = (
     setServerUpdateRequired: (updateRequired) => {
         set(
             produce((state: EndpointConfigState) => {
-                const { endpointConfig, customErrors } = get();
-
                 state.serverUpdateRequired = updateRequired;
 
-                populateErrors(endpointConfig, customErrors, state);
+                populateErrors(state.endpointConfig, state.customErrors, state);
             }),
             false,
             'Server Update Required Flag Changed'

--- a/src/stores/EndpointConfig/hooks.ts
+++ b/src/stores/EndpointConfig/hooks.ts
@@ -1,233 +1,98 @@
-import { useEntityType } from 'context/EntityContext';
-import { useZustandStore } from 'context/Zustand/provider';
-import { EndpointConfigStoreNames } from 'stores/names';
-import { Entity } from 'types';
 import { useShallow } from 'zustand/react/shallow';
-import { EndpointConfigState } from './types';
-
-const getStoreName = (entityType: Entity): EndpointConfigStoreNames => {
-    if (entityType === 'capture' || entityType === 'materialization') {
-        return EndpointConfigStoreNames.GENERAL;
-    } else {
-        throw new Error('Invalid EndpointConfig store name');
-    }
-};
+import { useEnpointConfigStore } from './Store';
 
 export const useEndpointConfigStore_errorsExist = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['errorsExist']
-    >(getStoreName(entityType), (state) => state.errorsExist);
+    return useEnpointConfigStore((state) => state.errorsExist);
 };
 
 export const useEndpointConfigStore_endpointConfigErrors = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['endpointConfigErrors']
-    >(getStoreName(entityType), (state) => state.endpointConfigErrors);
+    return useEnpointConfigStore((state) => state.endpointConfigErrors);
 };
 
 export const useEndpointConfigStore_reset = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['resetState']
-    >(getStoreName(entityType), (state) => state.resetState);
+    return useEnpointConfigStore((state) => state.resetState);
 };
 
 export const useEndpointConfigStore_changed = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['stateChanged']
-    >(
-        getStoreName(entityType),
-        useShallow((state) => state.stateChanged)
-    );
+    return useEnpointConfigStore(useShallow((state) => state.stateChanged));
 };
 
 export const useEndpointConfigStore_endpointSchema = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['endpointSchema']
-    >(getStoreName(entityType), (state) => state.endpointSchema);
+    return useEnpointConfigStore((state) => state.endpointSchema);
 };
 
 export const useEndpointConfigStore_customErrors = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['customErrors']
-    >(getStoreName(entityType), (state) => state.customErrors);
+    return useEnpointConfigStore((state) => state.customErrors);
 };
 
 export const useEndpointConfigStore_setCustomErrors = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setCustomErrors']
-    >(getStoreName(entityType), (state) => state.setCustomErrors);
+    return useEnpointConfigStore((state) => state.setCustomErrors);
 };
 
 export const useEndpointConfigStore_setEndpointSchema = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setEndpointSchema']
-    >(getStoreName(entityType), (state) => state.setEndpointSchema);
+    return useEnpointConfigStore((state) => state.setEndpointSchema);
 };
 
 export const useEndpointConfigStore_encryptedEndpointConfig_data = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['encryptedEndpointConfig']['data']
-    >(getStoreName(entityType), (state) => state.encryptedEndpointConfig.data);
+    return useEnpointConfigStore((state) => state.encryptedEndpointConfig.data);
 };
 
 export const useEndpointConfigStore_setEncryptedEndpointConfig = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setEncryptedEndpointConfig']
-    >(getStoreName(entityType), (state) => state.setEncryptedEndpointConfig);
+    return useEnpointConfigStore((state) => state.setEncryptedEndpointConfig);
 };
 
 export const useEndpointConfigStore_previousEndpointConfig_data = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['previousEndpointConfig']['data']
-    >(getStoreName(entityType), (state) => state.previousEndpointConfig.data);
+    return useEnpointConfigStore((state) => state.previousEndpointConfig.data);
 };
 
 export const useEndpointConfigStore_setPreviousEndpointConfig = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setPreviousEndpointConfig']
-    >(getStoreName(entityType), (state) => state.setPreviousEndpointConfig);
+    return useEnpointConfigStore((state) => state.setPreviousEndpointConfig);
 };
 
 export const useEndpointConfigStore_endpointConfig_data = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['endpointConfig']['data']
-    >(getStoreName(entityType), (state) => state.endpointConfig.data);
+    return useEnpointConfigStore((state) => state.endpointConfig.data);
 };
 
 export const useEndpointConfigStore_setEndpointConfig = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setEndpointConfig']
-    >(getStoreName(entityType), (state) => state.setEndpointConfig);
+    return useEnpointConfigStore((state) => state.setEndpointConfig);
 };
 
 export const useEndpointConfig_hydrated = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['hydrated']
-    >(getStoreName(entityType), (state) => state.hydrated);
+    return useEnpointConfigStore((state) => state.hydrated);
 };
 
 export const useEndpointConfig_setHydrated = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setHydrated']
-    >(getStoreName(entityType), (state) => state.setHydrated);
+    return useEnpointConfigStore((state) => state.setHydrated);
 };
 
 export const useEndpointConfig_hydrationErrorsExist = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['hydrationErrorsExist']
-    >(getStoreName(entityType), (state) => state.hydrationErrorsExist);
+    return useEnpointConfigStore((state) => state.hydrationErrorsExist);
 };
 
 export const useEndpointConfig_setHydrationErrorsExist = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setHydrationErrorsExist']
-    >(getStoreName(entityType), (state) => state.setHydrationErrorsExist);
+    return useEnpointConfigStore((state) => state.setHydrationErrorsExist);
 };
 
 export const useEndpointConfig_hydrateState = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['hydrateState']
-    >(getStoreName(entityType), (state) => state.hydrateState);
+    return useEnpointConfigStore((state) => state.hydrateState);
 };
 
 export const useEndpointConfig_setActive = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setActive']
-    >(getStoreName(entityType), (state) => state.setActive);
+    return useEnpointConfigStore((state) => state.setActive);
 };
 
 export const useEndpointConfig_serverUpdateRequired = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['serverUpdateRequired']
-    >(getStoreName(entityType), (state) => state.serverUpdateRequired);
+    return useEnpointConfigStore((state) => state.serverUpdateRequired);
 };
 
 export const useEndpointConfig_setServerUpdateRequired = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setServerUpdateRequired']
-    >(getStoreName(entityType), (state) => state.setServerUpdateRequired);
+    return useEnpointConfigStore((state) => state.setServerUpdateRequired);
 };
 
 export const useEndpointConfig_endpointCanBeEmpty = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['endpointCanBeEmpty']
-    >(getStoreName(entityType), (state) => state.endpointCanBeEmpty);
+    return useEnpointConfigStore((state) => state.endpointCanBeEmpty);
 };
 
 export const useEndpointConfig_setEndpointCanBeEmpty = () => {
-    const entityType = useEntityType();
-
-    return useZustandStore<
-        EndpointConfigState,
-        EndpointConfigState['setEndpointCanBeEmpty']
-    >(getStoreName(entityType), (state) => state.setEndpointCanBeEmpty);
+    return useEnpointConfigStore((state) => state.setEndpointCanBeEmpty);
 };

--- a/src/stores/EndpointConfig/hooks.ts
+++ b/src/stores/EndpointConfig/hooks.ts
@@ -2,6 +2,7 @@ import { useEntityType } from 'context/EntityContext';
 import { useZustandStore } from 'context/Zustand/provider';
 import { EndpointConfigStoreNames } from 'stores/names';
 import { Entity } from 'types';
+import { useShallow } from 'zustand/react/shallow';
 import { EndpointConfigState } from './types';
 
 const getStoreName = (entityType: Entity): EndpointConfigStoreNames => {
@@ -45,7 +46,10 @@ export const useEndpointConfigStore_changed = () => {
     return useZustandStore<
         EndpointConfigState,
         EndpointConfigState['stateChanged']
-    >(getStoreName(entityType), (state) => state.stateChanged);
+    >(
+        getStoreName(entityType),
+        useShallow((state) => state.stateChanged)
+    );
 };
 
 export const useEndpointConfigStore_endpointSchema = () => {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1082

## Changes

### 1082

- Remove all uses of `get` while inside of a `produce` as I think this is causing changes to get lost
- While we are testing this already - just using hooks for the store directly
- Adding events for LR to make this issue easier to track

## Tests

### Manually tested

- Capture create/edit with Oauth
- Materialization create/edit with Oauth

### Automated tests

- N/A

## Screenshots

...tbd
