### PR TITLE
PROD: Filter out soft deleted captures and materializations

### DIFF
--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -79,7 +79,8 @@ const getLiveSpecs_captures = (
         .from<CaptureQuery>(TABLES.LIVE_SPECS_EXT)
         .select(captureColumns, {
             count: 'exact',
-        });
+        })
+        .filter('spec', 'not.is', null);
 
     queryBuilder = defaultTableFilter<CaptureQuery>(
         queryBuilder,
@@ -101,7 +102,8 @@ const getLiveSpecs_materializations = (
         .from<MaterializationQuery>(TABLES.LIVE_SPECS_EXT)
         .select(materializationsColumns, {
             count: 'exact',
-        });
+        })
+        .filter('spec', 'not.is', null);
 
     queryBuilder = defaultTableFilter<MaterializationQuery>(
         queryBuilder,

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -80,7 +80,7 @@ const getLiveSpecs_captures = (
         .select(captureColumns, {
             count: 'exact',
         })
-        .filter('spec', 'not.is', null);
+        .not('spec', 'is', null);
 
     queryBuilder = defaultTableFilter<CaptureQuery>(
         queryBuilder,
@@ -103,7 +103,7 @@ const getLiveSpecs_materializations = (
         .select(materializationsColumns, {
             count: 'exact',
         })
-        .filter('spec', 'not.is', null);
+        .not('spec', 'is', null);
 
     queryBuilder = defaultTableFilter<MaterializationQuery>(
         queryBuilder,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -278,6 +278,9 @@ export interface LiveSpecsExtBaseQuery extends LiveSpecsExtBareMinimum {
     title: string;
     last_pub_id: string;
     updated_at: string;
+
+    // Used ONLY for filtering
+    spec: any;
 }
 
 export interface GatewayAuthTokenResponse {


### PR DESCRIPTION
Second part of https://github.com/estuary/ui/pull/1148

Now during delete there is a soft delete before the hard delete. it is best that this know about the type of entity being removed. This means that Live Specs Ext will still show entities that are actively being deleted. 

To fix this we will not make sure the spec is not null when trying to list the entities.