### PR TITLE
Update storage mapping section description

### DIFF
--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -58,7 +58,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'terms.capture': `Capture`,
     'terms.derivation': `Derivation`,
     'terms.documentation': `Docs`,
-    'terms.storageMapping': `Storage Mappings`,
+    'terms.storageMapping': `Storage Mapping`,
     'terms.entity': `Entity`,
 
     // Common fields
@@ -595,7 +595,7 @@ const StorageMappings: ResolvedIntlConfig['messages'] = {
     'storageMappings.bucket.label': `Bucket`,
     'storageMappings.bucket.description': `The name of the bucket you have setup to store data in.`,
     'storageMappings.lastUpdated.label': `Last Updated`,
-    'storageMappings.message': `Below are all the ${CommonMessages['terms.storageMapping']} that you have read or admin access to. These are the locations that your data is stored.`,
+    'storageMappings.message': `Create a ${CommonMessages['terms.storageMapping']} to govern where your data is stored. The first storage mapping is the one and only location that data is saved.`,
 
     'storageMappings.configureStorage.label': `Configure Storage`,
     'storageMappings.dialog.generate.description': `Choose where you'd like {tenant} data to be stored. This location will be used for all future write operations.`,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -58,7 +58,6 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'terms.capture': `Capture`,
     'terms.derivation': `Derivation`,
     'terms.documentation': `Docs`,
-    'terms.storageMapping': `Storage Mapping`,
     'terms.entity': `Entity`,
 
     // Common fields
@@ -595,7 +594,7 @@ const StorageMappings: ResolvedIntlConfig['messages'] = {
     'storageMappings.bucket.label': `Bucket`,
     'storageMappings.bucket.description': `The name of the bucket you have setup to store data in.`,
     'storageMappings.lastUpdated.label': `Last Updated`,
-    'storageMappings.message': `Create a ${CommonMessages['terms.storageMapping']} to govern where your data is stored. The first storage mapping is the one and only location that data is saved.`,
+    'storageMappings.message': `Create a Storage Mapping to govern where your data is stored. The first storage mapping is the one and only location that data is saved.`,
 
     'storageMappings.configureStorage.label': `Configure Storage`,
     'storageMappings.dialog.generate.description': `Choose where you'd like {tenant} data to be stored. This location will be used for all future write operations.`,


### PR DESCRIPTION
## Issues

N/A

## Changes

The following features are included in this PR:

* Update the storage mappings section description on the _Settings_ tab of the _Admin_ page to the following: `Create a Storage Mapping to govern where your data is stored. The first storage mapping is the one and only location that data is saved.`

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the storage mappings section description is the desired message.

### Automated tests

N/A

## Screenshots

<img width="1012" alt="pr_screenshot-1100-mappings_content" src="https://github.com/estuary/ui/assets/77648584/f311092c-5aad-437f-90f2-60b84b7a8fab">
