### PR TITLE
Add a network failure state to the notifications table

### DIFF
--- a/src/stores/Tables/PrefixAlerts/Store.ts
+++ b/src/stores/Tables/PrefixAlerts/Store.ts
@@ -36,7 +36,7 @@ export const getInitialState = (
 
             const response = await supabaseRetry<PostgrestResponse<any>>(
                 () => fetcher,
-                'tablesHydrateStore'
+                'prefixAlertTableHydrateStore'
             );
 
             if (response.error) {


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1142

## Changes

### 1142

The following features are included in this PR:

* Port updates to the select table store hydrate action over to the notification table store hydrate action.

## Tests

### Manually tested

* Validate that the table enters a network failure state when it is unable to be initialized for that reason.

### Automated tests

N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**Network error encountered when initializing the notifications table**

<img width="685" alt="pr_screenshot-1226-alert_table_init-network_failure_state" src="https://github.com/user-attachments/assets/afb3fe5d-7cbd-4579-bf85-50a9775bde34">
