### PR TITLE
Fix group titles

### DIFF
--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -40,7 +40,6 @@ import {
 } from '@jsonforms/core';
 import { concat, includes, isPlainObject, orderBy } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
-import keys from 'lodash/keys';
 import startCase from 'lodash/startCase';
 import { logRocketConsole, logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
@@ -573,10 +572,6 @@ const generateUISchema = (
         addLabel(layout, label);
 
         schemaElements.push(layout);
-
-        if (jsonSchema.properties && keys(jsonSchema.properties).length > 1) {
-            addLabel(layout, schemaName);
-        }
 
         if (!isEmpty(jsonSchema.properties)) {
             // traverse properties


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1262

## Changes

### 1262

- This line was added with https://github.com/estuary/ui/pull/131 and does not really help at all. We are already setting the title up above and then this guarantees it will be overwritten for groups with the schema name. This is often the key of the object and not the `title` like we want.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/fa0672e4-05aa-4382-b5ba-5e8e8c2d43c5)

