### PR TITLE
Backfill counter not handling empty

### DIFF
--- a/src/components/editor/Bindings/Backfill/BackfillCount.tsx
+++ b/src/components/editor/Bindings/Backfill/BackfillCount.tsx
@@ -4,15 +4,16 @@ import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import {
     useBinding_backfilledBindings_count,
-    useBinding_resourceConfigs_count,
+    useBinding_collections_count,
 } from 'stores/Binding/hooks';
+import { BackfillCountProps } from './types';
 
-function BackfillCount() {
+function BackfillCount({ disabled }: BackfillCountProps) {
     const intl = useIntl();
     const entityType = useEntityType();
 
     const backfillCount = useBinding_backfilledBindings_count();
-    const bindingsTotal = useBinding_resourceConfigs_count();
+    const bindingsTotal = useBinding_collections_count();
 
     // Only reason noBackfill is in here is because we are already running the memo on backfillCount change
     const [noBackfill, itemType_backfill, itemType_bindings] = useMemo(() => {
@@ -43,10 +44,19 @@ function BackfillCount() {
             aria-label={intl.formatMessage({
                 id: 'workflows.collectionSelector.manualBackfill.count.aria',
             })}
-            color={noBackfill ? 'info' : 'success'}
+            color={noBackfill || disabled ? 'info' : 'success'}
             variant="outlined"
             label={
-                noBackfill
+                disabled
+                    ? intl.formatMessage(
+                          {
+                              id: 'workflows.collectionSelector.manualBackfill.count.disabled',
+                          },
+                          {
+                              itemType: itemType_backfill,
+                          }
+                      )
+                    : noBackfill
                     ? intl.formatMessage(
                           {
                               id: 'workflows.collectionSelector.manualBackfill.count.empty',

--- a/src/components/editor/Bindings/Backfill/BackfillCount.tsx
+++ b/src/components/editor/Bindings/Backfill/BackfillCount.tsx
@@ -53,7 +53,7 @@ function BackfillCount({ disabled }: BackfillCountProps) {
                               id: 'workflows.collectionSelector.manualBackfill.count.disabled',
                           },
                           {
-                              itemType: itemType_backfill,
+                              itemType: itemType_bindings,
                           }
                       )
                     : noBackfill

--- a/src/components/editor/Bindings/Backfill/index.tsx
+++ b/src/components/editor/Bindings/Backfill/index.tsx
@@ -7,17 +7,16 @@ import {
     useBinding_allBindingsDisabled,
     useBinding_backfillAllBindings,
     useBinding_backfilledBindings,
-    useBinding_collections,
     useBinding_currentCollection,
     useBinding_currentBindingUUID,
     useBinding_setBackfilledBindings,
+    useBinding_collections_count,
 } from 'stores/Binding/hooks';
 import {
     useFormStateStore_isActive,
     useFormStateStore_setFormState,
 } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
-import { hasLength } from 'utils/misc-utils';
 import { useEditorStore_queryResponse_draftSpecs } from '../../Store/hooks';
 import BackfillCount from './BackfillCount';
 import { BackfillProps } from './types';
@@ -35,7 +34,7 @@ function Backfill({ description, bindingIndex = -1 }: BackfillProps) {
     // Binding Store
     const currentCollection = useBinding_currentCollection();
     const currentBindingUUID = useBinding_currentBindingUUID();
-    const collections = useBinding_collections();
+    const collectionsCount = useBinding_collections_count();
     const allBindingsDisabled = useBinding_allBindingsDisabled();
 
     const backfillAllBindings = useBinding_backfillAllBindings();
@@ -148,6 +147,8 @@ function Backfill({ description, bindingIndex = -1 }: BackfillProps) {
         ]
     );
 
+    const disabled = formActive || collectionsCount < 1 || allBindingsDisabled;
+
     return (
         <Box sx={{ mt: 3 }}>
             <Stack spacing={1} sx={{ mb: 2 }}>
@@ -166,11 +167,7 @@ function Backfill({ description, bindingIndex = -1 }: BackfillProps) {
                 <BooleanToggleButton
                     size={bindingIndex === -1 ? 'large' : undefined}
                     selected={selected}
-                    disabled={
-                        formActive ||
-                        !hasLength(collections) ||
-                        allBindingsDisabled
-                    }
+                    disabled={disabled}
                     onClick={(event, checked: string) => {
                         event.preventDefault();
                         event.stopPropagation();
@@ -183,7 +180,9 @@ function Backfill({ description, bindingIndex = -1 }: BackfillProps) {
                     })}
                 </BooleanToggleButton>
 
-                {bindingIndex === -1 ? <BackfillCount /> : null}
+                {bindingIndex === -1 ? (
+                    <BackfillCount disabled={disabled} />
+                ) : null}
             </Stack>
 
             {/* // TODO (reset dataflow)

--- a/src/components/editor/Bindings/Backfill/types.ts
+++ b/src/components/editor/Bindings/Backfill/types.ts
@@ -8,3 +8,7 @@ export interface BackfillProps {
 export interface BackfillDataflowOptionProps {
     disabled?: boolean;
 }
+
+export interface BackfillCountProps {
+    disabled?: boolean;
+}

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -81,6 +81,7 @@ export const Workflows: Record<string, string> = {
     'workflows.collectionSelector.manualBackfill.cta.backfill': `Backfill`,
     'workflows.collectionSelector.manualBackfill.count': `{backfillCount} of {bindingsTotal} {itemType} marked for backfill`,
     'workflows.collectionSelector.manualBackfill.count.empty': `no {itemType} marked for backfill`,
+    'workflows.collectionSelector.manualBackfill.count.disabled': `no {itemType} available to backfill`,
     'workflows.collectionSelector.manualBackfill.count.aria': `Backfill count`,
 
     'workflows.collectionSelector.dataFlowBackfill.header': `Choose to backfill just your capture or the entire ${CommonMessages['terms.dataFlow']}.`,

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -122,6 +122,9 @@ export const useBinding_collections = () => {
     return useBindingStore(useShallow((state) => state.getCollections()));
 };
 
+export const useBinding_collections_count = () =>
+    useBindingStore(useShallow((state) => state.getCollections().length));
+
 export const useBinding_toggleDisable = () => {
     return useBindingStore((state) => state.toggleDisable);
 };
@@ -310,12 +313,5 @@ export const useBinding_backfilledBindings_count = () =>
     useBindingStore(
         useShallow((state) => {
             return state.backfilledBindings.length;
-        })
-    );
-
-export const useBinding_resourceConfigs_count = () =>
-    useBindingStore(
-        useShallow((state) => {
-            return Object.keys(state.resourceConfigs).length;
         })
     );


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1245

## Changes

### 1245

- Add new content for messaging
- Pass when the backfill all button is disabled to counter
- Updating how we fetch collection count from hooks

## Tests

### Manually tested

- messed around with Materialization edit

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/fce34b21-756a-451a-9152-0a9d90deea1f)
![image](https://github.com/user-attachments/assets/5a9815f0-ab42-4ac6-b0ca-3bca40e5e1dd)
