### PR TITLE
Prevent the creation of duplicate alert subscriptions

### DIFF
--- a/src/components/admin/Settings/PrefixAlerts/Dialog/SaveButton.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/SaveButton.tsx
@@ -4,6 +4,7 @@ import {
 } from 'api/alerts';
 import SafeLoadingButton from 'components/SafeLoadingButton';
 import { useZustandStore } from 'context/Zustand/provider';
+import { union } from 'lodash';
 import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -78,9 +79,13 @@ function SaveButton({ closeDialog }: Props) {
                     });
             }
 
-            const processedValues = emailsExistForPrefix
-                ? value.filter((email) => !existingEmails[key].includes(email))
-                : value;
+            const processedValues = union(
+                emailsExistForPrefix
+                    ? value.filter(
+                          (email) => !existingEmails[key].includes(email)
+                      )
+                    : value
+            );
 
             processedValues
                 .map((email): [string, string] => [key, email])


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1223

## Changes

### 1223

The following features are included in this PR:

* Prevent the creation of duplicate subscriptions.

**NOTE:** Duplicate emails can be entered in the email field but a subscription will only be created for a single instance of that email.

## Tests

### Manually tested

Approaches to testing are as follows:

-   scenarios you manually tested

### Automated tests

N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

N/A
