### PR TITLE
Display an error when unable to save alert subscriptions

### DIFF
--- a/src/components/admin/Settings/PrefixAlerts/Dialog/EmailListField.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/EmailListField.tsx
@@ -13,7 +13,7 @@ export default function EmailListField({ open }: Props) {
     );
 
     const serverError = useAlertSubscriptionsStore(
-        (state) => state.serverError
+        (state) => state.initializationError
     );
 
     const prefix = useAlertSubscriptionsStore((state) => state.prefix);

--- a/src/components/admin/Settings/PrefixAlerts/Dialog/InitializationError.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/InitializationError.tsx
@@ -1,19 +1,29 @@
-import { Box } from '@mui/material';
+import { Stack } from '@mui/material';
 import Error from 'components/shared/Error';
+import { hasLength } from 'utils/misc-utils';
 import useAlertSubscriptionsStore from '../useAlertSubscriptionsStore';
 
 export default function InitializationError() {
-    const serverError = useAlertSubscriptionsStore(
-        (state) => state.serverError
+    const serverErrors = useAlertSubscriptionsStore((state) =>
+        [state.initializationError].concat(state.saveErrors)
     );
 
-    if (!serverError) {
+    if (!hasLength(serverErrors)) {
         return null;
     }
 
     return (
-        <Box style={{ marginBottom: 16 }}>
-            <Error condensed error={serverError} severity="error" />
-        </Box>
+        <Stack spacing={1} style={{ marginBottom: 16 }}>
+            {serverErrors.map((error, index) =>
+                error ? (
+                    <Error
+                        condensed
+                        error={error}
+                        key={`save-error-${index}`}
+                        severity="error"
+                    />
+                ) : null
+            )}
+        </Stack>
     );
 }

--- a/src/components/admin/Settings/PrefixAlerts/Dialog/SaveButton.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/SaveButton.tsx
@@ -36,6 +36,10 @@ function SaveButton({ closeDialog }: Props) {
         (state) => state.subscriptions
     );
 
+    const setServerError = useAlertSubscriptionsStore(
+        (state) => state.setSaveErrors
+    );
+
     const existingEmails = useAlertSubscriptionsStore(
         (state) => state.existingEmails
     );
@@ -54,6 +58,7 @@ function SaveButton({ closeDialog }: Props) {
     const onClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
         setLoading(true);
+        setServerError([]);
 
         const subscriptionsToCancel: { [K: string]: string[] } = {};
         const subscriptionsToCreate: [string, string][] = [];
@@ -104,13 +109,14 @@ function SaveButton({ closeDialog }: Props) {
 
         // The create could be undefined and this was easier to mark than tweak logic
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        const errors = responses.filter((r) => r?.error);
+        const errors = responses.filter((r) => r?.error).map((r) => r?.error);
 
         if (!hasLength(errors)) {
             hydrate();
             closeDialog();
         }
 
+        setServerError(errors);
         setLoading(false);
     };
 

--- a/src/components/admin/Settings/PrefixAlerts/Dialog/ServerErrors.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/ServerErrors.tsx
@@ -19,7 +19,7 @@ export default function ServerErrors() {
                     <Error
                         condensed
                         error={error}
-                        key={`save-error-${index}`}
+                        key={`prefix-alert-save-error-${index}`}
                         severity="error"
                     />
                 ) : null

--- a/src/components/admin/Settings/PrefixAlerts/Dialog/ServerErrors.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/ServerErrors.tsx
@@ -3,7 +3,7 @@ import Error from 'components/shared/Error';
 import { hasLength } from 'utils/misc-utils';
 import useAlertSubscriptionsStore from '../useAlertSubscriptionsStore';
 
-export default function InitializationError() {
+export default function ServerErrors() {
     const serverErrors = useAlertSubscriptionsStore((state) =>
         [state.initializationError].concat(state.saveErrors)
     );

--- a/src/components/admin/Settings/PrefixAlerts/Dialog/index.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/index.tsx
@@ -15,8 +15,8 @@ import { Dispatch, SetStateAction } from 'react';
 import { FormattedMessage } from 'react-intl';
 import useAlertSubscriptionsStore from '../useAlertSubscriptionsStore';
 import EmailListField from './EmailListField';
-import InitializationError from './InitializationError';
 import PrefixField from './PrefixField';
+import ServerErrors from './ServerErrors';
 
 interface Props {
     headerId: string;
@@ -75,7 +75,7 @@ function AlertSubscriptionDialog({
             </DialogTitle>
 
             <DialogContent sx={{ mt: 1 }}>
-                <InitializationError />
+                <ServerErrors />
 
                 <Typography sx={{ mb: 2 }}>
                     <FormattedMessage id="admin.alerts.dialog.description" />

--- a/src/components/admin/Settings/PrefixAlerts/useAlertSubscriptionsStore.ts
+++ b/src/components/admin/Settings/PrefixAlerts/useAlertSubscriptionsStore.ts
@@ -8,16 +8,18 @@ import { EmailDictionary } from './types';
 
 interface AlertSubscriptionState {
     existingEmails: EmailDictionary;
+    initializationError: PostgrestError | null | undefined;
     initializeState: (
         prefix: string | undefined,
         subscriptions: AlertSubscriptionState['subscriptions'],
-        error: AlertSubscriptionState['serverError']
+        error: AlertSubscriptionState['initializationError']
     ) => void;
     prefix: string;
     prefixErrorsExist: boolean;
-    serverError: PostgrestError | null | undefined;
+    saveErrors: (PostgrestError | null | undefined)[];
     subscriptions: PrefixSubscriptionDictionary | null | undefined;
     resetState: () => void;
+    setSaveErrors: (value: AlertSubscriptionState['saveErrors']) => void;
     setUpdatedEmails: (value: AlertSubscriptionState['updatedEmails']) => void;
     updatePrefix: (value: string, errors: string | null) => void;
     updatedEmails: EmailDictionary;
@@ -26,16 +28,18 @@ interface AlertSubscriptionState {
 const getInitialState = (): Pick<
     AlertSubscriptionState,
     | 'existingEmails'
+    | 'initializationError'
     | 'prefix'
     | 'prefixErrorsExist'
-    | 'serverError'
+    | 'saveErrors'
     | 'subscriptions'
     | 'updatedEmails'
 > => ({
     existingEmails: {},
+    initializationError: null,
     prefix: '',
     prefixErrorsExist: false,
-    serverError: null,
+    saveErrors: [],
     subscriptions: undefined,
     updatedEmails: {},
 });
@@ -71,13 +75,22 @@ const useAlertSubscriptionsStore = create<AlertSubscriptionState>()(
                         }
 
                         state.subscriptions = subscriptions;
-                        state.serverError = error;
+                        state.initializationError = error;
                     }),
                     false,
                     'state initialized'
                 ),
 
             resetState: () => set(getInitialState(), false, 'state reset'),
+
+            setSaveErrors: (value) =>
+                set(
+                    produce((state: AlertSubscriptionState) => {
+                        state.saveErrors = value;
+                    }),
+                    false,
+                    'save errors set'
+                ),
 
             setUpdatedEmails: (value) =>
                 set(


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1142

## Changes

### 1142

The following features are included in this PR:

* Display an error alert in the alert subscription dialog when the call to create and/or delete a subscription fails.

* Broaden the scope of the alert subscription dialog error component.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that an error is displayed when the creation of a subscription fails.

* Validate that an error is displayed when the deletion of a subscription fails.

* Validate that errors encountered when clicking the _Save_ CTA are non-blocking and cleared on a subsequent click.

* Validate that an error is displayed when the alert subscriptions dialog fails to initialize and the emails field and save button are disabled.

### Automated tests

N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**Dialog save error alert | Subscription deleted**

<img width="452" alt="pr_screenshot-1225-alert_dialog_save-delete_error-edit" src="https://github.com/user-attachments/assets/4e612b85-fa0b-4793-9f51-b9a1ae9ff998">

<br />
<br />

**Dialog save error alert | Subscription created and deleted**

<img width="452" alt="pr_screenshot-1225-alert_dialog_save-delete_create_error-edit" src="https://github.com/user-attachments/assets/ff9d135f-aaec-4a4d-bc93-c815057dcff6">

<br />
<br />

**Dialog save error alert | Subscription created**

<img width="454" alt="pr_screenshot-1225-alert_dialog_save-create_error-edit" src="https://github.com/user-attachments/assets/f3360773-b534-43e2-a507-29be8fc1c8ab">

<br />
<br />
