### PR TITLE
OPS - enable CSP on dashboard

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -64,6 +64,21 @@ http {
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy no-referrer-when-downgrade always;
             add_header Permissions-Policy "geolocation=(), microphone=(), camera=() always";
+            add_header Content-Security-Policy "
+                default-src 'self' https:;
+                script-src 'self' 'unsafe-inline' 'unsafe-eval' https: https://cdn.logrocket.io https://cdn.lr-ingest.io https://cdn.lr-in.com https://cdn.lr-in-prod.com https://cdn.lr-ingest.com https://cdn.ingest-lr.com https://cdn.lr-intake.com https://cdn.intake-lr.com;
+                style-src 'self' 'unsafe-inline' https:;
+                img-src 'self' data: https:;
+                font-src 'self' data: https:;
+                connect-src 'self' https: https://*.logrocket.io https://*.lr-ingest.io https://*.logrocket.com https://*.lr-in.com https://*.lr-in-prod.com https://*.lr-ingest.com https://*.ingest-lr.com https://*.lr-intake.com https://*.intake-lr.com https://*.logr-ingest.com;
+                object-src 'none';
+                base-uri 'self';
+                form-action 'self';
+                frame-ancestors 'self';
+                worker-src 'self' blob https:;
+                child-src 'self' blob https:;
+                upgrade-insecure-requests;
+                reflected-xss 'block';" always;
 
             # Here to serve our T&C doc
             location /terms.html {


### PR DESCRIPTION
Disabled CSP changes just to be safe as it was tested in the middle of the night.

This will enable it with the settings that seemed to work best.