### PR TITLE
Highlight the latest storage mapping in the table

### DIFF
--- a/src/components/tables/StorageMappings/Rows.tsx
+++ b/src/components/tables/StorageMappings/Rows.tsx
@@ -57,42 +57,27 @@ function DataCells({ store }: DataCellProps) {
 
 function Row({ row }: RowProps) {
     const key = `StorageMappings-${row.id}`;
-    const multipleStores = row.spec.stores.length > 1;
-
-    if (multipleStores) {
-        return (
-            <>
-                {row.spec.stores.map((store, index) =>
-                    index === 0 ? (
-                        <TableRow key={`${key}_stores_${index}`}>
-                            <TableCell>{row.catalog_prefix}</TableCell>
-                            <ChipStatus
-                                color="success"
-                                messageId="data.active"
-                            />
-                            <DataCells store={store} />
-                            <TimeStamp time={row.updated_at} enableRelative />
-                        </TableRow>
-                    ) : (
-                        <TableRow key={`${key}_stores_${index}`}>
-                            <TableCell />
-                            <TableCell />
-                            <DataCells store={store} />
-                            <TableCell />
-                        </TableRow>
-                    )
-                )}
-            </>
-        );
-    }
 
     return (
-        <TableRow key={key}>
-            <TableCell>{row.catalog_prefix}</TableCell>
-            <ChipStatus color="success" messageId="data.active" />
-            <DataCells store={row.spec.stores[0]} />
-            <TimeStamp time={row.updated_at} enableRelative />
-        </TableRow>
+        <>
+            {row.spec.stores.map((store, index) =>
+                index === 0 ? (
+                    <TableRow key={`${key}_stores_${index}`}>
+                        <TableCell>{row.catalog_prefix}</TableCell>
+                        <ChipStatus color="success" messageId="data.active" />
+                        <DataCells store={store} />
+                        <TimeStamp time={row.updated_at} enableRelative />
+                    </TableRow>
+                ) : (
+                    <TableRow key={`${key}_stores_${index}`}>
+                        <TableCell />
+                        <TableCell />
+                        <DataCells store={store} />
+                        <TableCell />
+                    </TableRow>
+                )
+            )}
+        </>
     );
 }
 

--- a/src/components/tables/StorageMappings/Rows.tsx
+++ b/src/components/tables/StorageMappings/Rows.tsx
@@ -89,6 +89,7 @@ function Row({ row }: RowProps) {
     return (
         <TableRow key={key}>
             <TableCell>{row.catalog_prefix}</TableCell>
+            <ChipStatus color="success" messageId="data.active" />
             <DataCells store={row.spec.stores[0]} />
             <TimeStamp time={row.updated_at} enableRelative />
         </TableRow>

--- a/src/components/tables/StorageMappings/Rows.tsx
+++ b/src/components/tables/StorageMappings/Rows.tsx
@@ -1,6 +1,6 @@
 import { TableCell, TableRow } from '@mui/material';
 import TimeStamp from 'components/tables/cells/TimeStamp';
-import { StorageMappings, StorageMappingStore } from 'types';
+import { StorageMappingStore, StorageMappings } from 'types';
 
 interface RowProps {
     row: StorageMappings;
@@ -57,17 +57,21 @@ function Row({ row }: RowProps) {
     if (multipleStores) {
         return (
             <>
-                <TableRow key={key}>
-                    <TableCell colSpan={4}>{row.catalog_prefix}</TableCell>
-                    <TimeStamp time={row.updated_at} enableRelative />
-                </TableRow>
-                {row.spec.stores.map((store, index) => (
-                    <TableRow key={`${key}_stores_${index}`}>
-                        <TableCell />
-                        <DataCells store={store} />
-                        <TableCell />
-                    </TableRow>
-                ))}
+                {row.spec.stores.map((store, index) =>
+                    index === 0 ? (
+                        <TableRow key={`${key}_stores_${index}`}>
+                            <TableCell>{row.catalog_prefix}</TableCell>
+                            <DataCells store={store} />
+                            <TimeStamp time={row.updated_at} enableRelative />
+                        </TableRow>
+                    ) : (
+                        <TableRow key={`${key}_stores_${index}`}>
+                            <TableCell />
+                            <DataCells store={store} />
+                            <TableCell />
+                        </TableRow>
+                    )
+                )}
             </>
         );
     }

--- a/src/components/tables/StorageMappings/Rows.tsx
+++ b/src/components/tables/StorageMappings/Rows.tsx
@@ -1,6 +1,7 @@
 import { TableCell, TableRow } from '@mui/material';
 import TimeStamp from 'components/tables/cells/TimeStamp';
 import { StorageMappingStore, StorageMappings } from 'types';
+import ChipStatus from '../cells/ChipStatus';
 
 interface RowProps {
     row: StorageMappings;
@@ -18,6 +19,10 @@ export const tableColumns = [
     {
         field: 'catalog_prefix',
         headerIntlKey: 'entityTable.data.catalogPrefix',
+    },
+    {
+        field: null,
+        headerIntlKey: 'data.status',
     },
     {
         field: null,
@@ -61,11 +66,16 @@ function Row({ row }: RowProps) {
                     index === 0 ? (
                         <TableRow key={`${key}_stores_${index}`}>
                             <TableCell>{row.catalog_prefix}</TableCell>
+                            <ChipStatus
+                                color="success"
+                                messageId="data.active"
+                            />
                             <DataCells store={store} />
                             <TimeStamp time={row.updated_at} enableRelative />
                         </TableRow>
                     ) : (
                         <TableRow key={`${key}_stores_${index}`}>
+                            <TableCell />
                             <TableCell />
                             <DataCells store={store} />
                             <TableCell />

--- a/src/components/tables/cells/ChipStatus.tsx
+++ b/src/components/tables/cells/ChipStatus.tsx
@@ -1,16 +1,10 @@
-import { AlertColor, Chip, TableCell, Theme } from '@mui/material';
-import { outlinedColoredChipBackground } from 'context/Theme';
+import { Chip, ChipProps, TableCell } from '@mui/material';
 import { useIntl } from 'react-intl';
 
 interface Props {
     messageId: string;
-    color: AlertColor;
+    color: ChipProps['color'];
 }
-
-const getOutlineColor = (theme: Theme, color: AlertColor) =>
-    theme.palette.mode === 'dark'
-        ? theme.palette[color].main
-        : theme.palette[color].dark;
 
 function ChipStatus({ messageId, color }: Props) {
     const intl = useIntl();
@@ -19,13 +13,10 @@ function ChipStatus({ messageId, color }: Props) {
         <TableCell>
             <Chip
                 component="span"
+                color={color}
                 label={intl.formatMessage({ id: messageId })}
                 size="small"
                 variant="outlined"
-                sx={{
-                    borderColor: (theme) => getOutlineColor(theme, color),
-                    backgroundColor: outlinedColoredChipBackground[color],
-                }}
             />
         </TableCell>
     );

--- a/src/components/tables/cells/ChipStatus.tsx
+++ b/src/components/tables/cells/ChipStatus.tsx
@@ -1,0 +1,34 @@
+import { AlertColor, Chip, TableCell, Theme } from '@mui/material';
+import { outlinedColoredChipBackground } from 'context/Theme';
+import { useIntl } from 'react-intl';
+
+interface Props {
+    messageId: string;
+    color: AlertColor;
+}
+
+const getOutlineColor = (theme: Theme, color: AlertColor) =>
+    theme.palette.mode === 'dark'
+        ? theme.palette[color].main
+        : theme.palette[color].dark;
+
+function ChipStatus({ messageId, color }: Props) {
+    const intl = useIntl();
+
+    return (
+        <TableCell>
+            <Chip
+                component="span"
+                label={intl.formatMessage({ id: messageId })}
+                size="small"
+                variant="outlined"
+                sx={{
+                    borderColor: (theme) => getOutlineColor(theme, color),
+                    backgroundColor: outlinedColoredChipBackground[color],
+                }}
+            />
+        </TableCell>
+    );
+}
+
+export default ChipStatus;

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -308,13 +308,6 @@ export const typographyTruncation: TypographyProps = {
     },
 };
 
-export const outlinedColoredChipBackground: { [key: string]: string } = {
-    success: 'rgba(42, 121, 66, 0.12)',
-    error: 'rgba(202, 59, 85, 0.12)',
-    warning: 'rgba(237, 108, 2, 0.12)',
-    info: 'rgba(79, 214, 255, 0.12)',
-};
-
 export const draggableChipIconSx: SxProps<Theme> = {
     '& .MuiChip-icon': {
         borderTopRightRadius: 0,
@@ -769,6 +762,34 @@ const themeSettings = createTheme({
         MuiChip: {
             defaultProps: {
                 deleteIcon: <DeleteCircle style={{ fontSize: 14 }} />,
+                sx: {
+                    '&.MuiChip-outlined': {
+                        '&.MuiChip-colorPrimary': {
+                            color: (theme) => theme.palette.text.primary,
+                            backgroundColor: 'rgba(58, 86, 202, 0.12)',
+                        },
+                        '&.MuiChip-colorSecondary': {
+                            color: (theme) => theme.palette.text.primary,
+                            backgroundColor: 'rgba(25, 42, 136, 0.12)',
+                        },
+                        '&.MuiChip-colorSuccess': {
+                            color: (theme) => theme.palette.text.primary,
+                            backgroundColor: 'rgba(42, 121, 66, 0.12)',
+                        },
+                        '&.MuiChip-colorError': {
+                            color: (theme) => theme.palette.text.primary,
+                            backgroundColor: 'rgba(202, 59, 85, 0.12)',
+                        },
+                        '&.MuiChip-colorInfo': {
+                            color: (theme) => theme.palette.text.primary,
+                            backgroundColor: 'rgba(79, 214, 255, 0.12)',
+                        },
+                        '&.MuiChip-colorWarning': {
+                            color: (theme) => theme.palette.text.primary,
+                            backgroundColor: 'rgba(237, 108, 2, 0.12)',
+                        },
+                    },
+                },
             },
         },
         MuiFormControl: {

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -308,6 +308,13 @@ export const typographyTruncation: TypographyProps = {
     },
 };
 
+export const outlinedColoredChipBackground: { [key: string]: string } = {
+    success: 'rgba(42, 121, 66, 0.12)',
+    error: 'rgba(202, 59, 85, 0.12)',
+    warning: 'rgba(237, 108, 2, 0.12)',
+    info: 'rgba(79, 214, 255, 0.12)',
+};
+
 export const draggableChipIconSx: SxProps<Theme> = {
     '& .MuiChip-icon': {
         borderTopRightRadius: 0,

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -177,6 +177,7 @@ const Data: ResolvedIntlConfig['messages'] = {
     'data.connectorImage': `Connector Image`,
     'data.details': `Details`,
     'data.actions': `Actions`,
+    'data.active': `Active`,
 };
 
 const Error: ResolvedIntlConfig['messages'] = {


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/435

## Changes

### 435

The following features are included in this PR:

* Create a shared table cell component that displays a status in a chip.

* Add a status column to the storage mappings table which displays an _active_ status chip on the first table row (which corresponds to the storage mapping used for write operations).

* Consolidate the first and second rows of the storage mappings table so that the _new_ first row displays data in every column.

* Customize the styling of colored, outlined chips in the theme.

## Tests

### Manually tested

Approaches to testing are as follows:

* Review the appearance of the storage mapping table.

### Automated tests

N/A

## Screenshots

**Storage mappings table | Multiple mappings | Light mode**

<img width="962" alt="pr_screenshot-1103-mappings_table-multi-light" src="https://github.com/estuary/ui/assets/77648584/0f6198c9-0d3d-4906-9877-aa4be220636b">

<br />
<br />

**Storage mappings table | Multiple mappings | Dark mode**

<img width="943" alt="sm_table-outlined-2-right" src="https://github.com/estuary/ui/assets/77648584/a2d7310f-d49f-44f1-9e93-a7bd24d08409">

<br />
<br />

**Storage mappings table | Single mapping | Light mode**

<img width="956" alt="pr_screenshot-1103-mappings_table-single-light" src="https://github.com/estuary/ui/assets/77648584/892ff71f-19ca-4a48-9bcd-5f663ab5df49">

<br />
<br />

**Storage mappings table | Single mapping | Dark mode**

<img width="949" alt="pr_screenshot-1103-mappings_table-single-dark" src="https://github.com/estuary/ui/assets/77648584/556fa6c0-de81-464e-8c7f-5ccc1294a3c6">