### PR TITLE
Removing all disabled bindings based on the draft during save

### DIFF
--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -235,7 +235,6 @@ const getInitialMiscData = (): Pick<
     | 'backfillDataFlowTarget'
     | 'backfillSupported'
     | 'collectionsRequiringRediscovery'
-    | 'disabledCollections'
     | 'discoveredCollections'
     | 'rediscoveryRequired'
     | 'resourceConfigErrorsExist'
@@ -251,7 +250,6 @@ const getInitialMiscData = (): Pick<
     backfillSupported: true,
     backfilledBindings: [],
     collectionsRequiringRediscovery: [],
-    disabledCollections: new Set(),
     discoveredCollections: [],
     rediscoveryRequired: false,
     resourceConfigErrorsExist: false,
@@ -377,7 +375,6 @@ const getInitialState = (
 
                 state.rediscoveryRequired = false;
                 state.collectionsRequiringRediscovery = [];
-                state.disabledCollections.clear();
 
                 state.backfilledBindings = [];
                 state.backfillAllBindings = false;
@@ -1099,8 +1096,6 @@ const getInitialState = (
                                     state.collectionsRequiringRediscovery
                                 );
                             }
-
-                            state.disabledCollections.add(collectionName);
                         } else {
                             delete state.resourceConfigs[uuid].meta.disable;
 
@@ -1111,8 +1106,6 @@ const getInitialState = (
 
                                 state.rediscoveryRequired = true;
                             }
-
-                            state.disabledCollections.delete(collectionName);
                         }
                     });
                 }),

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -1,4 +1,3 @@
-import { Entity } from 'types';
 import { useShallow } from 'zustand/react/shallow';
 import { FullSourceJsonForms } from './slices/TimeTravel';
 import { useBindingStore } from './Store';
@@ -150,18 +149,6 @@ export const useBinding_someBindingsDisabled = () => {
             Object.values(state.resourceConfigs).some(
                 (config) => config.meta.disable
             )
-        )
-    );
-};
-
-// We are only using this to clean up - hence checking for `capture` here because that
-//  is the only entity that we want to clean up disabled collections
-export const useBinding_disabledBindings = (entityType: Entity) => {
-    return useBindingStore(
-        useShallow((state) =>
-            entityType === 'capture'
-                ? Array.from(state.disabledCollections.keys())
-                : []
         )
     );
 };

--- a/src/stores/Binding/types.ts
+++ b/src/stores/Binding/types.ts
@@ -77,7 +77,6 @@ export interface BindingState
     ) => void;
 
     collectionsRequiringRediscovery: string[];
-    disabledCollections: Set<string>;
     rediscoveryRequired: boolean;
     resetRediscoverySettings: () => void;
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1305

## Changes

### 1305

- No longer keep a list of disabled collections
- Just read the bindings directly from the draft
     - Kinda sucks we have to loop over but this is by far the safest approach

## Tests

### Manually tested

- Discovered and rediscovered with postgres locally 

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [x] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [x] Materialization

## Screenshots

### Edited capture and did a rediscover. Left all the previously disabled disabled and those are now removed.
![image](https://github.com/user-attachments/assets/138a87af-32cf-4a6d-867b-ac206d255904)

