### PR TITLE
Prevent background test poller cancellation

### DIFF
--- a/src/components/collection/ResourceConfig.tsx
+++ b/src/components/collection/ResourceConfig.tsx
@@ -17,12 +17,14 @@ import { BindingsEditorConfigSkeleton } from './CollectionSkeletons';
 interface Props {
     bindingUUID: string;
     collectionName: string;
+    refreshRequired: boolean;
     readOnly?: boolean;
 }
 
 function ResourceConfig({
     bindingUUID,
     collectionName,
+    refreshRequired,
     readOnly = false,
 }: Props) {
     const entityType = useEntityType();
@@ -78,6 +80,7 @@ function ResourceConfig({
                 <FieldSelectionViewer
                     bindingUUID={bindingUUID}
                     collectionName={collectionName}
+                    refreshRequired={refreshRequired}
                 />
             ) : null}
 

--- a/src/components/editor/Bindings/Editor.tsx
+++ b/src/components/editor/Bindings/Editor.tsx
@@ -28,6 +28,7 @@ import {
 } from 'stores/Binding/hooks';
 import SchemaEditCLIButton from '../Bindings/SchemaEdit/CLIButton';
 import SchemaEditToggle from '../Bindings/SchemaEdit/Toggle';
+import useBackgroundTest from './FieldSelection/useBackgroundTest';
 
 interface Props {
     itemType: string;
@@ -38,6 +39,7 @@ function BindingsEditor({ itemType, readOnly = false }: Props) {
     const entityType = useEntityType();
 
     const initializeCollectionDraft = useInitializeCollectionDraft();
+    const { refreshRequired } = useBackgroundTest();
 
     // Binding Store
     const currentCollection = useBinding_currentCollection();
@@ -92,6 +94,7 @@ function BindingsEditor({ itemType, readOnly = false }: Props) {
                             bindingUUID={currentBindingUUID}
                             collectionName={currentCollection}
                             readOnly={readOnly}
+                            refreshRequired={refreshRequired}
                         />
                     ) : collectionData || collectionData === null ? (
                         <Stack spacing={2}>

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -12,27 +12,18 @@ import {
     ValidationResponse_Binding,
 } from 'components/editor/Bindings/FieldSelection/types';
 import useFieldSelection from 'components/editor/Bindings/FieldSelection/useFieldSelection';
-import {
-    useEditorStore_id,
-    useEditorStore_queryResponse_draftSpecs,
-} from 'components/editor/Store/hooks';
+import { useEditorStore_queryResponse_draftSpecs } from 'components/editor/Store/hooks';
 import FieldSelectionTable from 'components/tables/FieldSelection';
-import { useEntityWorkflow_Editing } from 'context/Workflow';
-import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
 import { isEqual } from 'lodash';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { logRocketEvent } from 'services/shared';
-import { CustomEvents } from 'services/types';
 import {
     useBinding_currentBindingIndex,
     useBinding_initializeSelections,
     useBinding_selectionSaving,
-    useBinding_serverUpdateRequired,
     useBinding_setRecommendFields,
     useBinding_setSelectionSaving,
 } from 'stores/Binding/hooks';
-import { useEndpointConfig_serverUpdateRequired } from 'stores/EndpointConfig/hooks';
 import {
     useFormStateStore_isActive,
     useFormStateStore_setFormState,
@@ -40,18 +31,17 @@ import {
 } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
 import { Schema } from 'types';
-import { BooleanParam, useQueryParam } from 'use-query-params';
 import {
     evaluateRequiredExcludedFields,
     evaluateRequiredIncludedFields,
     getBindingIndex,
 } from 'utils/workflow-utils';
 import RefreshStatus from './RefreshStatus';
-import useFieldSelectionRefresh from './useFieldSelectionRefresh';
 
 interface Props {
     bindingUUID: string;
     collectionName: string;
+    refreshRequired: boolean;
 }
 
 interface FieldMetadata {
@@ -107,23 +97,17 @@ const mapConstraintsToProjections = (
         };
     });
 
-function FieldSelectionViewer({ bindingUUID, collectionName }: Props) {
-    const { 1: setForcedEnable } = useQueryParam(
-        GlobalSearchParams.FORCED_SHARD_ENABLE,
-        BooleanParam
-    );
-
-    const isEdit = useEntityWorkflow_Editing();
-    const fireBackgroundTest = useRef(isEdit);
-
-    const [refreshRequired, setRefreshRequired] = useState(false);
+function FieldSelectionViewer({
+    bindingUUID,
+    collectionName,
+    refreshRequired,
+}: Props) {
     const [saveInProgress, setSaveInProgress] = useState(false);
     const [data, setData] = useState<
         CompositeProjection[] | null | undefined
     >();
 
     const applyFieldSelections = useFieldSelection(bindingUUID, collectionName);
-    const { refresh } = useFieldSelectionRefresh();
 
     // Bindings Store
     const setRecommendFields = useBinding_setRecommendFields();
@@ -135,42 +119,11 @@ function FieldSelectionViewer({ bindingUUID, collectionName }: Props) {
 
     // Draft Editor Store
     const draftSpecs = useEditorStore_queryResponse_draftSpecs();
-    const draftId = useEditorStore_id();
 
     // Form State Store
     const formActive = useFormStateStore_isActive();
     const formStatus = useFormStateStore_status();
     const setFormState = useFormStateStore_setFormState();
-
-    const serverUpdateRequired = useEndpointConfig_serverUpdateRequired();
-    const resourceRequiresUpdate = useBinding_serverUpdateRequired();
-
-    useEffect(() => {
-        return () => {
-            // Mainly for when a user enters edit and their initial bg test fails
-            //  want to make sure we fire off another bg test if they click on
-            //  next and not refresh after updating the config.
-            if (isEdit && formStatus === FormStatus.FAILED) {
-                fireBackgroundTest.current = true;
-            }
-        };
-    }, [formStatus, isEdit]);
-
-    useEffect(() => {
-        // If we need an update at the same time we are generating then we need to show
-        //  the refresh message.
-        if (
-            (resourceRequiresUpdate || serverUpdateRequired) &&
-            formStatus === FormStatus.GENERATING
-        ) {
-            setRefreshRequired(true);
-        } else if (formStatus === FormStatus.TESTED) {
-            // If we are here then the flag might be true and we only can stop showing it
-            //  if there is a test ran. This is kinda janky as a test does not 100% guarantee
-            //  a built spec but it is pretty darn close.
-            setRefreshRequired(false);
-        }
-    }, [formStatus, resourceRequiresUpdate, serverUpdateRequired]);
 
     useEffect(() => {
         const hasDraftSpec = draftSpecs.length > 0;
@@ -262,41 +215,14 @@ function FieldSelectionViewer({ bindingUUID, collectionName }: Props) {
                 }
             }
         } else {
-            if (hasDraftSpec && formStatus === FormStatus.GENERATED) {
-                if (fireBackgroundTest.current) {
-                    // We only want to force an update if the spec is disabled. This way when a
-                    //  test is ran there wil not be an error and the backend will connect to the
-                    // connector.  When the user goes to saves we will flip this back
-                    const forceEnabled = Boolean(
-                        draftSpecs[0].spec?.shards?.disable
-                    );
-
-                    // Only update the param to keep track when we do this so if someone
-                    //  reloads the page their draft will get switched back properly
-                    if (forceEnabled) {
-                        setForcedEnable(forceEnabled);
-                    }
-
-                    fireBackgroundTest.current = false;
-                    setRefreshRequired(false);
-                    logRocketEvent(CustomEvents.FIELD_SELECTION_REFRESH_AUTO);
-
-                    void refresh(draftId, forceEnabled);
-                }
-            }
-
             setData(null);
         }
     }, [
         bindingUUID,
         collectionName,
-        draftId,
         draftSpecs,
         formActive,
-        formStatus,
         initializeSelections,
-        refresh,
-        setForcedEnable,
         setRecommendFields,
         stagedBindingIndex,
     ]);

--- a/src/components/editor/Bindings/FieldSelection/useBackgroundTest.ts
+++ b/src/components/editor/Bindings/FieldSelection/useBackgroundTest.ts
@@ -1,0 +1,103 @@
+import {
+    useEditorStore_id,
+    useEditorStore_queryResponse_draftSpecs,
+} from 'components/editor/Store/hooks';
+import { useEntityType } from 'context/EntityContext';
+import { useEntityWorkflow_Editing } from 'context/Workflow';
+import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
+import { useEffect, useRef, useState } from 'react';
+import { logRocketEvent } from 'services/shared';
+import { CustomEvents } from 'services/types';
+import { useBinding_serverUpdateRequired } from 'stores/Binding/hooks';
+import { useEndpointConfig_serverUpdateRequired } from 'stores/EndpointConfig/hooks';
+import { useFormStateStore_status } from 'stores/FormState/hooks';
+import { FormStatus } from 'stores/FormState/types';
+import { BooleanParam, useQueryParam } from 'use-query-params';
+import useFieldSelectionRefresh from './useFieldSelectionRefresh';
+
+export default function useBackgroundTest() {
+    const { 1: setForcedEnable } = useQueryParam(
+        GlobalSearchParams.FORCED_SHARD_ENABLE,
+        BooleanParam
+    );
+
+    const entityType = useEntityType();
+    const isEdit = useEntityWorkflow_Editing();
+
+    const fireBackgroundTest = useRef(isEdit);
+
+    const { refresh } = useFieldSelectionRefresh();
+
+    // Binding Store
+    const bindingUpdated = useBinding_serverUpdateRequired();
+
+    // Draft Editor Store
+    const draftSpecs = useEditorStore_queryResponse_draftSpecs();
+    const draftId = useEditorStore_id();
+
+    // Endpoint Config Store
+    const endpointConfigUpdated = useEndpointConfig_serverUpdateRequired();
+
+    // Form State Store
+    const formStatus = useFormStateStore_status();
+
+    const [refreshRequired, setRefreshRequired] = useState(false);
+
+    useEffect(() => {
+        return () => {
+            // Mainly for when a user enters edit and their initial bg test fails
+            //  want to make sure we fire off another bg test if they click on
+            //  next and not refresh after updating the config.
+            if (
+                isEdit &&
+                entityType === 'materialization' &&
+                formStatus === FormStatus.FAILED
+            ) {
+                fireBackgroundTest.current = true;
+            }
+        };
+    }, [entityType, formStatus, isEdit]);
+
+    useEffect(() => {
+        // If we need an update at the same time we are generating then we need to show
+        //  the refresh message.
+        if (
+            (bindingUpdated || endpointConfigUpdated) &&
+            formStatus === FormStatus.GENERATING
+        ) {
+            setRefreshRequired(true);
+        } else if (formStatus === FormStatus.TESTED) {
+            // If we are here then the flag might be true and we only can stop showing it
+            //  if there is a test ran. This is kinda janky as a test does not 100% guarantee
+            //  a built spec but it is pretty darn close.
+            setRefreshRequired(false);
+        }
+    }, [bindingUpdated, endpointConfigUpdated, formStatus]);
+
+    useEffect(() => {
+        if (draftSpecs.length > 0 && formStatus === FormStatus.GENERATED) {
+            if (fireBackgroundTest.current) {
+                // We only want to force an update if the spec is disabled. This way when a
+                //  test is ran there will not be an error and the backend will connect to the
+                // connector.  When the user goes to save, we will flip this back.
+                const forceEnabled = Boolean(
+                    draftSpecs[0].spec?.shards?.disable
+                );
+
+                // Only update the param to keep track of when we do this so if someone
+                //  reloads the page their draft will get switched back properly.
+                if (forceEnabled) {
+                    setForcedEnable(forceEnabled);
+                }
+
+                fireBackgroundTest.current = false;
+                setRefreshRequired(false);
+                logRocketEvent(CustomEvents.FIELD_SELECTION_REFRESH_AUTO);
+
+                void refresh(draftId, forceEnabled);
+            }
+        }
+    }, [draftId, draftSpecs, formStatus, refresh, setForcedEnable]);
+
+    return { refreshRequired };
+}


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1201

## Changes

### 1201

The following features are included in this PR:

* Create a hook to bundle the background testing logic together.

* Move the logic responsible for initiating a background test in materialization workflows into a higher-level component.

## Tests

### Manually tested

* Validate that field selection is initialized when the selected binding remains unchanged while the publication job is queued.

* Validate that field selection is initialized when the selected binding changes while the publication job is queued.

### Automated tests

N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [x] Materialization

## Screenshots

N/A