### PR TITLE
Update content for re-versioning auto-discovery option

### DIFF
--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -1107,7 +1107,7 @@ const Workflows: ResolvedIntlConfig['messages'] = {
     'workflows.autoDiscovery.header': `Schema Evolution`,
     'workflows.autoDiscovery.label.optIntoDiscovery': `Automatically keep schemas up to date`,
     'workflows.autoDiscovery.label.addNewBindings': `Automatically add new collections`,
-    'workflows.autoDiscovery.label.evolveIncompatibleCollection': `Breaking changes re-version collections`,
+    'workflows.autoDiscovery.label.evolveIncompatibleCollection': `Changing primary keys re-versions collections`,
     'workflows.autoDiscovery.update.failed': `Schema evolution update failed`,
 
     'workflows.sourceCapture.header': `Link Capture`,


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1227

## Changes

### 1227

The following features are included in this PR:

-   Update the content for the auto-discovery option relating to re-versioning collections.

## Tests

### Manually tested

* Validate that the appropriate auto-discovery option content specified in [issue 1227](https://github.com/estuary/ui/issues/1227) appears in the client.

### Automated tests

N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**Auto-discovery options**

<img width="467" alt="pr_screenshot-1228-auto_discovery_content-option_label" src="https://github.com/user-attachments/assets/d9490605-4b17-40ff-9845-602522070776">
