### PR TITLE
Disable include action for forbidden and unsatisfiable fields

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -42,6 +42,7 @@ import { FormStatus } from 'stores/FormState/types';
 import { Schema } from 'types';
 import { BooleanParam, useQueryParam } from 'use-query-params';
 import {
+    evaluateRequiredExcludedFields,
     evaluateRequiredIncludedFields,
     getBindingIndex,
 } from 'utils/workflow-utils';
@@ -89,7 +90,15 @@ const mapConstraintsToProjections = (
                     constraint.type
                 );
 
-                selectionType = includeRequired ? 'include' : null;
+                const excludeRequired = evaluateRequiredExcludedFields(
+                    constraint.type
+                );
+
+                selectionType = includeRequired
+                    ? 'include'
+                    : excludeRequired
+                    ? 'exclude'
+                    : null;
             }
         }
 

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -90,13 +90,9 @@ const mapConstraintsToProjections = (
                     constraint.type
                 );
 
-                const excludeRequired = evaluateRequiredExcludedFields(
-                    constraint.type
-                );
-
                 selectionType = includeRequired
                     ? 'include'
-                    : excludeRequired
+                    : evaluateRequiredExcludedFields(constraint.type)
                     ? 'exclude'
                     : null;
             }

--- a/src/components/tables/cells/fieldSelection/FieldActions.tsx
+++ b/src/components/tables/cells/fieldSelection/FieldActions.tsx
@@ -15,6 +15,7 @@ import {
 import { useFormStateStore_isActive } from 'stores/FormState/hooks';
 import {
     evaluateRecommendedIncludedFields,
+    evaluateRequiredExcludedFields,
     evaluateRequiredIncludedFields,
 } from 'utils/workflow-utils';
 
@@ -55,6 +56,8 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
         constraint.type
     );
 
+    const excludeRequired = evaluateRequiredExcludedFields(constraint.type);
+
     const coloredIncludeButton =
         selectedValue === 'default' && includeRecommended;
 
@@ -78,7 +81,9 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
                     value="include"
                     coloredDefaultState={coloredIncludeButton}
                     disabled={
-                        formActive || (includeRequired && !recommendFields)
+                        formActive ||
+                        excludeRequired ||
+                        (includeRequired && !recommendFields)
                     }
                     onClick={() => {
                         const singleValue =
@@ -105,7 +110,9 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
                     disabled={includeRequired || formActive}
                     onClick={() => {
                         const singleValue =
-                            selectedValue !== 'exclude' ? 'exclude' : null;
+                            selectedValue !== 'exclude' || excludeRequired
+                                ? 'exclude'
+                                : null;
 
                         const selectionType = evaluateSelectionType(
                             recommendFields[bindingUUID],

--- a/src/components/tables/cells/fieldSelection/FieldActions.tsx
+++ b/src/components/tables/cells/fieldSelection/FieldActions.tsx
@@ -107,7 +107,11 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
                     selectedValue={selectedValue}
                     value="exclude"
                     coloredDefaultState={coloredExcludeButton}
-                    disabled={includeRequired || formActive}
+                    disabled={
+                        formActive ||
+                        includeRequired ||
+                        (excludeRequired && !recommendFields)
+                    }
                     onClick={() => {
                         const singleValue =
                             selectedValue !== 'exclude' || excludeRequired

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -357,7 +357,10 @@ export const evaluateRecommendedIncludedFields = (
 export const evaluateRequiredExcludedFields = (
     constraintType: ConstraintTypes
 ): boolean => {
-    return constraintType === ConstraintTypes.FIELD_FORBIDDEN;
+    return (
+        constraintType === ConstraintTypes.FIELD_FORBIDDEN ||
+        constraintType === ConstraintTypes.UNSATISFIABLE
+    );
 };
 
 export interface ConnectorVersionEvaluationOptions {

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -354,6 +354,12 @@ export const evaluateRecommendedIncludedFields = (
     );
 };
 
+export const evaluateRequiredExcludedFields = (
+    constraintType: ConstraintTypes
+): boolean => {
+    return constraintType === ConstraintTypes.FIELD_FORBIDDEN;
+};
+
 export interface ConnectorVersionEvaluationOptions {
     connectorId: string;
     existingImageTag: string;


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1186

## Changes

### 1186

The following features are included in this PR:

* Disable the _Include_ field action for forbidden and unsatisfiable fields.

* Mark forbidden fields as being excluded by default when the draft is evaluated in the UI (i.e., `mapConstraintsToProjections` in _src/component/editor/Bindings/FieldSelections/index.tsx_).

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the _Include_ field action is always disabled for forbidden fields. `estuary/stripe/materialize-postgres` is a materialization in production that has at least one forbidden field.

### Automated tests

N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**Forbidden field row**

<img width="502" alt="pr_screenshot-1169-forbidden_field-rec_flag_true" src="https://github.com/user-attachments/assets/9db6d2ae-a84b-49a7-ba4e-5b103bd60353">
