### PR TITLE
Display missing data for stats

### DIFF
--- a/src/components/graphs/DataByHourGraph/index.tsx
+++ b/src/components/graphs/DataByHourGraph/index.tsx
@@ -17,7 +17,7 @@ import { UniversalTransition } from 'echarts/features';
 import { CanvasRenderer } from 'echarts/renderers';
 import prettyBytes from 'pretty-bytes';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { FormatDateOptions, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import readable from 'readable-numbers';
 import { CatalogStats_Details } from 'types';
 import { getTooltipItem, getTooltipTitle } from '../tooltips';
@@ -42,11 +42,6 @@ const barMinHeight = 1;
 const type = 'bar';
 const itemStyle = {
     borderRadius: [4, 4, 0, 0],
-};
-
-const formatTimeSettings: FormatDateOptions = {
-    hour: '2-digit',
-    minute: '2-digit',
 };
 
 const defaultDataFormat = (value: any, fractionDigits: number = 0) => {
@@ -103,10 +98,7 @@ function DataByHourGraph({ id, stats = [] }: Props) {
     // Update the "last updated" string shown as an xAxis label
     useEffect(() => {
         // Want to format with seconds to show more of a "ticking clock" to users
-        const currentTime = intl.formatTime(new Date(), {
-            ...formatTimeSettings,
-            second: '2-digit',
-        });
+        const currentTime = format(new Date(), `pp`);
 
         // Made a string instead of passing value into message to make life easier
         setLastUpdated(
@@ -330,7 +322,7 @@ function DataByHourGraph({ id, stats = [] }: Props) {
                         align: 'center',
                         formatter: (value: any) => {
                             if (value) {
-                                return format(parseISO(value), `hh:mm aa`);
+                                return format(parseISO(value), `p`);
                             }
                             return '';
                         },

--- a/src/hooks/useDetailsStats.ts
+++ b/src/hooks/useDetailsStats.ts
@@ -23,6 +23,11 @@ function useDetailsStats(catalogName: string, grain: string) {
         }
     );
 
+    // TODO (graphs)
+    // This approach is kinda bad because the benefit of using dataset/dimensions is we didn't have to loop over data.
+    //  However, to get this feature in quick this is the quickest way to do that. We should look at the graph
+    //  and potentially get it off of dataset/dimensions since we are already having to loop over all the intervals
+    //  and generating the proper data.
     const stats = useMemo(() => {
         if (!data?.data || data.data.length === 0) {
             return;

--- a/src/hooks/useDetailsStats.ts
+++ b/src/hooks/useDetailsStats.ts
@@ -4,6 +4,9 @@ import { useSelectNew } from 'hooks/supabase-swr/hooks/useSelect';
 import { hasLength } from 'utils/misc-utils';
 import { CatalogStats_Details } from 'types';
 import useDetailsUsageStore from 'components/shared/Entity/Details/Usage/useDetailsUsageStore';
+import { useMemo } from 'react';
+import { DateTime, Interval } from 'luxon';
+import { find } from 'lodash';
 
 function useDetailsStats(catalogName: string, grain: string) {
     const entityType = useEntityType();
@@ -20,11 +23,52 @@ function useDetailsStats(catalogName: string, grain: string) {
         }
     );
 
+    const stats = useMemo(() => {
+        if (data?.data && data.data.length > 0) {
+            const max = DateTime.utc().startOf('hour');
+
+            // Subtracting 1 here because the interval is inclusive of the minimum
+            const min = max.minus({ hours: range - 1 });
+
+            // Go through the entire interval and populate the response if we have data
+            //  otherwise default to an "empty" response
+            const timeRange: CatalogStats_Details[] = Interval.fromDateTimes(
+                min,
+                max.plus({ hours: 1 })
+            )
+                .splitBy({ hours: 1 })
+                .map((timeInterval) => {
+                    const ts = timeInterval.start?.toFormat(
+                        `yyyy-MM-dd'T'HH:mm:ssZZ`
+                    );
+                    const currentStat = find(data.data, { ts });
+
+                    if (currentStat) {
+                        return currentStat;
+                    }
+
+                    return {
+                        ts,
+                        catalog_name: '',
+                        grain: 'hourly',
+                        bytes_read: 0,
+                        docs_read: 0,
+                        bytes_written: 0,
+                        docs_written: 0,
+                    } as CatalogStats_Details;
+                });
+
+            return timeRange;
+        }
+
+        return undefined;
+    }, [data?.data, range]);
+
     // Not always returning an array so we know when the empty array is a response
     //  vs a default. That way we can keep showing old data while new data is geing fetched
     //  during isValidating
     return {
-        stats: data?.data,
+        stats,
         error,
         isValidating,
     };

--- a/src/hooks/useDetailsStats.ts
+++ b/src/hooks/useDetailsStats.ts
@@ -24,7 +24,7 @@ function useDetailsStats(catalogName: string, grain: string) {
     );
 
     const stats = useMemo(() => {
-        if (!data?.data) {
+        if (!data?.data || data.data.length === 0) {
             return;
         }
 

--- a/src/hooks/useDetailsStats.ts
+++ b/src/hooks/useDetailsStats.ts
@@ -54,10 +54,10 @@ function useDetailsStats(catalogName: string, grain: string) {
                         ts,
                         catalog_name: '',
                         grain: 'hourly',
-                        bytes_read: NaN,
-                        docs_read: NaN,
-                        bytes_written: NaN,
-                        docs_written: NaN,
+                        bytes_read: 0,
+                        docs_read: 0,
+                        bytes_written: 0,
+                        docs_written: 0,
                     } as CatalogStats_Details)
                 );
             });


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1029

## Changes

### 1029

- Figure out the range of times and ensure there are defaults if stats are missing

## Tests

### Manually tested

- Hit stats and overrode the content response

### Automated tests

- N/A

## Screenshots

Removed half the response
![image](https://github.com/estuary/ui/assets/270078/dd906e5b-f1bd-4c76-806c-87eed71a3443)

Missing data displayed as `0` (screenshot shows `N/A` as it was before content change)
![image](https://github.com/estuary/ui/assets/270078/6e6f2acf-2645-498e-b142-92bae6ad76ab)

Empty responses will display error as usual
![image](https://github.com/estuary/ui/assets/270078/6cb23520-5622-44c7-9dcc-4a65df81e393)
