### PR TITLE
Need to skip all these when not in a materialization

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/useBackgroundTest.ts
+++ b/src/components/editor/Bindings/FieldSelection/useBackgroundTest.ts
@@ -24,7 +24,9 @@ export default function useBackgroundTest() {
     const entityType = useEntityType();
     const isEdit = useEntityWorkflow_Editing();
 
-    const fireBackgroundTest = useRef(isEdit);
+    const fireBackgroundTest = useRef(
+        Boolean(entityType === 'materialization' && isEdit)
+    );
 
     const { refresh } = useFieldSelectionRefresh();
 
@@ -59,6 +61,10 @@ export default function useBackgroundTest() {
     }, [entityType, formStatus, isEdit]);
 
     useEffect(() => {
+        if (entityType !== 'materialization') {
+            return;
+        }
+
         // If we need an update at the same time we are generating then we need to show
         //  the refresh message.
         if (
@@ -72,11 +78,16 @@ export default function useBackgroundTest() {
             //  a built spec but it is pretty darn close.
             setRefreshRequired(false);
         }
-    }, [bindingUpdated, endpointConfigUpdated, formStatus]);
+    }, [bindingUpdated, endpointConfigUpdated, formStatus, entityType]);
 
     useEffect(() => {
+        if (entityType !== 'materialization') {
+            return;
+        }
+
         if (draftSpecs.length > 0 && formStatus === FormStatus.GENERATED) {
             if (fireBackgroundTest.current) {
+                console.log('sup');
                 // We only want to force an update if the spec is disabled. This way when a
                 //  test is ran there will not be an error and the backend will connect to the
                 // connector.  When the user goes to save, we will flip this back.
@@ -97,7 +108,7 @@ export default function useBackgroundTest() {
                 void refresh(draftId, forceEnabled);
             }
         }
-    }, [draftId, draftSpecs, formStatus, refresh, setForcedEnable]);
+    }, [draftId, draftSpecs, formStatus, refresh, setForcedEnable, entityType]);
 
     return { refreshRequired };
 }


### PR DESCRIPTION
## Issues

Slack Issue

## Changes

### slack

- Need to make sure we don't run field selection refresh stuff in captures

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
