### PR TITLE
Extend data processing notification interval options

### DIFF
--- a/src/components/shared/Entity/Details/Overview/NotificationSettings/useSettingIntervalOptions.ts
+++ b/src/components/shared/Entity/Details/Overview/NotificationSettings/useSettingIntervalOptions.ts
@@ -22,6 +22,9 @@ function useSettingIntervalOptions() {
     // while a postgresql interval in day increments has the following format: '# day(s)'.
     const options: IntervalOptions = useMemo(
         () => ({
+            '3 days': intl.formatMessage(intervalOptionIds.day, {
+                interval: 3,
+            }),
             '2 days': intl.formatMessage(intervalOptionIds.day, {
                 interval: 2,
             }),
@@ -39,6 +42,9 @@ function useSettingIntervalOptions() {
             }),
             '02:00:00': intl.formatMessage(intervalOptionIds.hour, {
                 interval: 2,
+            }),
+            '01:00:00': intl.formatMessage(intervalOptionIds.hour, {
+                interval: 1,
             }),
             'none': intl.formatMessage({
                 id: 'details.settings.notifications.dataProcessing.noDataProcessedInInterval.unsetOption',


### PR DESCRIPTION
## Changes

The following features are included in this PR:

* Extend the data processing notification interval options to include the following: three days and one hour.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the two, new data processing notification interval options are displayed and can be applied.

### Automated tests

N/A

## Screenshots

**Data processing notification interval options**

<img width="100" alt="pr_screenshot-1132-extend_notification_interval-options" src="https://github.com/estuary/ui/assets/77648584/5de2ee3a-557a-4180-91f9-773751ffcd4f">
