### PR TITLE
Force enable materializations during initialization to allow prefill bindings to work

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/useBackgroundTest.ts
+++ b/src/components/editor/Bindings/FieldSelection/useBackgroundTest.ts
@@ -4,7 +4,6 @@ import {
 } from 'components/editor/Store/hooks';
 import { useEntityType } from 'context/EntityContext';
 import { useEntityWorkflow_Editing } from 'context/Workflow';
-import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
 import { useEffect, useRef, useState } from 'react';
 import { logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
@@ -12,15 +11,9 @@ import { useBinding_serverUpdateRequired } from 'stores/Binding/hooks';
 import { useEndpointConfig_serverUpdateRequired } from 'stores/EndpointConfig/hooks';
 import { useFormStateStore_status } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
-import { BooleanParam, useQueryParam } from 'use-query-params';
 import useFieldSelectionRefresh from './useFieldSelectionRefresh';
 
 export default function useBackgroundTest() {
-    const { 1: setForcedEnable } = useQueryParam(
-        GlobalSearchParams.FORCED_SHARD_ENABLE,
-        BooleanParam
-    );
-
     const entityType = useEntityType();
     const isEdit = useEntityWorkflow_Editing();
 
@@ -87,27 +80,14 @@ export default function useBackgroundTest() {
 
         if (draftSpecs.length > 0 && formStatus === FormStatus.GENERATED) {
             if (fireBackgroundTest.current) {
-                // We only want to force an update if the spec is disabled. This way when a
-                //  test is ran there will not be an error and the backend will connect to the
-                // connector.  When the user goes to save, we will flip this back.
-                const forceEnabled = Boolean(
-                    draftSpecs[0].spec?.shards?.disable
-                );
-
-                // Only update the param to keep track of when we do this so if someone
-                //  reloads the page their draft will get switched back properly.
-                if (forceEnabled) {
-                    setForcedEnable(forceEnabled);
-                }
-
                 fireBackgroundTest.current = false;
                 setRefreshRequired(false);
                 logRocketEvent(CustomEvents.FIELD_SELECTION_REFRESH_AUTO);
 
-                void refresh(draftId, forceEnabled);
+                void refresh(draftId);
             }
         }
-    }, [draftId, draftSpecs, formStatus, refresh, setForcedEnable, entityType]);
+    }, [draftId, draftSpecs.length, entityType, formStatus, refresh]);
 
     return { refreshRequired };
 }

--- a/src/components/editor/Bindings/FieldSelection/useFieldSelectionRefresh.ts
+++ b/src/components/editor/Bindings/FieldSelection/useFieldSelectionRefresh.ts
@@ -20,15 +20,14 @@ function useFieldSelectionRefresh() {
     );
 
     const refresh = useCallback(
-        async (draftIdToUse?: string | null, toggleDisable?: boolean) => {
+        async (draftIdToUse?: string | null) => {
             setUpdating(true);
 
             let evaluatedDraftId = draftIdToUse;
-            if (!evaluatedDraftId || toggleDisable) {
+            if (!evaluatedDraftId) {
                 try {
                     evaluatedDraftId = await generateCatalog(
                         mutateDraftSpec,
-                        toggleDisable,
                         false // we don't want to skip all the extra updates
                     );
                 } catch (_error: unknown) {

--- a/src/components/materialization/useGenerateCatalog.ts
+++ b/src/components/materialization/useGenerateCatalog.ts
@@ -126,11 +126,7 @@ function useGenerateCatalog() {
     );
 
     return useCallback(
-        async (
-            mutateDraftSpecs: Function,
-            toggleDisable?: boolean,
-            skipStoreUpdates?: boolean
-        ) => {
+        async (mutateDraftSpecs: Function, skipStoreUpdates?: boolean) => {
             updateFormStatus(FormStatus.GENERATING);
 
             if (
@@ -199,38 +195,30 @@ function useGenerateCatalog() {
                     evaluatedDraftId = draftsResponse.data[0].id;
                 }
 
-                let draftSpec;
-                if (toggleDisable && existingTaskData) {
-                    // Want to toggle the value to the opposite
-                    existingTaskData.spec.shards.disable =
-                        !existingTaskData.spec.shards.disable;
-                    draftSpec = existingTaskData.spec;
-                } else {
-                    const encryptedEndpointConfig = await encryptEndpointConfig(
-                        serverUpdateRequired
-                            ? endpointConfigData
-                            : serverEndpointConfigData,
-                        endpointSchema,
-                        serverUpdateRequired,
-                        imageConnectorId,
-                        imageConnectorTagId,
-                        callFailed,
-                        { overrideJsonFormDefaults: true }
-                    );
+                const encryptedEndpointConfig = await encryptEndpointConfig(
+                    serverUpdateRequired
+                        ? endpointConfigData
+                        : serverEndpointConfigData,
+                    endpointSchema,
+                    serverUpdateRequired,
+                    imageConnectorId,
+                    imageConnectorTagId,
+                    callFailed,
+                    { overrideJsonFormDefaults: true }
+                );
 
-                    draftSpec = generateTaskSpec(
-                        ENTITY_TYPE,
-                        {
-                            image: imagePath,
-                            config: encryptedEndpointConfig.data,
-                        },
-                        resourceConfigs,
-                        resourceConfigServerUpdateRequired,
-                        bindings,
-                        existingTaskData,
-                        { fullSource: fullSourceConfigs, sourceCapture }
-                    );
-                }
+                const draftSpec = generateTaskSpec(
+                    ENTITY_TYPE,
+                    {
+                        image: imagePath,
+                        config: encryptedEndpointConfig.data,
+                    },
+                    resourceConfigs,
+                    resourceConfigServerUpdateRequired,
+                    bindings,
+                    existingTaskData,
+                    { fullSource: fullSourceConfigs, sourceCapture }
+                );
 
                 // If there is a draft already with task data then update. We do not match on
                 //   the catalog name as the user could change the name. There is a small issue

--- a/src/components/shared/Entity/Edit/useInitializeTaskDraft.ts
+++ b/src/components/shared/Entity/Edit/useInitializeTaskDraft.ts
@@ -211,6 +211,15 @@ function useInitializeTaskDraft() {
                     await getTaskDraft(task);
 
                 if (evaluatedDraftId) {
+                    // Force disabled materializations enabled. This way when a test is ran
+                    //  there will not be an error and the backend will connect to the connector
+                    const forceEnabled =
+                        Boolean(task.spec?.shards?.disable) &&
+                        taskSpecType === 'materialization';
+                    if (forceEnabled) {
+                        task.spec.shards.disable = false;
+                    }
+
                     const draftSpecsError = await getTaskDraftSpecs(
                         evaluatedDraftId,
                         draftSpecsRequestConfig,
@@ -236,6 +245,11 @@ function useInitializeTaskDraft() {
                                 [GlobalSearchParams.PREFILL_LIVE_SPEC_ID]:
                                     prefillLiveSpecIds,
                                 [GlobalSearchParams.DRAFT_ID]: evaluatedDraftId,
+
+                                // Only update the param to keep track of when we do this so if someone
+                                //  reloads the page their draft will get switched back properly.
+                                [GlobalSearchParams.FORCED_SHARD_ENABLE]:
+                                    forceEnabled ? 1 : undefined,
                             },
                             true
                         );

--- a/src/components/shared/Entity/Edit/useInitializeTaskDraft.ts
+++ b/src/components/shared/Entity/Edit/useInitializeTaskDraft.ts
@@ -245,9 +245,6 @@ function useInitializeTaskDraft() {
                                 [GlobalSearchParams.PREFILL_LIVE_SPEC_ID]:
                                     prefillLiveSpecIds,
                                 [GlobalSearchParams.DRAFT_ID]: evaluatedDraftId,
-
-                                // Only update the param to keep track of when we do this so if someone
-                                //  reloads the page their draft will get switched back properly.
                                 [GlobalSearchParams.FORCED_SHARD_ENABLE]:
                                     forceEnabled,
                             },

--- a/src/components/shared/Entity/Edit/useInitializeTaskDraft.ts
+++ b/src/components/shared/Entity/Edit/useInitializeTaskDraft.ts
@@ -249,7 +249,7 @@ function useInitializeTaskDraft() {
                                 // Only update the param to keep track of when we do this so if someone
                                 //  reloads the page their draft will get switched back properly.
                                 [GlobalSearchParams.FORCED_SHARD_ENABLE]:
-                                    forceEnabled ? 1 : undefined,
+                                    forceEnabled,
                             },
                             true
                         );

--- a/src/components/shared/Entity/hooks/useEntityEditNavigate.ts
+++ b/src/components/shared/Entity/hooks/useEntityEditNavigate.ts
@@ -16,6 +16,9 @@ interface BaseSearchParams {
 interface OptionalSearchParams {
     [GlobalSearchParams.PREFILL_LIVE_SPEC_ID]?: string | string[];
     [GlobalSearchParams.DRAFT_ID]?: string;
+    // Param to keep track of when we force enable something so if someone
+    //  reloads the page their draft will get switched back properly.
+    [GlobalSearchParams.FORCED_SHARD_ENABLE]?: number;
 }
 
 export default function useEntityEditNavigate() {

--- a/src/components/shared/Entity/hooks/useEntityEditNavigate.ts
+++ b/src/components/shared/Entity/hooks/useEntityEditNavigate.ts
@@ -18,7 +18,7 @@ interface OptionalSearchParams {
     [GlobalSearchParams.DRAFT_ID]?: string;
     // Param to keep track of when we force enable something so if someone
     //  reloads the page their draft will get switched back properly.
-    [GlobalSearchParams.FORCED_SHARD_ENABLE]?: number;
+    [GlobalSearchParams.FORCED_SHARD_ENABLE]?: boolean;
 }
 
 export default function useEntityEditNavigate() {

--- a/src/hooks/searchParams/useSearchParamAppend.ts
+++ b/src/hooks/searchParams/useSearchParamAppend.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { createSearchParams, useSearchParams } from 'react-router-dom';
+import { encodeParamVal } from 'utils/misc-utils';
 
 export default function useSearchParamAppend() {
     const [searchParams] = useSearchParams();
@@ -12,12 +13,12 @@ export default function useSearchParamAppend() {
                     sp.delete(key);
 
                     val.forEach((element) => {
-                        sp.append(key, element);
+                        sp.append(key, encodeParamVal(element));
                     });
                 } else if (val === undefined) {
                     sp.delete(key);
                 } else {
-                    sp.set(key, val);
+                    sp.set(key, encodeParamVal(val));
                 }
             });
             return sp;

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -61,6 +61,14 @@ export const hasLength = (val: string | any[] | null | undefined): boolean => {
 export const appendWithForwardSlash = (value: string): string =>
     hasLength(value) && !value.endsWith('/') ? `${value}/` : value;
 
+export const encodeParamVal = (val: any) => {
+    if (typeof val === 'boolean') {
+        return val ? 1 : 0;
+    }
+
+    return val;
+};
+
 export const getPathWithParams = (
     baseURL: string,
     params: { [key: string]: string | string[] } | URLSearchParams


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1200

## Changes

### 1200

- Have the draft init code handle enabling disabled materializations
- Edit now knows that we are force enabling right away instead of setting after all of edit is loaded

### Misc

- Add encoding to search param handler for booleans

## Tests

### Manually tested

- Editing [`enabled`,`disabled`] materialization
- Materializing to a [`enabled`,`disabled`] materialization

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

Editing a disabled materialization
![image](https://github.com/user-attachments/assets/9c9c4cc8-93ff-48bf-9831-b2f5ebe4773d)

Materializing to disabled materialization
![image](https://github.com/user-attachments/assets/5659e20c-19fd-4b38-bca3-bc675b9c9b07)
