### PR TITLE
Try to make stats filtering a bit more obvious to users

### DIFF
--- a/src/components/filters/Date/index.tsx
+++ b/src/components/filters/Date/index.tsx
@@ -81,7 +81,7 @@ function DateFilter({ disabled, header, selectableTableStoreName }: Props) {
                 variant="text"
                 color="primary"
                 sx={{ whiteSpace: 'nowrap' }}
-                startIcon={<Calendar style={{ fontSize: 13 }} />}
+                endIcon={<Calendar style={{ fontSize: 13 }} />}
             >
                 <FormattedMessage id={`filter.time.${statsFilter}`} />
             </Button>

--- a/src/components/filters/Date/index.tsx
+++ b/src/components/filters/Date/index.tsx
@@ -1,7 +1,6 @@
 import {
-    CircularProgress,
+    Button,
     Divider,
-    IconButton,
     ListItem,
     Menu,
     Stack,
@@ -9,7 +8,7 @@ import {
 } from '@mui/material';
 import { StatsFilter } from 'api/stats';
 import { useZustandStore } from 'context/Zustand/provider';
-import { Filter } from 'iconoir-react';
+import { Calendar } from 'iconoir-react';
 import React, { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { SelectTableStoreNames } from 'stores/names';
@@ -41,11 +40,6 @@ function DateFilter({ disabled, header, selectableTableStoreName }: Props) {
         SelectableTableStore['setStatsFilter']
     >(selectableTableStoreName, selectableTableStoreSelectors.statsFilter.set);
 
-    const stats = useZustandStore<
-        SelectableTableStore,
-        SelectableTableStore['stats']
-    >(selectableTableStoreName, selectableTableStoreSelectors.stats.get);
-
     const handlers = {
         closeMenu: () => {
             setAnchorEl(null);
@@ -73,7 +67,7 @@ function DateFilter({ disabled, header, selectableTableStoreName }: Props) {
                 {header}
             </Typography>
 
-            <IconButton
+            <Button
                 id="stat-filter-selector-button"
                 aria-controls={open ? 'stat-filter-selector-menu' : undefined}
                 aria-haspopup="true"
@@ -84,14 +78,13 @@ function DateFilter({ disabled, header, selectableTableStoreName }: Props) {
                 )}
                 onClick={handlers.openMenu}
                 disabled={disabled}
+                variant="text"
                 color="primary"
+                sx={{ whiteSpace: 'nowrap' }}
+                startIcon={<Calendar style={{ fontSize: 13 }} />}
             >
-                {!disabled && stats === null ? (
-                    <CircularProgress size={15} />
-                ) : (
-                    <Filter style={{ fontSize: 13 }} />
-                )}
-            </IconButton>
+                <FormattedMessage id={`filter.time.${statsFilter}`} />
+            </Button>
 
             <Menu
                 id="stat-filter-selector-menu"

--- a/src/components/tables/cells/stats/Bytes.tsx
+++ b/src/components/tables/cells/stats/Bytes.tsx
@@ -1,6 +1,6 @@
 import { Box, TableCell, Tooltip, Typography } from '@mui/material';
 import useHideStatsColumnsSx from 'components/tables/hooks/useHideStatsColumnsSx';
-import { semiTransparentBackgroundIntensified } from 'context/Theme';
+import { textloadingColor } from 'context/Theme';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { formatBytes } from './shared';
@@ -39,9 +39,7 @@ const Bytes = ({ read, val }: Props) => {
                             transitionDelay: statsLoading ? '800ms' : '0ms',
                             color: (theme) =>
                                 statsLoading
-                                    ? semiTransparentBackgroundIntensified[
-                                          theme.palette.mode
-                                      ]
+                                    ? textloadingColor[theme.palette.mode]
                                     : null,
                         }}
                     >

--- a/src/components/tables/cells/stats/Docs.tsx
+++ b/src/components/tables/cells/stats/Docs.tsx
@@ -1,6 +1,6 @@
 import { Box, TableCell, Tooltip, Typography } from '@mui/material';
 import useHideStatsColumnsSx from 'components/tables/hooks/useHideStatsColumnsSx';
-import { semiTransparentBackgroundIntensified } from 'context/Theme';
+import { textloadingColor } from 'context/Theme';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { formatDocs } from './shared';
@@ -39,9 +39,7 @@ const Docs = ({ read, val }: Props) => {
                             transitionDelay: statsLoading ? '800ms' : '0ms',
                             color: (theme) =>
                                 statsLoading
-                                    ? semiTransparentBackgroundIntensified[
-                                          theme.palette.mode
-                                      ]
+                                    ? textloadingColor[theme.palette.mode]
                                     : null,
                         }}
                     >

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -355,6 +355,11 @@ export const semiTransparentBackgroundIntensified = {
     dark: 'rgba(247, 249, 252, 0.08)',
 };
 
+export const textloadingColor = {
+    light: 'rgba(11, 19, 30, 0.4)',
+    dark: 'rgba(247, 249, 252, 0.4)',
+};
+
 export const jsonFormsGroupHeaders = {
     light: 'white',
     dark: 'transparent',


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1163

## Changes

### 1163

- Switch icon to a calendar
- Show which option is currently selected

## Tests

### Manually tested

- Messed with tables a bit... no true functionality changes

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/1f6168e4-7e74-42f1-bcb7-c0206b5814be)

![image](https://github.com/user-attachments/assets/da746d7c-f6a0-45f0-92c5-de770eba09a9)

