### PR TITLE
Adding an option for `All Time` for stats in entity table

### DIFF
--- a/src/components/filters/Date/index.tsx
+++ b/src/components/filters/Date/index.tsx
@@ -108,6 +108,7 @@ function DateFilter({ disabled, header, selectableTableStoreName }: Props) {
                 <DateFilterOption {...optionProps} option="lastWeek" />
                 <DateFilterOption {...optionProps} option="thisMonth" />
                 <DateFilterOption {...optionProps} option="lastMonth" />
+                <DateFilterOption {...optionProps} option="allTime" />
             </Menu>
         </Stack>
     );

--- a/src/lang/en-US/CommonMessages.ts
+++ b/src/lang/en-US/CommonMessages.ts
@@ -99,6 +99,7 @@ export const CommonMessages: Record<string, string> = {
     'filter.time.thisWeek': `This Week`,
     'filter.time.lastMonth': `Last Month`,
     'filter.time.thisMonth': `This Month`,
+    'filter.time.allTime': `All Time`,
 
     'catalogName.limitations': `letters, numbers, periods, underscores, and hyphens`,
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1241

## Changes

### 1241

- Added the option for `All Time` for the stats

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/fd29b63e-8bd7-4918-8952-d966f7ddd2e8)
![image](https://github.com/user-attachments/assets/5acc4ef0-c795-4696-b47a-f6cdbc018940)
![image](https://github.com/user-attachments/assets/0be85382-bdac-48a3-b9a5-5257de7e3dea)
![image](https://github.com/user-attachments/assets/78d3268c-d2b4-48b4-b64d-a46133fb577d)

