### PR TITLE
PROD: putting the GitPod link back

### DIFF
--- a/src/services/gitpod.ts
+++ b/src/services/gitpod.ts
@@ -4,6 +4,9 @@ import { RefreshTokenData } from 'types';
 
 const GIT_REPO = 'https://github.com/estuary/flow-gitpod-base';
 
+// WARNING GitPod can change the URL format at anytime
+// https://www.gitpod.io/docs/configure/repositories/environment-variables#providing-one-time-environment-variables-via-the-context-url
+//  Last verified Q4 2024
 export const generateGitPodURL = (
     draftId: string,
     token: RefreshTokenData,
@@ -15,11 +18,18 @@ export const generateGitPodURL = (
         ? sourceCollections.length
         : sourceCollections.size;
 
-    return `https://gitpod.io/#${GIT_REPO}?FLOW_DRAFT_ID=${encodeURIComponent(
+    const gitPodURL = `https://gitpod.io/#`;
+
+    const urlVariables = `FLOW_DRAFT_ID=${encodeURIComponent(
         draftId
     )},FLOW_REFRESH_TOKEN=${encodeURIComponent(
         Buffer.from(JSON.stringify(token)).toString('base64')
     )},FLOW_TEMPLATE_TYPE=${derivationLanguage},FLOW_TEMPLATE_MODE=${
         sourceCollectionCount > 1 ? 'multi' : 'single'
     },FLOW_COLLECTION_NAME=${encodeURIComponent(computedEntityName)}`;
+
+    // Must start with a slash to separate it from the variables
+    const gitRepoPath = `/${GIT_REPO}`;
+
+    return `${gitPodURL}${urlVariables}${gitRepoPath}`;
 };


### PR DESCRIPTION
The URL was fine - https://github.com/gitpod-io/gitpod/issues/20263 

Still breaking the code up a bit to make it more understandable

![image](https://github.com/user-attachments/assets/7ba03de7-08eb-4632-b916-4eb615c9b082)
