### PR TITLE
Fix table pagination when using back button

### DIFF
--- a/src/components/admin/Billing/TenantOptions.tsx
+++ b/src/components/admin/Billing/TenantOptions.tsx
@@ -26,7 +26,7 @@ function TenantOptions() {
     const updateStoreState = useCallback(() => {
         resetBillingState();
 
-        resetBillingSelectTableState();
+        resetBillingSelectTableState(false);
         setHydrated(false);
         setHydrationErrorsExist(false);
     }, [

--- a/src/components/tables/EntityTable/TableFooter.tsx
+++ b/src/components/tables/EntityTable/TableFooter.tsx
@@ -56,9 +56,9 @@ function EntityTableFooter({
                 </TableRow>
             </TableFooter>
         );
-    } else {
-        return null;
     }
+
+    return null;
 }
 
 export default EntityTableFooter;

--- a/src/components/tables/EntityTable/index.tsx
+++ b/src/components/tables/EntityTable/index.tsx
@@ -80,7 +80,6 @@ interface Props {
     tableAriaLabelKey?: string;
 }
 
-// WARNING - You MUST include a count with your query or else pagination breaks
 function EntityTable({
     columns,
     noExistingDataContentIds,

--- a/src/stores/Tables/Hydrator.tsx
+++ b/src/stores/Tables/Hydrator.tsx
@@ -75,8 +75,8 @@ export const TableHydrator = ({
     useUnmount(() => {
         setDisableMultiSelect(false);
 
-        // TODO (https://github.com/estuary/ui/issues/815)
-        resetState();
+        // TODO (cache) https://github.com/estuary/ui/issues/815
+        resetState(true);
     });
 
     // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/stores/Tables/Store.ts
+++ b/src/stores/Tables/Store.ts
@@ -69,7 +69,7 @@ export interface SelectableTableStore extends StoreWithHydration {
     successfulTransformations: number;
     incrementSuccessfulTransformations: () => void;
 
-    resetState: () => void;
+    resetState: (keepCount: boolean) => void;
 
     setQuery: (query: PostgrestFilterBuilder<any, any, any>) => void;
     query: AsyncOperationProps;
@@ -388,12 +388,29 @@ export const getInitialState = (
             );
         },
 
-        resetState: () => {
+        resetState: (keepCount) => {
+            // Safe to use `set` and `get` together here
+            const previousCount = get().query.count;
+
             set(
                 { ...getInitialStateData(), ...getInitialHydrationData() },
                 false,
                 'Resetting State'
             );
+
+            // We do not always want to reset the `count` because we only fetch count
+            //  when a user is on the first page of a table. Keeping `count` around after
+            //  reset means they can easily click the back button and come back to a table
+            //  that has pagination enabled.
+            if (keepCount) {
+                set(
+                    produce((state: SelectableTableStore) => {
+                        state.query.count = previousCount;
+                    }),
+                    false,
+                    'Resetting State - Add Count Again'
+                );
+            }
         },
 
         hydrate: async () => {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1190

## Changes

### 1190

-  Allow tables to keep the `count` around after resetting

## Tests

### Manually tested

- Clicked around on tables and hitting back button
- Slowed network and messed with connectivity

### Automated tests

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

N/A