### PR TITLE
Try to get live specs performance to be better

### DIFF
--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -78,7 +78,7 @@ const getLiveSpecs_captures = (
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(captureColumns, {
-                count: 'exact',
+                count: 'planned',
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'capture'),
@@ -98,7 +98,7 @@ const getLiveSpecs_materializations = (
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(materializationsColumns, {
-                count: 'exact',
+                count: 'planned',
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'materialization'),
@@ -118,7 +118,7 @@ const getLiveSpecs_collections = (
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(collectionColumns, {
-                count: 'exact',
+                count: 'planned',
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'collection'),
@@ -154,7 +154,7 @@ const getLiveSpecs_collectionsSelector = (
                     ? collectionsSelectorColumns_capture
                     : collectionsSelectorColumns,
                 {
-                    count: 'exact',
+                    count: 'planned',
                 }
             )
             .eq('spec_type', specType),
@@ -184,7 +184,7 @@ const getLiveSpecs_existingTasks = (
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(columns, {
-                count: 'exact',
+                count: 'planned',
             })
             .eq('connector_id', connectorId)
             .not('catalog_name', 'ilike', 'ops/%')

--- a/src/components/tables/EntityTable/TableFooter.tsx
+++ b/src/components/tables/EntityTable/TableFooter.tsx
@@ -45,6 +45,7 @@ function EntityTableFooter({
                         page={page}
                         onPageChange={onPageChange}
                         onRowsPerPageChange={onRowsPerPageChange}
+                        showLastButton={false}
                         SelectProps={{
                             // TODO (table filtering)
                             // Same as the other one

--- a/src/components/tables/PaginationActions.tsx
+++ b/src/components/tables/PaginationActions.tsx
@@ -30,12 +30,6 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
         nextButtonClick: (event: React.MouseEvent<HTMLButtonElement>) => {
             onPageChange(event, page + 1);
         },
-        lastPageButtonClick: (event: React.MouseEvent<HTMLButtonElement>) => {
-            onPageChange(
-                event,
-                Math.max(0, Math.ceil(count / rowsPerPage) - 1)
-            );
-        },
     };
 
     return (
@@ -76,19 +70,6 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
                     <NavArrowLeft />
                 ) : (
                     <NavArrowRight />
-                )}
-            </IconButton>
-
-            <IconButton
-                onClick={handlers.lastPageButtonClick}
-                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-                aria-label="last page"
-                sx={{ color: theme.palette.text.primary }}
-            >
-                {theme.direction === 'rtl' ? (
-                    <FastArrowLeft />
-                ) : (
-                    <FastArrowRight />
                 )}
             </IconButton>
         </Box>


### PR DESCRIPTION
## Issues

`tech debt`

## Changes

- Replaced `exact` count with `planned` to try to make the queries better.

## Tests

### Manually tested

- Pointed local to production and hit tables. Seems to load **way** faster.

### Automated tests

- N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/estuary/ui/assets/270078/dca0f7e5-7aab-4c55-94c4-b96629d09368)

