### PR TITLE
UX for beta onbording issues

### DIFF
--- a/src/directives/BetaOnboard.tsx
+++ b/src/directives/BetaOnboard.tsx
@@ -31,6 +31,7 @@ import { jobStatusQuery, trackEvent } from './shared';
 import { DirectiveProps } from './types';
 
 const directiveName = 'betaOnboard';
+const nameTaken = 'is already in use';
 
 const submit_onboard = async (
     requestedTenant: string,
@@ -112,7 +113,7 @@ const BetaOnboard = ({ directive, mutate }: DirectiveProps) => {
     };
 
     const nameAlreadyUsed = useMemo(
-        () => serverError?.includes('is already in use'),
+        () => serverError?.includes(nameTaken),
         [serverError]
     );
 

--- a/src/directives/BetaOnboard.tsx
+++ b/src/directives/BetaOnboard.tsx
@@ -22,7 +22,7 @@ import {
 } from 'directives/Onboard/Store/hooks';
 import OnboardingSurvey from 'directives/Onboard/Survey';
 import useJobStatusPoller from 'hooks/useJobStatusPoller';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useMount, useUnmount } from 'react-use';
 import { fireGtmEvent } from 'services/gtm';
@@ -111,6 +111,11 @@ const BetaOnboard = ({ directive, mutate }: DirectiveProps) => {
         },
     };
 
+    const nameAlreadyUsed = useMemo(
+        () => serverError?.includes('is already in use'),
+        [serverError]
+    );
+
     useMount(() => {
         trackEvent(`${directiveName}:Viewed`);
     });
@@ -174,7 +179,7 @@ const BetaOnboard = ({ directive, mutate }: DirectiveProps) => {
                             justifyContent: 'center',
                         }}
                     >
-                        <OrganizationNameField />
+                        <OrganizationNameField forceError={nameAlreadyUsed} />
 
                         <OnboardingSurvey />
 

--- a/src/directives/Onboard/OrganizationName.tsx
+++ b/src/directives/Onboard/OrganizationName.tsx
@@ -7,7 +7,11 @@ import {
 } from 'directives/Onboard/Store/hooks';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-function OrganizationNameField() {
+interface Props {
+    forceError?: boolean;
+}
+
+function OrganizationNameField({ forceError }: Props) {
     const intl = useIntl();
 
     // Onboarding Store
@@ -22,8 +26,10 @@ function OrganizationNameField() {
         },
     };
 
+    const showError = Boolean(nameMissing || nameInvalid || forceError);
+
     return (
-        <FormControl error={nameMissing || nameInvalid}>
+        <FormControl error={showError}>
             <FormLabel id="origin" required sx={{ mb: 1, fontSize: 20 }}>
                 <FormattedMessage id="tenant.input.label" />
             </FormLabel>
@@ -31,7 +37,7 @@ function OrganizationNameField() {
             <TextField
                 autoComplete="organization"
                 autoFocus
-                error={nameMissing || nameInvalid}
+                error={showError}
                 helperText={intl.formatMessage({
                     id:
                         nameMissing || nameInvalid

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -32,7 +32,7 @@ const CommonMessages: ResolvedIntlConfig['messages'] = {
     'common.noUnDo': `This action cannot be undone.`,
     'common.version': `version`,
     'common.tenant': `Prefix`,
-    'common.tenant.creationForm': `Name`,
+    'common.tenant.creationForm': `Organization`,
     'common.recommended': `Recommended`,
     'common.copied': `Copied`,
     'common.copyFailed': `Failed to copy`,


### PR DESCRIPTION
## Changes

### UX

- Highlight the field if the server error is for sure about the name
- Change the input to `organization` as some people have been submitting their `name`

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

A server failure will not highlight the field
![image](https://github.com/user-attachments/assets/3c8aa112-f57a-4b44-b497-c11a0b4894dc)

An error that contains `is already in use` will highlight the field
![image](https://github.com/user-attachments/assets/5daf2d60-ca5c-44cd-a7bb-261993b3b3ce)


