### PR TITLE
Fixing binding collection editing

### DIFF
--- a/src/components/collection/schema/Editor/index.tsx
+++ b/src/components/collection/schema/Editor/index.tsx
@@ -78,21 +78,22 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
         setCollectionData,
     ]);
 
+    // If the schema is updated via the scheme inference
+    //  of CLI button we want to fire mutate and make sure we get the latest
     useUpdateEffect(() => {
-        console.log('sup', {
-            schemaUpdated,
-            collectionInitializationDone,
-            mutate,
-        });
-        // If the schema is updated via the scheme inference
-        //  of CLI button we want to fire mutate and make sure we get the latest
-        // If the collection was initialized we need to fire mutate so that the collection
-        //  spec editor can refresh itself and know about the new draft we just created
-        //  for the collection
-        if (mutate && (schemaUpdated || collectionInitializationDone)) {
+        if (mutate && schemaUpdated) {
             void mutate();
         }
-    }, [mutate, schemaUpdated, collectionInitializationDone]);
+    }, [schemaUpdated]);
+
+    // If the collection was initialized we need to fire mutate so that the collection
+    //  spec editor can refresh itself and know about the new draft we just created
+    //  for the collection
+    useUpdateEffect(() => {
+        if (mutate && collectionInitializationDone) {
+            void mutate();
+        }
+    }, [mutate, collectionInitializationDone]);
 
     const onKeyChange = useCallback(
         async (_event, keys) => {

--- a/src/components/collection/schema/Editor/index.tsx
+++ b/src/components/collection/schema/Editor/index.tsx
@@ -1,4 +1,5 @@
 import { Grid, Stack, Typography } from '@mui/material';
+import { useBindingsEditorStore } from 'components/editor/Bindings/Store/create';
 import {
     useBindingsEditorStore_editModeEnabled,
     useBindingsEditorStore_inferSchemaResponseDoneProcessing,
@@ -38,6 +39,9 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
 
     // We need to know the schema was updated so we can "reload" this section
     const schemaUpdated = useBindingsEditorStore_schemaUpdated();
+    const collectionInitializationDone = useBindingsEditorStore(
+        (state) => state.collectionInitializationDone
+    );
 
     const setCollectionData = useBindingsEditorStore_setCollectionData();
 
@@ -75,12 +79,20 @@ function CollectionSchemaEditor({ entityName, localZustandScope }: Props) {
     ]);
 
     useUpdateEffect(() => {
+        console.log('sup', {
+            schemaUpdated,
+            collectionInitializationDone,
+            mutate,
+        });
         // If the schema is updated via the scheme inference
         //  of CLI button we want to fire mutate and make sure we get the latest
-        if (mutate && schemaUpdated) {
+        // If the collection was initialized we need to fire mutate so that the collection
+        //  spec editor can refresh itself and know about the new draft we just created
+        //  for the collection
+        if (mutate && (schemaUpdated || collectionInitializationDone)) {
             void mutate();
         }
-    }, [schemaUpdated]);
+    }, [mutate, schemaUpdated, collectionInitializationDone]);
 
     const onKeyChange = useCallback(
         async (_event, keys) => {

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -150,6 +150,7 @@ const getInitialMiscData = (): Pick<
     BindingsEditorState,
     | 'collectionData'
     | 'collectionInitializationAlert'
+    | 'collectionInitializationDone'
     | 'documentsRead'
     | 'inferredSchemaApplicationErrored'
     | 'inferredSpec'
@@ -169,6 +170,7 @@ const getInitialMiscData = (): Pick<
 > => ({
     collectionData: null,
     collectionInitializationAlert: null,
+    collectionInitializationDone: null,
     documentsRead: null,
     inferredSchemaApplicationErrored: false,
     inferredSpec: null,
@@ -224,6 +226,16 @@ const getInitialState = (
             }),
             false,
             'Collection Initialization Alert Set'
+        );
+    },
+
+    setCollectionInitializationDone: (value) => {
+        set(
+            produce((state: BindingsEditorState) => {
+                state.collectionInitializationDone = value;
+            }),
+            false,
+            'Collection Initialization Done Set'
         );
     },
 

--- a/src/components/editor/Bindings/Store/create.ts
+++ b/src/components/editor/Bindings/Store/create.ts
@@ -170,7 +170,7 @@ const getInitialMiscData = (): Pick<
 > => ({
     collectionData: null,
     collectionInitializationAlert: null,
-    collectionInitializationDone: null,
+    collectionInitializationDone: false,
     documentsRead: null,
     inferredSchemaApplicationErrored: false,
     inferredSpec: null,

--- a/src/components/editor/Bindings/Store/hooks.ts
+++ b/src/components/editor/Bindings/Store/hooks.ts
@@ -81,10 +81,6 @@ export const useBindingsEditorStore_schemaUpdated = () => {
     return useBindingsEditorStore((state) => state.schemaUpdated);
 };
 
-export const useBindingsEditorStore_setSchemaUpdated = () => {
-    return useBindingsEditorStore((state) => state.setSchemaUpdated);
-};
-
 export const useBindingsEditorStore_schemaUpdateErrored = () => {
     return useBindingsEditorStore((state) => state.schemaUpdateErrored);
 };

--- a/src/components/editor/Bindings/Store/types.ts
+++ b/src/components/editor/Bindings/Store/types.ts
@@ -8,7 +8,7 @@ export interface BindingsEditorState {
     collectionData: CollectionData | null | undefined;
     setCollectionData: (value: BindingsEditorState['collectionData']) => void;
 
-    collectionInitializationDone: null | boolean;
+    collectionInitializationDone: boolean;
     setCollectionInitializationDone: (
         value: BindingsEditorState['collectionInitializationDone']
     ) => void;

--- a/src/components/editor/Bindings/Store/types.ts
+++ b/src/components/editor/Bindings/Store/types.ts
@@ -8,6 +8,11 @@ export interface BindingsEditorState {
     collectionData: CollectionData | null | undefined;
     setCollectionData: (value: BindingsEditorState['collectionData']) => void;
 
+    collectionInitializationDone: null | boolean;
+    setCollectionInitializationDone: (
+        value: BindingsEditorState['collectionInitializationDone']
+    ) => void;
+
     collectionInitializationAlert: null | {
         severity: AlertColor;
         messageId: string;

--- a/src/components/editor/DraftSpec.tsx
+++ b/src/components/editor/DraftSpec.tsx
@@ -25,8 +25,6 @@ function DraftSpecEditor({
             monitorCurrentCatalog
         );
 
-    console.log('draftSpec', draftSpec);
-
     if (draftSpec) {
         return (
             <MonacoEditor

--- a/src/components/editor/DraftSpec.tsx
+++ b/src/components/editor/DraftSpec.tsx
@@ -7,6 +7,7 @@ export interface Props {
     localZustandScope?: boolean;
     editorHeight?: number;
     entityName?: string;
+    monitorCurrentCatalog?: boolean;
 }
 
 function DraftSpecEditor({
@@ -14,9 +15,17 @@ function DraftSpecEditor({
     localZustandScope = false,
     editorHeight,
     entityName,
+    monitorCurrentCatalog,
 }: Props) {
     const { draftSpec, isValidating, onChange, defaultValue } =
-        useDraftSpecEditor(entityName, localZustandScope);
+        useDraftSpecEditor(
+            entityName,
+            localZustandScope,
+            undefined,
+            monitorCurrentCatalog
+        );
+
+    console.log('draftSpec', draftSpec);
 
     if (draftSpec) {
         return (

--- a/src/components/editor/Store/hooks.ts
+++ b/src/components/editor/Store/hooks.ts
@@ -511,7 +511,7 @@ export const useEditorStore_queryResponse_isValidating = (
         EditorStoreState<DraftSpecQuery>['queryResponse']['isValidating']
     >(
         storeName(entityType, localScope),
-        (state) => state.queryResponse.isValidating
+        useShallow((state) => state.queryResponse.isValidating)
     );
 };
 
@@ -529,7 +529,10 @@ export const useEditorStore_queryResponse_mutate = (
     return useZustandStore<
         EditorStoreState<DraftSpecQuery>,
         EditorStoreState<DraftSpecQuery>['queryResponse']['mutate']
-    >(storeName(entityType, localScope), (state) => state.queryResponse.mutate);
+    >(
+        storeName(entityType, localScope),
+        useShallow((state) => state.queryResponse.mutate)
+    );
 };
 
 export const useEditorStore_queryResponse_draftedBindingIndex = (

--- a/src/components/shared/Entity/CatalogEditor.tsx
+++ b/src/components/shared/Entity/CatalogEditor.tsx
@@ -37,7 +37,10 @@ function CatalogEditor({ messageId }: Props) {
                     </Typography>
 
                     <Paper variant="outlined" sx={{ p: 1 }}>
-                        <DraftSpecEditor disabled={formActive} />
+                        <DraftSpecEditor
+                            disabled={formActive}
+                            monitorCurrentCatalog
+                        />
                     </Paper>
                 </ErrorBoundryWrapper>
             </WrapperWithHeader>

--- a/src/hooks/useDraftSpecEditor.ts
+++ b/src/hooks/useDraftSpecEditor.ts
@@ -28,6 +28,7 @@ function useDraftSpecEditor(
     const currentCatalog = useEditorStore_currentCatalog({
         localScope,
     });
+
     const setSpecs = useEditorStore_setSpecs({
         localScope,
     });
@@ -129,10 +130,18 @@ function useDraftSpecEditor(
     }, [currentCatalog, draftSpecs, entityName, setSpecs]);
 
     useEffect(() => {
-        if (currentCatalog && !isEqual(draftSpecRef.current, currentCatalog)) {
+        // Make sure that we only ever update the draftSpec after the currentCatalog has been updated
+        //  Otherwise the old binding will get populated while still waiting for the new one to get done
+        //  initializing and then it will show the PREVIOUS collection in the editor
+        if (
+            currentCatalog &&
+            currentCatalog.catalog_name === entityName &&
+            !isEqual(draftSpecRef.current, currentCatalog)
+        ) {
             setDraftSpec(currentCatalog);
+            draftSpecRef.current = currentCatalog;
         }
-    }, [currentCatalog]);
+    }, [currentCatalog, entityName]);
 
     // TODO (sync editing) : turning off as right now this will show lots of "Out of sync" errors
     //    because we are comparing two JSON objects that are being stringified and that means the order

--- a/src/hooks/useDraftSpecEditor.ts
+++ b/src/hooks/useDraftSpecEditor.ts
@@ -16,7 +16,8 @@ import { Entity } from 'types';
 function useDraftSpecEditor(
     entityName: string | undefined,
     localScope?: boolean,
-    editorSchemaScope?: string
+    editorSchemaScope?: string,
+    monitorCurrentCatalog?: boolean
 ) {
     // Local State
     // We store off a ref and a state so we can constantly do compares against
@@ -107,6 +108,7 @@ function useDraftSpecEditor(
         [draftId, draftSpec, mutate]
     );
 
+    // This is mainly for the binding collection editing
     useEffect(() => {
         if (draftSpecs.length > 0) {
             setSpecs(draftSpecs);
@@ -129,29 +131,16 @@ function useDraftSpecEditor(
         }
     }, [currentCatalog, draftSpecs, entityName, setSpecs]);
 
-    // TODO (sync editing) : turning off as right now this will show lots of "Out of sync" errors
-    //    because we are comparing two JSON objects that are being stringified and that means the order
-    //    change change whenever. We should probably compare the two objects and THEN if those do not match
-    //    show an error/diff editor.
-    //
-    // useEffectOnce(() => {
-    //     const publicationSubscription = supabaseClient
-    //         .from(TABLES.DRAFT_SPECS)
-    //         .on('*', async (payload: any) => {
-    //             if (payload.new.spec) {
-    //                 setServerUpdates(payload.new.spec);
-    //             }
-    //         })
-    //         .subscribe();
-
-    //     setSubscription(publicationSubscription);
-
-    //     return () => {
-    //         if (subscription) {
-    //             void supabaseClient.removeSubscription(subscription);
-    //         }
-    //     };
-    // });
+    // This for advanced spec editor
+    useEffect(() => {
+        if (
+            monitorCurrentCatalog &&
+            currentCatalog &&
+            !isEqual(draftSpecRef.current, currentCatalog)
+        ) {
+            setDraftSpec(currentCatalog);
+        }
+    }, [currentCatalog, monitorCurrentCatalog]);
 
     // TODO (draftSpecEditor) need to better handle returning so we are not causing extra renders
     return useMemo(() => {

--- a/src/hooks/useDraftSpecEditor.ts
+++ b/src/hooks/useDraftSpecEditor.ts
@@ -129,20 +129,6 @@ function useDraftSpecEditor(
         }
     }, [currentCatalog, draftSpecs, entityName, setSpecs]);
 
-    useEffect(() => {
-        // Make sure that we only ever update the draftSpec after the currentCatalog has been updated
-        //  Otherwise the old binding will get populated while still waiting for the new one to get done
-        //  initializing and then it will show the PREVIOUS collection in the editor
-        if (
-            currentCatalog &&
-            currentCatalog.catalog_name === entityName &&
-            !isEqual(draftSpecRef.current, currentCatalog)
-        ) {
-            setDraftSpec(currentCatalog);
-            draftSpecRef.current = currentCatalog;
-        }
-    }, [currentCatalog, entityName]);
-
     // TODO (sync editing) : turning off as right now this will show lots of "Out of sync" errors
     //    because we are comparing two JSON objects that are being stringified and that means the order
     //    change change whenever. We should probably compare the two objects and THEN if those do not match

--- a/src/hooks/useInitializeCollectionDraft.ts
+++ b/src/hooks/useInitializeCollectionDraft.ts
@@ -4,6 +4,7 @@ import {
     getLiveSpecsByCatalogName,
     LiveSpecsExtQuery_ByCatalogName,
 } from 'api/liveSpecsExt';
+import { useBindingsEditorStore } from 'components/editor/Bindings/Store/create';
 import {
     useBindingsEditorStore_resetState,
     useBindingsEditorStore_setCollectionData,
@@ -48,6 +49,9 @@ const getCollection = async (
 
 function useInitializeCollectionDraft() {
     // Bindings Editor Store
+    const setCollectionInitializationDone = useBindingsEditorStore(
+        (state) => state.setCollectionInitializationDone
+    );
     const setCollectionData = useBindingsEditorStore_setCollectionData();
     const setCollectionInitializationAlert =
         useBindingsEditorStore_setCollectionInitializationAlert();
@@ -119,8 +123,14 @@ function useInitializeCollectionDraft() {
                         'workflows.collectionSelector.error.message.draftCreationFailed',
                 });
             }
+
+            setCollectionInitializationDone(true);
         },
-        [setCollectionInitializationAlert, updateBindingsEditorState]
+        [
+            setCollectionInitializationAlert,
+            setCollectionInitializationDone,
+            updateBindingsEditorState,
+        ]
     );
 
     const getCollectionDraftSpecs = useCallback(
@@ -150,6 +160,7 @@ function useInitializeCollectionDraft() {
                     });
 
                     if (lastPubId && expectedPubId !== lastPubId) {
+                        setCollectionInitializationDone(false);
                         setCollectionInitializationAlert({
                             severity: 'warning',
                             messageId:
@@ -226,6 +237,7 @@ function useInitializeCollectionDraft() {
         [
             createCollectionDraftSpec,
             setCollectionInitializationAlert,
+            setCollectionInitializationDone,
             setDraftId,
             setLocalDraftId,
             setPersistedDraftId,

--- a/src/hooks/useInitializeCollectionDraft.ts
+++ b/src/hooks/useInitializeCollectionDraft.ts
@@ -111,20 +111,21 @@ function useInitializeCollectionDraft() {
                     spec: newDraftSpecResponse.data[0].spec,
                     belongsToDraft: true,
                 });
+
+                setCollectionInitializationDone(true);
             } else {
                 updateBindingsEditorState({
                     spec: liveSpec,
                     belongsToDraft: false,
                 });
 
+                setCollectionInitializationDone(false);
                 setCollectionInitializationAlert({
                     severity: 'warning',
                     messageId:
                         'workflows.collectionSelector.error.message.draftCreationFailed',
                 });
             }
-
-            setCollectionInitializationDone(true);
         },
         [
             setCollectionInitializationAlert,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1166

## Changes

### 1166

- Add a initialization done flag so we know to not try to render until ready
- Ensure the draft initializer fires a mutate so that the parent hydrator knows to fetch the recently made draft.
- Ensure the catalog name matches when starting up editing

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [x] Captures
-   [x] Collections
-   [ ] HomePage
-   [ ] Login
-   [x] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
