### PR TITLE
Ensure the original order of discovered bindings is maintained

### DIFF
--- a/src/api/draftSpecs.ts
+++ b/src/api/draftSpecs.ts
@@ -34,6 +34,7 @@ interface DraftSpecData {
     spec: any;
     catalog_name?: string;
     expect_pub_id?: string;
+    detail?: string;
 }
 
 export const createDraftSpec = (
@@ -61,7 +62,8 @@ export const modifyDraftSpec = (
     draftSpec: any,
     matchData: UpdateMatchData,
     catalogName?: string | null,
-    lastPubId?: string | null
+    lastPubId?: string | null,
+    detail?: string
 ) => {
     let data: DraftSpecData = { spec: draftSpec };
 
@@ -75,6 +77,10 @@ export const modifyDraftSpec = (
 
     if (lastPubId) {
         data = { ...data, expect_pub_id: lastPubId };
+    }
+
+    if (detail) {
+        data = { ...data, detail };
     }
 
     return updateSupabase(TABLES.DRAFT_SPECS, data, matchData);

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -20,7 +20,6 @@ import {
     useBinding_currentBindingUUID,
     useBinding_resourceConfigs,
 } from 'stores/Binding/hooks';
-import { sortResourceConfigs } from 'stores/Binding/Store';
 import { BindingState } from 'stores/Binding/types';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
@@ -124,24 +123,19 @@ function CollectionSelectorList({
             return [];
         }
 
-        // We need to sort here so we have more control over how things are being sorted.
-        //  Since DataGrid only allows to sort by a single criterian at a time we just handle
-        //  sorting here. That way we can sort by disabled and then by name.
-        return Object.entries(sortResourceConfigs(resourceConfigs)).map(
-            ([bindingUUID, config]) => {
-                const collection = config.meta.collectionName;
+        // We have bindings so need to format them in a format that mui
+        //  datagrid will handle. At a minimum each object must have an
+        //  `id` property.
+        return Object.entries(resourceConfigs).map(([bindingUUID, config]) => {
+            const collection = config.meta.collectionName;
 
-                // We have bindings so need to format them in a format that mui
-                //  datagrid will handle. At a minimum each object must have an
-                //  `id` property.
-                return {
-                    [COLLECTION_SELECTOR_UUID_COL]: bindingUUID,
-                    [COLLECTION_SELECTOR_NAME_COL]: collection,
-                    [COLLECTION_SELECTOR_STRIPPED_PATH_NAME]:
-                        stripPathing(collection),
-                };
-            }
-        );
+            return {
+                [COLLECTION_SELECTOR_UUID_COL]: bindingUUID,
+                [COLLECTION_SELECTOR_NAME_COL]: collection,
+                [COLLECTION_SELECTOR_STRIPPED_PATH_NAME]:
+                    stripPathing(collection),
+            };
+        });
     }, [resourceConfigs]);
 
     const rowsEmpty = useMemo(() => !hasLength(rows), [rows]);

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -20,6 +20,7 @@ import {
     useBinding_currentBindingUUID,
     useBinding_resourceConfigs,
 } from 'stores/Binding/hooks';
+import { sortResourceConfigs } from 'stores/Binding/Store';
 import { BindingState } from 'stores/Binding/types';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
@@ -123,19 +124,24 @@ function CollectionSelectorList({
             return [];
         }
 
-        // We have bindings so need to format them in a format that mui
-        //  datagrid will handle. At a minimum each object must have an
-        //  `id` property.
-        return Object.entries(resourceConfigs).map(([bindingUUID, config]) => {
-            const collection = config.meta.collectionName;
+        // We need to sort here so we have more control over how things are being sorted.
+        //  Since DataGrid only allows to sort by a single criterian at a time we just handle
+        //  sorting here. That way we can sort by disabled and then by name.
+        return Object.entries(sortResourceConfigs(resourceConfigs)).map(
+            ([bindingUUID, config]) => {
+                const collection = config.meta.collectionName;
 
-            return {
-                [COLLECTION_SELECTOR_UUID_COL]: bindingUUID,
-                [COLLECTION_SELECTOR_NAME_COL]: collection,
-                [COLLECTION_SELECTOR_STRIPPED_PATH_NAME]:
-                    stripPathing(collection),
-            };
-        });
+                // We have bindings so need to format them in a format that mui
+                //  datagrid will handle. At a minimum each object must have an
+                //  `id` property.
+                return {
+                    [COLLECTION_SELECTOR_UUID_COL]: bindingUUID,
+                    [COLLECTION_SELECTOR_NAME_COL]: collection,
+                    [COLLECTION_SELECTOR_STRIPPED_PATH_NAME]:
+                        stripPathing(collection),
+                };
+            }
+        );
     }, [resourceConfigs]);
 
     const rowsEmpty = useMemo(() => !hasLength(rows), [rows]);

--- a/src/components/shared/Entity/Details/Overview/TotalsSection.tsx
+++ b/src/components/shared/Entity/Details/Overview/TotalsSection.tsx
@@ -16,7 +16,6 @@ interface Props {
 // TODO (details) want to make some kidn of summary of totals and potentially
 //  include the cost. Leaving here as this can be used lated when we add this section
 function TotalsSection({ entityName }: Props) {
-    console.log('entityname', entityName);
     const intl = useIntl();
     const entityType = useEntityType();
 

--- a/src/context/User/index.tsx
+++ b/src/context/User/index.tsx
@@ -22,8 +22,6 @@ const UserStoreProvider = ({ children }: BaseComponentProps) => {
             async (event, change_session) => {
                 logRocketConsole('Auth:Event:', event);
 
-                console.log('change_session', change_session);
-
                 if (event === 'INITIAL_SESSION') {
                     setInitialized(true);
                 }

--- a/src/hooks/useDraftSpecEditor.ts
+++ b/src/hooks/useDraftSpecEditor.ts
@@ -93,7 +93,7 @@ function useDraftSpecEditor(
                     },
                     undefined,
                     undefined,
-                    'Updated with Advanced Editor'
+                    'Manually Edited'
                 );
 
                 if (updateResponse.error) {

--- a/src/hooks/useDraftSpecEditor.ts
+++ b/src/hooks/useDraftSpecEditor.ts
@@ -84,11 +84,17 @@ function useDraftSpecEditor(
                 });
 
                 // Update only the SPEC on the server
-                const updateResponse = await modifyDraftSpec(updatedSpec, {
-                    draft_id: draftId,
-                    catalog_name: catalogName,
-                    spec_type: specType,
-                });
+                const updateResponse = await modifyDraftSpec(
+                    updatedSpec,
+                    {
+                        draft_id: draftId,
+                        catalog_name: catalogName,
+                        spec_type: specType,
+                    },
+                    undefined,
+                    undefined,
+                    'Updated with Advanced Editor'
+                );
 
                 if (updateResponse.error) {
                     return Promise.reject();

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -1,4 +1,4 @@
-import { FETCH_DEFAULT_ERROR } from './shared';
+import { FETCH_DEFAULT_ERROR, logRocketConsole } from './shared';
 
 export interface ClientConfig<T> extends RequestInit {
     data?: T;
@@ -46,7 +46,7 @@ export const client = <Response, Request = {}>(
             }
         })
         .catch((error) => {
-            console.log('fetchPromise:error', error);
+            logRocketConsole('fetchPromise:error', error);
             return Promise.reject({
                 message: returnOriginalMessage
                     ? error.message

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -376,6 +376,9 @@ const getInitialState = (
                 state.backfilledBindings = [];
                 state.backfillAllBindings = false;
 
+                // TODO (perf) - we could probably go ahead and figure out the sort
+                //  while also going through and initializing but I am really tired right now
+
                 // Go through the discovered bindings BEFORE sorting so that
                 //  we know the original indexs of all the bindings.
                 state.resourceConfigs = {};

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -918,12 +918,6 @@ const getInitialState = (
                               (uuid) => !bindingUUIDs.includes(uuid)
                           );
 
-                console.log('existingBindingUUIDs', existingBindingUUIDs);
-                console.log(
-                    'state.backfilledBindings',
-                    state.backfilledBindings
-                );
-
                 state.backfillAllBindings =
                     hasLength(existingBindingUUIDs) &&
                     existingBindingUUIDs.length ===

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -79,7 +79,7 @@ const sortByDisableStatus = (
         : collectionB.localeCompare(collectionA);
 };
 
-const sortBindings = (bindings: any[]) => {
+export const sortBindings = (bindings: any[]) => {
     return bindings.sort((a, b) => {
         const collectionA = getCollectionName(a);
         const collectionB = getCollectionName(b);
@@ -94,7 +94,9 @@ const sortBindings = (bindings: any[]) => {
     });
 };
 
-const sortResourceConfigs = (resourceConfigs: ResourceConfigDictionary) => {
+export const sortResourceConfigs = (
+    resourceConfigs: ResourceConfigDictionary
+) => {
     const sortedResources: ResourceConfigDictionary = {};
 
     Object.entries(resourceConfigs)
@@ -157,6 +159,8 @@ const getResourceConfig = (
 
     const collectionName = getCollectionName(binding);
     const disableProp = getDisableProps(disable);
+
+    console.log('binding', binding);
 
     // Take the binding resource and place into config OR
     // generate a default in case there are any issues with it
@@ -310,6 +314,8 @@ const getInitialState = (
                 // Run through and make sure all collections have a corresponding resource config
                 const modifiedResourceConfigs = state.resourceConfigs;
 
+                console.log('state.bindings', state.bindings);
+
                 Object.entries(state.bindings).forEach(
                     ([collectionName, bindingUUIDs], outerIndex) => {
                         bindingUUIDs.forEach((bindingUUID, innerIndex) => {
@@ -327,6 +333,13 @@ const getInitialState = (
                                     bindingUUID
                                 )
                             ) {
+                                console.log('collectionName', collectionName);
+                                console.log(
+                                    'state.resourceConfigs[bindingUUID]',
+                                    state.resourceConfigs[bindingUUID]
+                                );
+                                console.log('bindingIndex', bindingIndex);
+                                console.log('__________________________');
                                 state.resourceConfigs[
                                     bindingUUID
                                 ].meta.bindingIndex = bindingIndex;
@@ -346,15 +359,15 @@ const getInitialState = (
                     }
                 );
 
-                const sortedResourceConfigs = sortResourceConfigs(
-                    modifiedResourceConfigs
-                );
+                // const sortedResourceConfigs = sortResourceConfigs(
+                //     modifiedResourceConfigs
+                // );
 
-                state.resourceConfigs = sortedResourceConfigs;
-                populateResourceConfigErrors(state, sortedResourceConfigs);
+                state.resourceConfigs = modifiedResourceConfigs;
+                populateResourceConfigErrors(state, modifiedResourceConfigs);
 
                 state.bindingErrorsExist = isEmpty(state.bindings);
-                initializeCurrentBinding(state, sortedResourceConfigs);
+                initializeCurrentBinding(state, modifiedResourceConfigs);
             }),
             false,
             'Empty bindings added'
@@ -379,15 +392,14 @@ const getInitialState = (
                 const discoveredBindings: any[] =
                     draftSpecResponse.data[0].spec.bindings;
 
-                sortBindings(discoveredBindings).forEach(
-                    (binding: any, index) => {
-                        const collection = getCollectionName(binding);
-                        const UUID = crypto.randomUUID();
+                // sortBindings(discoveredBindings)
+                discoveredBindings.forEach((binding: any, index) => {
+                    const collection = getCollectionName(binding);
+                    const UUID = crypto.randomUUID();
 
-                        initializeBinding(state, collection, UUID);
-                        initializeResourceConfig(state, binding, UUID, index);
-                    }
-                );
+                    initializeBinding(state, collection, UUID);
+                    initializeResourceConfig(state, binding, UUID, index);
+                });
 
                 state.discoveredCollections = Object.values(
                     state.resourceConfigs
@@ -563,15 +575,15 @@ const getInitialState = (
                     }
                 });
 
-                const sortedResourceConfigs = sortResourceConfigs(
-                    state.resourceConfigs
-                );
+                // const sortedResourceConfigs = sortResourceConfigs(
+                //     state.resourceConfigs
+                // );
 
-                state.resourceConfigs = sortedResourceConfigs;
-                populateResourceConfigErrors(state, sortedResourceConfigs);
+                // state.resourceConfigs = sortedResourceConfigs;
+                populateResourceConfigErrors(state, state.resourceConfigs);
 
                 state.bindingErrorsExist = isEmpty(state.bindings);
-                initializeCurrentBinding(state, sortedResourceConfigs);
+                initializeCurrentBinding(state, state.resourceConfigs);
             }),
             false,
             'Binding dependent state prefilled'
@@ -629,9 +641,9 @@ const getInitialState = (
                 // If previous state had no collections set to first
                 // If selected item is removed set to first.
                 // If adding new ones set to last
-                state.resourceConfigs = sortResourceConfigs(
-                    state.resourceConfigs
-                );
+                // state.resourceConfigs = sortResourceConfigs(
+                //     state.resourceConfigs
+                // );
                 const bindingUUIDs = Object.keys(state.resourceConfigs);
 
                 const selectedBindingUUID =
@@ -916,6 +928,12 @@ const getInitialState = (
                         : state.backfilledBindings.filter(
                               (uuid) => !bindingUUIDs.includes(uuid)
                           );
+
+                console.log('existingBindingUUIDs', existingBindingUUIDs);
+                console.log(
+                    'state.backfilledBindings',
+                    state.backfilledBindings
+                );
 
                 state.backfillAllBindings =
                     hasLength(existingBindingUUIDs) &&


### PR DESCRIPTION
## Issues

contributes to https://github.com/estuary/ui/issues/1192

## Changes

### 1192

- Only sort the `resource configs` after we fetch off the original `index`

### Misc

- as a `Manually Edited` detail when something changes via the editor

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
