### PR TITLE
User `CI` command for ci npm installs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
                   scope: '@estuary'
 
             - name: Get Deps
-              run: npm install
+              run: npm ci
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,7 +50,7 @@ jobs:
                   cache-dependency-path: '**/package-lock.json'
 
             - name: Get Deps
-              run: npm install
+              run: npm ci
 
             - name: Licenses
               run: npm run licenses
@@ -97,7 +97,7 @@ jobs:
                   cache-dependency-path: '**/package-lock.json'
 
             - name: Get Deps
-              run: npm install
+              run: npm ci
 
             - name: Create a release build
               run: npm run build


### PR DESCRIPTION
## Issues

tech debt / security

## Changes

- Use the `ci` command instead of `install` ensure the `package-lock` file is followed. This will _slightly_ reduce the surface area of a supply chain attack.

## Tests

N/A

#### Playwright tests ran locally

N/A

## Screenshots

N/A
