### PR TITLE
Columns marked as read due to copy paste error

### DIFF
--- a/src/components/tables/Collections/Rows.tsx
+++ b/src/components/tables/Collections/Rows.tsx
@@ -58,7 +58,6 @@ function Row({ isSelected, setRow, row, stats, showEntityStatus }: RowProps) {
             {hasLength(tenantDetails) ? (
                 <>
                     <Bytes
-                        read
                         val={
                             stats
                                 ? stats[row.catalog_name]?.bytes_written_to_me
@@ -76,7 +75,6 @@ function Row({ isSelected, setRow, row, stats, showEntityStatus }: RowProps) {
                     />
 
                     <Docs
-                        read
                         val={
                             stats
                                 ? stats[row.catalog_name]?.docs_written_to_me


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1131

## Changes

### 1131

- Removed the `read` prop from the columns

## Tests

### Manually tested

- Hit the collections table

### Automated tests

- N/A

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/910d279f-92d5-49b5-8017-040fbf4804b0)

![image](https://github.com/estuary/ui/assets/270078/94617fc5-c86d-479d-9f39-4d505ac245f6)

