### PR TITLE
Support varied journals list API response shapes

### DIFF
--- a/src/hooks/journals/useJournalData.ts
+++ b/src/hooks/journals/useJournalData.ts
@@ -8,6 +8,7 @@ import useJournalStore from 'stores/JournalData/Store';
 import useSWR from 'swr';
 import {
     getJournals,
+    isNestedProtocolListResponse,
     MAX_DOCUMENT_SIZE,
     shouldRefreshToken,
 } from 'utils/dataPlane-utils';
@@ -63,12 +64,14 @@ const useJournalsForCollection = (collectionName: string | undefined) => {
                     return Promise.reject(dataPlaneListResponse);
                 }
 
+                const journals = isNestedProtocolListResponse(
+                    dataPlaneListResponse
+                )
+                    ? dataPlaneListResponse.result.journals
+                    : dataPlaneListResponse.journals;
+
                 return {
-                    journals:
-                        dataPlaneListResponse.result.journals &&
-                        dataPlaneListResponse.result.journals.length > 0
-                            ? dataPlaneListResponse.result.journals
-                            : [],
+                    journals: journals ?? [],
                 };
             } else {
                 return null;

--- a/src/utils/dataPlane-utils.ts
+++ b/src/utils/dataPlane-utils.ts
@@ -121,11 +121,18 @@ export const authorizeCollection = async (
         accessToken
     );
 
+// Streaming RPC responses going through grpc-gateway have a `result` vs `error` top-level property added,
+// which wraps the actual response. The old data-plane gateway returns unary RPC responses from the /list APIs,
+// which don't have a top-level `result` property.
+export const isNestedProtocolListResponse = (
+    response: { result: ProtocolListResponse } | ProtocolListResponse
+): response is { result: ProtocolListResponse } => 'result' in response;
+
 export const getJournals = async (
     brokerAddress: string,
     brokerToken: string,
     selector: ProtocolLabelSelector
-): Promise<{ result: ProtocolListResponse }> =>
+): Promise<{ result: ProtocolListResponse } | ProtocolListResponse> =>
     client(
         `${brokerAddress}/v1/journals/list`,
         { data: { selector } },


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1269

## Changes

### 1269

* Create a type guard that will identify the shape of the `/journals/list` API response.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

N/A