### PR TITLE
Correct error type in useShardEndpoint hook

### DIFF
--- a/src/hooks/shards/useShardEndpoints.ts
+++ b/src/hooks/shards/useShardEndpoints.ts
@@ -17,7 +17,7 @@ export const useShardEndpoints = (
                 const url = new URL(reactorAddress);
 
                 return url.host;
-            } catch (error: any) {
+            } catch (error: unknown) {
                 logRocketConsole('ShardEndpoint : error', { error });
             }
         }


### PR DESCRIPTION
## Changes

* Correct how the `error` in the catch block of `useShardEndpoint` is typed.

## Tests

### Manually tested

N/A

### Automated tests

N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

N/A