### PR TITLE
Updating the support email

### DIFF
--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -263,9 +263,9 @@ const Header: ResolvedIntlConfig['messages'] = {
     'helpMenu.slack': `Estuary Slack`,
     'helpMenu.slack.link': `https://join.slack.com/t/estuary-dev/shared_invite/zt-86nal6yr-VPbv~YfZE9Q~6Zl~gmZdFQ`,
     'helpMenu.support': `Email Support`,
-    'helpMenu.support.link': `mailto: flow-support@estuary.dev`,
+    'helpMenu.support.link': `${CommonMessages['support.email']}`,
     'helpMenu.contact': `Contact Us`,
-    'helpMenu.contact.link': `https://www.estuary.dev/#get-in-touch`,
+    'helpMenu.contact.link': `https://estuary.dev/about/#contact-us`,
     'helpMenu.about': `About ${CommonMessages.productName}`,
 
     'accountMenu.ariaLabel': `Open Account Menu`,


### PR DESCRIPTION
Updating the contact us links

## Issues

https://github.com/estuary/ui/issues/1083

## Changes

### 1083

- Removing the space in the `mailto` link... hoping this helps
- Updating the 'Contact Us` url to work again

## Tests

### Manually tested

- Clicked on the links

### Automated tests

- N/A... user menu tests are disabled currently

## Screenshots

Support Email
![image](https://github.com/estuary/ui/assets/270078/54cd2341-de3f-4706-9ee8-24e74b07cb90)
![image](https://github.com/estuary/ui/assets/270078/fde03e7d-f527-4b9e-9270-bb973af16742)


Contact Us
![image](https://github.com/estuary/ui/assets/270078/3c1d32b1-e2ec-44c2-af66-a798e6b55d5e)
![image](https://github.com/estuary/ui/assets/270078/b1415173-eeae-4b10-b352-2c1460e1311c)

