### PR TITLE
PROD: Reduce how often we get `exact: count` for live spec tables

### DIFF
--- a/src/api/alerts.ts
+++ b/src/api/alerts.ts
@@ -152,7 +152,7 @@ const getNotificationSubscriptionsForTable = (
     return defaultTableFilter<AlertSubscriptionsExtendedQuery>(
         supabaseClient
             .from(TABLES.ALERT_SUBSCRIPTIONS)
-            .select(`id, updated_at, catalog_prefix, email`, { count: 'exact' })
+            .select(`id, updated_at, catalog_prefix, email`)
             .eq('catalog_prefix', catalogPrefix),
         ['catalog_prefix', 'email'],
         searchQuery,

--- a/src/api/combinedGrantsExt.ts
+++ b/src/api/combinedGrantsExt.ts
@@ -9,6 +9,7 @@ import {
     DEFAULT_PAGING_SIZE,
 } from 'services/supabase';
 import { AuthRoles, Capability, Grant_UserExt } from 'types';
+import { getCountSettings } from 'utils/table-utils';
 
 // Used to display prefix grants in admin page
 const getGrants = (
@@ -28,7 +29,7 @@ const getGrants = (
             updated_at
         `,
                 {
-                    count: 'exact',
+                    count: getCountSettings(pagination),
                 }
             )
             .neq('subject_role', null),

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -74,11 +74,12 @@ const getLiveSpecs_captures = (
     searchQuery: any,
     sorting: SortingProps<any>[]
 ) => {
+    console.log('pagination', pagination);
     return defaultTableFilter<CaptureQuery[]>(
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(captureColumns, {
-                count: 'exact',
+                count: pagination.from === 0 ? 'exact' : undefined,
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'capture'),
@@ -98,7 +99,7 @@ const getLiveSpecs_materializations = (
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(materializationsColumns, {
-                count: 'exact',
+                count: pagination.from === 0 ? 'exact' : undefined,
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'materialization'),
@@ -118,7 +119,7 @@ const getLiveSpecs_collections = (
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(collectionColumns, {
-                count: 'exact',
+                count: pagination.from === 0 ? 'exact' : undefined,
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'collection'),

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -20,6 +20,7 @@ import {
     LiveSpecsExtBaseQuery,
 } from 'types';
 import { CHUNK_SIZE, DEMO_TENANT } from 'utils/misc-utils';
+import { getCountSettings } from 'utils/table-utils';
 
 const baseColumns = [
     'catalog_name',
@@ -67,9 +68,6 @@ const materializationsColumns = commonColumns.concat(['reads_from']).join(',');
 const materializationsColumnsWithSpec = materializationsColumns.concat(',spec');
 
 const collectionColumns = baseColumns.join(',');
-
-const getCountSettings = (pagination: any) =>
-    pagination.from === 0 ? 'exact' : undefined;
 
 // Entity table-specific queries
 const getLiveSpecs_captures = (

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -68,18 +68,20 @@ const materializationsColumnsWithSpec = materializationsColumns.concat(',spec');
 
 const collectionColumns = baseColumns.join(',');
 
+const getCountSettings = (pagination: any) =>
+    pagination.from === 0 ? 'exact' : undefined;
+
 // Entity table-specific queries
 const getLiveSpecs_captures = (
     pagination: any,
     searchQuery: any,
     sorting: SortingProps<any>[]
 ) => {
-    console.log('pagination', pagination);
     return defaultTableFilter<CaptureQuery[]>(
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(captureColumns, {
-                count: pagination.from === 0 ? 'exact' : undefined,
+                count: getCountSettings(pagination),
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'capture'),
@@ -99,7 +101,7 @@ const getLiveSpecs_materializations = (
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(materializationsColumns, {
-                count: pagination.from === 0 ? 'exact' : undefined,
+                count: getCountSettings(pagination),
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'materialization'),
@@ -119,7 +121,7 @@ const getLiveSpecs_collections = (
         supabaseClient
             .from(TABLES.LIVE_SPECS_EXT)
             .select(collectionColumns, {
-                count: pagination.from === 0 ? 'exact' : undefined,
+                count: getCountSettings(pagination),
             })
             .not('spec', 'is', null)
             .eq('spec_type', 'collection'),

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -6,19 +6,13 @@ import {
     nextSaturday,
     parseISO,
     previousSunday,
-    startOfMonth,
     sub,
     subDays,
     subMonths,
     subWeeks,
 } from 'date-fns';
 import { UTCDate } from '@date-fns/utc';
-import {
-    defaultTableFilter,
-    escapeReservedCharacters,
-    SortingProps,
-    TABLES,
-} from 'services/supabase';
+import { escapeReservedCharacters, TABLES } from 'services/supabase';
 import {
     CatalogStats,
     CatalogStats_Billing,
@@ -280,52 +274,47 @@ const getStatsForDetails = (
 //   returned by the billing_report RPC to populate the contents of its rows.
 
 // SBV2-typing (PostgrestFilterBuilder<CatalogStats_Billing>)
-const getStatsForBillingHistoryTable = (
-    tenants: string[],
-    // pagination: any,
-    searchQuery: any,
-    sorting: SortingProps<any>[]
-) => {
-    // switched this query to use `like` but never tested so might require `ilike` but that impacts perf (Q2 2024)
-    const subjectRoleFilters = tenants
-        .map(
-            (tenant) => `catalog_name.like.${escapeReservedCharacters(tenant)}%`
-        )
-        .join(',');
+// const getStatsForBillingHistoryTable = (
+//     tenants: string[],
+//     // pagination: any,
+//     searchQuery: any,
+//     sorting: SortingProps<any>[]
+// ) => {
+//     // switched this query to use `like` but never tested so might require `ilike` but that impacts perf (Q2 2024)
+//     const subjectRoleFilters = tenants
+//         .map(
+//             (tenant) => `catalog_name.like.${escapeReservedCharacters(tenant)}%`
+//         )
+//         .join(',');
 
-    const today = new Date();
-    const currentMonth = startOfMonth(today);
-    const startMonth = subMonths(currentMonth, 5);
+//     const today = new Date();
+//     const currentMonth = startOfMonth(today);
+//     const startMonth = subMonths(currentMonth, 5);
 
-    const query = supabaseClient
-        .from(TABLES.CATALOG_STATS)
-        .select(
-            `    
-            catalog_name,
-            grain,
-            ts,
-            bytes_written_by_me,
-            bytes_read_by_me,
-            flow_document
-        `,
-            { count: 'exact' }
-        )
-        .eq('grain', monthlyGrain)
-        .gte('ts', convertToUTC(startMonth, monthlyGrain))
-        .lte('ts', convertToUTC(today, monthlyGrain))
-        .or(subjectRoleFilters);
+//     const query = supabaseClient
+//         .from(TABLES.CATALOG_STATS)
+//         .select(
+//             `
+//             catalog_name,
+//             grain,
+//             ts,
+//             bytes_written_by_me,
+//             bytes_read_by_me,
+//             flow_document
+//         `,
+//             { count: 'exact' }
+//         )
+//         .eq('grain', monthlyGrain)
+//         .gte('ts', convertToUTC(startMonth, monthlyGrain))
+//         .lte('ts', convertToUTC(today, monthlyGrain))
+//         .or(subjectRoleFilters);
 
-    return defaultTableFilter<typeof query>(
-        query,
-        ['ts'],
-        searchQuery,
-        sorting
-    );
-};
+//     return defaultTableFilter<typeof query>(
+//         query,
+//         ['ts'],
+//         searchQuery,
+//         sorting
+//     );
+// };
 
-export {
-    getStatsByName,
-    getStatsForBilling,
-    getStatsForBillingHistoryTable,
-    getStatsForDetails,
-};
+export { getStatsByName, getStatsForBilling, getStatsForDetails };

--- a/src/stores/Tables/Store.ts
+++ b/src/stores/Tables/Store.ts
@@ -439,7 +439,18 @@ export const getInitialState = (
 
                     state.hydrated = true;
 
-                    state.query.count = response.count;
+                    // Setting count is weird because we do not want all queries always fetching exact counts
+                    //  The live spec tables only fetch exact count when the pagination.from is 0. That way
+                    //  they only get count on the first page or when the user kicks off a search.
+                    // So we only want to add a count when there is one in the response and nothing in the store
+                    //  of
+                    // If the response has a count that does not equal the current state
+                    state.query.count =
+                        (!state.query.count && response.count) ||
+                        (Number.isInteger(response.count) &&
+                            state.query.count !== response.count)
+                            ? response.count
+                            : state.query.count;
                     state.query.response = response.data;
                     state.query.loading = false;
                 }),

--- a/src/stores/Tables/Store.ts
+++ b/src/stores/Tables/Store.ts
@@ -439,18 +439,18 @@ export const getInitialState = (
 
                     state.hydrated = true;
 
-                    // Setting count is weird because we do not want all queries always fetching exact counts
-                    //  The live spec tables only fetch exact count when the pagination.from is 0. That way
-                    //  they only get count on the first page or when the user kicks off a search.
-                    // So we only want to add a count when there is one in the response and nothing in the store
-                    //  of
-                    // If the response has a count that does not equal the current state
-                    state.query.count =
-                        (!state.query.count && response.count) ||
-                        (Number.isInteger(response.count) &&
-                            state.query.count !== response.count)
-                            ? response.count
-                            : state.query.count;
+                    const hasNewCount = Number.isInteger(response.count);
+                    if (
+                        // We have no count and just recieved one so update
+                        //  ex: initial load
+                        (!state.query.count && hasNewCount) ||
+                        // We already have a count, but there is a new one, and it has changed
+                        //  ex: filter or count change since last time viewing 1st page
+                        (state.query.count !== response.count && hasNewCount)
+                    ) {
+                        state.query.count = response.count;
+                    }
+
                     state.query.response = response.data;
                     state.query.loading = false;
                 }),

--- a/src/stores/Tables/Store.ts
+++ b/src/stores/Tables/Store.ts
@@ -445,7 +445,7 @@ export const getInitialState = (
                         //  ex: initial load
                         (!state.query.count && hasNewCount) ||
                         // We already have a count, but there is a new one, and it has changed
-                        //  ex: filter or count change since last time viewing 1st page
+                        //  ex: user entered a filter or count change since last time they viewed the 1st page
                         (state.query.count !== response.count && hasNewCount)
                     ) {
                         state.query.count = response.count;

--- a/src/utils/table-utils.tsx
+++ b/src/utils/table-utils.tsx
@@ -4,6 +4,9 @@ import { FormattedMessage } from 'react-intl';
 import { Pagination } from 'services/supabase';
 import { TableColumns, TableIntlConfig, TableStatuses } from 'types';
 
+export const getCountSettings = (pagination: any) =>
+    pagination.from === 0 ? 'exact' : undefined;
+
 export const getEmptyTableHeader = (
     tableStatus: TableStatuses,
     intlConfig: TableIntlConfig


### PR DESCRIPTION
Today we are _always_ fetching the exact count and this can cause extra load on the DB. This should help reduce that a little bit. The amount it helps depends on how often users are actually using pagination.