### PR TITLE
Travjenkins/prod/stats header content

### DIFF
--- a/src/components/filters/Date/index.tsx
+++ b/src/components/filters/Date/index.tsx
@@ -70,12 +70,7 @@ function DateFilter({ disabled, header, selectableTableStoreName }: Props) {
                 component="span"
                 sx={{ mt: 0.5, fontWeight: 500, whiteSpace: 'nowrap' }}
             >
-                <FormattedMessage
-                    id="data.read"
-                    values={{
-                        type: <FormattedMessage id={header} />,
-                    }}
-                />
+                {header}
             </Typography>
 
             <IconButton

--- a/src/components/tables/Captures/useCaptureColumns.tsx
+++ b/src/components/tables/Captures/useCaptureColumns.tsx
@@ -40,7 +40,6 @@ const statsHeader: ColumnProps = {
         return (
             <StatsHeader
                 key={`captures-statsHeader-${index}`}
-                header="entityTable.stats.written"
                 selectableTableStoreName={selectableTableStoreName}
             />
         );

--- a/src/components/tables/Captures/useCaptureColumns.tsx
+++ b/src/components/tables/Captures/useCaptureColumns.tsx
@@ -40,6 +40,7 @@ const statsHeader: ColumnProps = {
         return (
             <StatsHeader
                 key={`captures-statsHeader-${index}`}
+                headerSuffix="data.written"
                 selectableTableStoreName={selectableTableStoreName}
             />
         );

--- a/src/components/tables/Collections/useCollectionColumns.tsx
+++ b/src/components/tables/Collections/useCollectionColumns.tsx
@@ -63,7 +63,7 @@ const useCollectionColumns = (): ColumnProps[] => {
                 defaultColumns_end,
             ];
         } else {
-            return [...defaultColumns_start, ...defaultColumns_end];
+            return [...defaultColumns_start, defaultColumns_end];
         }
     }, [hasDetails]);
 };

--- a/src/components/tables/Collections/useCollectionColumns.tsx
+++ b/src/components/tables/Collections/useCollectionColumns.tsx
@@ -15,12 +15,10 @@ const defaultColumns_start: ColumnProps[] = [
     },
 ];
 
-const defaultColumns_end: ColumnProps[] = [
-    {
-        field: 'updated_at',
-        headerIntlKey: 'entityTable.data.lastPublished',
-    },
-];
+const defaultColumns_end: ColumnProps = {
+    field: 'updated_at',
+    headerIntlKey: 'entityTable.data.lastPublished',
+};
 
 const dataStatsHeader: ColumnProps = {
     field: null,
@@ -62,7 +60,7 @@ const useCollectionColumns = (): ColumnProps[] => {
                 ...defaultColumns_start,
                 dataStatsHeader,
                 docsStatsHeader,
-                ...defaultColumns_end,
+                defaultColumns_end,
             ];
         } else {
             return [...defaultColumns_start, ...defaultColumns_end];

--- a/src/components/tables/Collections/useCollectionColumns.tsx
+++ b/src/components/tables/Collections/useCollectionColumns.tsx
@@ -22,16 +22,20 @@ const defaultColumns_end: ColumnProps[] = [
     },
 ];
 
-const dataStatsHeader: ColumnProps[] = [
-    {
-        field: null,
-        headerIntlKey: 'entityTable.stats.written',
+const dataStatsHeader: ColumnProps = {
+    field: null,
+    cols: 2,
+    renderHeader: (index, selectableTableStoreName) => {
+        return (
+            <StatsHeader
+                hideFilter
+                key={`collection-docsStatsHeader-${index}`}
+                header="data.data"
+                selectableTableStoreName={selectableTableStoreName}
+            />
+        );
     },
-    {
-        field: null,
-        headerIntlKey: 'entityTable.stats.read',
-    },
-];
+};
 
 const docsStatsHeader: ColumnProps = {
     field: null,
@@ -56,7 +60,7 @@ const useCollectionColumns = (): ColumnProps[] => {
         if (hasDetails) {
             return [
                 ...defaultColumns_start,
-                ...dataStatsHeader,
+                dataStatsHeader,
                 docsStatsHeader,
                 ...defaultColumns_end,
             ];

--- a/src/components/tables/Materializations/useMaterializationColumns.tsx
+++ b/src/components/tables/Materializations/useMaterializationColumns.tsx
@@ -40,6 +40,7 @@ const statsHeader: ColumnProps = {
         return (
             <StatsHeader
                 key={`materializations-statsHeader-${index}`}
+                headerSuffix="data.read"
                 selectableTableStoreName={selectableTableStoreName}
             />
         );

--- a/src/components/tables/Materializations/useMaterializationColumns.tsx
+++ b/src/components/tables/Materializations/useMaterializationColumns.tsx
@@ -40,7 +40,6 @@ const statsHeader: ColumnProps = {
         return (
             <StatsHeader
                 key={`materializations-statsHeader-${index}`}
-                header="entityTable.stats.read"
                 selectableTableStoreName={selectableTableStoreName}
             />
         );

--- a/src/components/tables/cells/stats/Header.tsx
+++ b/src/components/tables/cells/stats/Header.tsx
@@ -3,7 +3,7 @@ import DateFilter from 'components/filters/Date';
 import { useTenantDetails } from 'context/fetcher/Tenant';
 import { useZustandStore } from 'context/Zustand/provider';
 import { useMemo } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { SelectTableStoreNames } from 'stores/names';
 import {
     SelectableTableStore,
@@ -46,8 +46,18 @@ const StatsHeader = ({
         SelectableTableStore['query']['count']
     >(selectableTableStoreName, selectableTableStoreSelectors.query.count);
 
-    const secondColHeader = useMemo(
-        () =>
+    const [firstColHeader, secondColHeader] = useMemo(() => {
+        return [
+            intl.formatMessage(
+                {
+                    id: headerSuffix ? headerSuffix : 'data.written',
+                },
+                {
+                    type: intl.formatMessage({
+                        id: header ?? 'data.data',
+                    }),
+                }
+            ),
             intl.formatMessage(
                 {
                     id: headerSuffix ? headerSuffix : 'data.read',
@@ -58,10 +68,8 @@ const StatsHeader = ({
                     }),
                 }
             ),
-        [header, headerSuffix, intl]
-    );
-
-    console.log('secondColHeader', secondColHeader);
+        ];
+    }, [header, headerSuffix, intl]);
 
     return (
         <>
@@ -70,14 +78,7 @@ const StatsHeader = ({
                     component="span"
                     sx={{ mt: 0.5, fontWeight: 500, whiteSpace: 'nowrap' }}
                 >
-                    <FormattedMessage
-                        id={headerSuffix ? headerSuffix : 'data.written'}
-                        values={{
-                            type: (
-                                <FormattedMessage id={header ?? 'data.data'} />
-                            ),
-                        }}
-                    />
+                    {firstColHeader}
                 </Typography>
             </TableCell>
             <TableCell>

--- a/src/components/tables/cells/stats/Header.tsx
+++ b/src/components/tables/cells/stats/Header.tsx
@@ -11,8 +11,8 @@ import {
 import { hasLength } from 'utils/misc-utils';
 
 interface Props {
-    header: string;
     selectableTableStoreName: SelectTableStoreNames;
+    header?: string;
 }
 
 const StatsHeader = ({ header, selectableTableStoreName }: Props) => {
@@ -47,14 +47,16 @@ const StatsHeader = ({ header, selectableTableStoreName }: Props) => {
                     <FormattedMessage
                         id="data.written"
                         values={{
-                            type: <FormattedMessage id={header} />,
+                            type: (
+                                <FormattedMessage id={header ?? 'data.data'} />
+                            ),
                         }}
                     />
                 </Typography>
             </TableCell>
             <TableCell>
                 <DateFilter
-                    header={header}
+                    header={header ?? 'data.docs'}
                     disabled={
                         !hasStats ||
                         isValidating ||

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -415,9 +415,6 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
     'entityTable.stats.bytes_written': `Bytes Written`,
     'entityTable.stats.docs_written': `Docs Written`,
 
-    'entityTable.stats.written': `Data Written`,
-    'entityTable.stats.read': `Data Read`,
-
     'entityTable.stats.error': `Failed to fetch stats.`,
 
     'entityTable.unmatchedFilter.header': `No results found.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -417,8 +417,6 @@ const EntityTable: ResolvedIntlConfig['messages'] = {
 
     'entityTable.stats.written': `Data Written`,
     'entityTable.stats.read': `Data Read`,
-    'entityTable.stats.written.docs': `Docs Written`,
-    'entityTable.stats.read.docs': `Docs Read`,
 
     'entityTable.stats.error': `Failed to fetch stats.`,
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1095

## Changes

### 1095

- Make the stats header more reusable
- Remove old content to reduce chance that this happens again

## Tests

### Manually tested

- Hit all 3 tables

### Automated tests

- n/a

## Screenshots

### Captures
![image](https://github.com/estuary/ui/assets/270078/63dfaf35-2ff4-4be9-a1f3-6443d1bc9a70)

### Collections
![image](https://github.com/estuary/ui/assets/270078/2e85aa85-1748-4f66-bf04-dc777c086cf0)

### Materializations
![image](https://github.com/estuary/ui/assets/270078/4d22d779-280f-4a49-93c3-a6f134755d4e)

