### PR TITLE
add initial CSP config

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -64,6 +64,7 @@ http {
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy no-referrer-when-downgrade always;
             add_header Permissions-Policy "geolocation=(), microphone=(), camera=() always";
+            add_header Content-Security-Policy "default-src https:";
 
             # Here to serve our T&C doc
             location /terms.html {


### PR DESCRIPTION
## Issues

https://github.com/estuary/security/issues/100

## Changes

-   This adds an initial CSP configuration to only allow HTTPS connections. We'll narrow it down later. 
