### PR TITLE
Removed disabled collections from draft

### DIFF
--- a/playwright-tests/tests/admin.spec.ts
+++ b/playwright-tests/tests/admin.spec.ts
@@ -17,7 +17,7 @@ import {
 
 const invalidEmail = 'Fake_Invalid_Email';
 const testTokens = ['test token 1', 'test token 2', 'test token 3'];
-test.describe.serial.only('Admin:', () => {
+test.describe.serial('Admin:', () => {
     const uuid = crypto.randomUUID().split('-')[0];
     const userName = `${USERS.admin}_${uuid}`;
     const tenant = `${userName}/`;

--- a/src/components/shared/Entity/Actions/useSave.ts
+++ b/src/components/shared/Entity/Actions/useSave.ts
@@ -31,6 +31,7 @@ import useNotificationStore, {
     notificationStoreSelectors,
 } from 'stores/NotificationStore';
 import { hasLength } from 'utils/misc-utils';
+import { useEntityType } from 'context/EntityContext';
 
 const trackEvent = (logEvent: any, payload: any) => {
     logRocketEvent(logEvent, {
@@ -74,9 +75,11 @@ function useSave(
         notificationStoreSelectors.showNotification
     );
 
+    const entityType = useEntityType();
+
     const collections = useBinding_collections();
     const fullSourceErrorsExist = useBinding_fullSourceErrorsExist();
-    const disabledBindings = useBinding_disabledBindings();
+    const disabledBindings = useBinding_disabledBindings(entityType);
 
     const waitForPublishToFinish = useCallback(
         (publicationId: string, hideNotification?: boolean) => {
@@ -231,7 +234,8 @@ function useSave(
                             (collection) => !collections.includes(collection)
                         );
 
-                    // For a test we do not want to remove
+                    // For a test we do not want to remove from draft - otherwise we would need
+                    //  to add them back in after the test.
                     const disabledCollections: string[] = dryRun
                         ? []
                         : disabledBindings;

--- a/src/components/shared/Entity/Actions/useSave.ts
+++ b/src/components/shared/Entity/Actions/useSave.ts
@@ -17,6 +17,7 @@ import { DEFAULT_FILTER } from 'services/supabase';
 import { CustomEvents } from 'services/types';
 import {
     useBinding_collections,
+    useBinding_disabledBindings,
     useBinding_fullSourceErrorsExist,
 } from 'stores/Binding/hooks';
 import { useDetailsFormStore } from 'stores/DetailsForm/Store';
@@ -75,6 +76,7 @@ function useSave(
 
     const collections = useBinding_collections();
     const fullSourceErrorsExist = useBinding_fullSourceErrorsExist();
+    const disabledBindings = useBinding_disabledBindings();
 
     const waitForPublishToFinish = useCallback(
         (publicationId: string, hideNotification?: boolean) => {
@@ -229,11 +231,16 @@ function useSave(
                             (collection) => !collections.includes(collection)
                         );
 
+                    // For a test we do not want to remove
+                    const disabledCollections: string[] = dryRun
+                        ? []
+                        : disabledBindings;
+
                     const deleteDraftSpecsResponse =
                         await deleteDraftSpecsByCatalogName(
                             draftId,
                             'collection',
-                            unboundCollections
+                            [...unboundCollections, ...disabledCollections]
                         );
                     if (deleteDraftSpecsResponse.error) {
                         return onFailure({
@@ -270,6 +277,7 @@ function useSave(
         },
         [
             collections,
+            disabledBindings,
             dryRun,
             entityDescription,
             fullSourceErrorsExist,

--- a/src/directives/Onboard/OrganizationName.tsx
+++ b/src/directives/Onboard/OrganizationName.tsx
@@ -23,12 +23,14 @@ function OrganizationNameField() {
     };
 
     return (
-        <FormControl>
-            <FormLabel id="origin" required sx={{ mb: 1, fontSize: 16 }}>
+        <FormControl error={nameMissing || nameInvalid}>
+            <FormLabel id="origin" required sx={{ mb: 1, fontSize: 20 }}>
                 <FormattedMessage id="tenant.input.label" />
             </FormLabel>
 
             <TextField
+                autoComplete="organization"
+                autoFocus
                 error={nameMissing || nameInvalid}
                 helperText={intl.formatMessage({
                     id:
@@ -45,6 +47,7 @@ function OrganizationNameField() {
                 required
                 size="small"
                 value={requestedTenant}
+                variant="outlined"
                 sx={{
                     'maxWidth': 424,
                     '& .MuiInputBase-root': { borderRadius: 3 },

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -230,6 +230,7 @@ const getInitialMiscData = (): Pick<
     | 'backfillAllBindings'
     | 'backfilledBindings'
     | 'collectionsRequiringRediscovery'
+    | 'disabledCollections'
     | 'discoveredCollections'
     | 'rediscoveryRequired'
     | 'resourceConfigErrorsExist'
@@ -242,6 +243,7 @@ const getInitialMiscData = (): Pick<
     backfillAllBindings: false,
     backfilledBindings: [],
     collectionsRequiringRediscovery: [],
+    disabledCollections: new Set(),
     discoveredCollections: [],
     rediscoveryRequired: false,
     resourceConfigErrorsExist: false,
@@ -367,6 +369,7 @@ const getInitialState = (
 
                 state.rediscoveryRequired = false;
                 state.collectionsRequiringRediscovery = [];
+                state.disabledCollections.clear();
 
                 state.backfilledBindings = [];
                 state.backfillAllBindings = false;
@@ -1038,6 +1041,7 @@ const getInitialState = (
                                         collectionRequiringRediscovery ===
                                         collectionName
                                 );
+
                             if (existingIndex > -1) {
                                 state.collectionsRequiringRediscovery.splice(
                                     existingIndex,
@@ -1048,6 +1052,8 @@ const getInitialState = (
                                     state.collectionsRequiringRediscovery
                                 );
                             }
+
+                            state.disabledCollections.add(collectionName);
                         } else {
                             delete state.resourceConfigs[uuid].meta.disable;
 
@@ -1058,6 +1064,8 @@ const getInitialState = (
 
                                 state.rediscoveryRequired = true;
                             }
+
+                            state.disabledCollections.delete(collectionName);
                         }
                     });
                 }),

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -215,6 +215,20 @@ export const useBinding_someBindingsDisabled = () => {
     );
 };
 
+export const useBinding_disabledBindings = () => {
+    return useZustandStore<BindingState, string[]>(
+        BindingStoreNames.GENERAL,
+        useShallow((state) => Array.from(state.disabledCollections.keys()))
+    );
+};
+
+export const useBinding_collectionsRequiringRediscovery = () => {
+    return useZustandStore<BindingState, string[]>(
+        BindingStoreNames.GENERAL,
+        useShallow((state) => state.collectionsRequiringRediscovery)
+    );
+};
+
 export const useBinding_bindingErrorsExist = () => {
     return useZustandStore<BindingState, BindingState['bindingErrorsExist']>(
         BindingStoreNames.GENERAL,

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -1,5 +1,6 @@
 import { useZustandStore } from 'context/Zustand/provider';
 import { BindingStoreNames } from 'stores/names';
+import { Entity } from 'types';
 import { useShallow } from 'zustand/react/shallow';
 import { FullSource, FullSourceJsonForms } from './slices/TimeTravel';
 import { BindingState, ResourceConfig } from './types';
@@ -215,10 +216,16 @@ export const useBinding_someBindingsDisabled = () => {
     );
 };
 
-export const useBinding_disabledBindings = () => {
+// We are only using this to clean up - hence checking for `capture` here because that
+//  is the only entity that we want to clean up disabled collections
+export const useBinding_disabledBindings = (entityType: Entity) => {
     return useZustandStore<BindingState, string[]>(
         BindingStoreNames.GENERAL,
-        useShallow((state) => Array.from(state.disabledCollections.keys()))
+        useShallow((state) =>
+            entityType === 'capture'
+                ? Array.from(state.disabledCollections.keys())
+                : []
+        )
     );
 };
 

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -229,13 +229,6 @@ export const useBinding_disabledBindings = (entityType: Entity) => {
     );
 };
 
-export const useBinding_collectionsRequiringRediscovery = () => {
-    return useZustandStore<BindingState, string[]>(
-        BindingStoreNames.GENERAL,
-        useShallow((state) => state.collectionsRequiringRediscovery)
-    );
-};
-
 export const useBinding_bindingErrorsExist = () => {
     return useZustandStore<BindingState, BindingState['bindingErrorsExist']>(
         BindingStoreNames.GENERAL,

--- a/src/stores/Binding/types.ts
+++ b/src/stores/Binding/types.ts
@@ -77,6 +77,7 @@ export interface BindingState
     ) => void;
 
     collectionsRequiringRediscovery: string[];
+    disabledCollections: Set<string>;
     rediscoveryRequired: boolean;
     resetRediscoverySettings: () => void;
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1183

## Changes

### 1183

- Removed disabled collections during `save` for `captures`

## Tests

### Manually tested

- Ran a create and edit with/without disabled bindings

### Automated tests

#### Playwright tests ran locally

-   [x] Admin
-   [x] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [x] Materialization (field refresh failed)

## Screenshots

N/A
