### PR TITLE
Updating so we keep the title and description in sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,6 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="initial-scale=1, width=device-width" />
         <meta name="theme-color" content="#000000" />
-        <meta
-            name="description"
-            content="The central, low-code environment for creating, managing, and monitoring Data Flows."
-        />
 
         <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
         <link rel="manifest" href="/manifest.json" />

--- a/src/context/UpdateHelmet.tsx
+++ b/src/context/UpdateHelmet.tsx
@@ -3,12 +3,12 @@ import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { BaseComponentProps } from 'types';
 
 const UpdateHelmetContext = React.createContext<{
-    updateOgDescription: (newVal: string | undefined) => void;
+    updateDescription: (newVal: string | undefined) => void;
     updateOgTitle: (newVal: string | undefined) => void;
     updateTitle: (newVal: string) => void;
 }>({
     updateTitle: () => {},
-    updateOgDescription: () => {},
+    updateDescription: () => {},
     updateOgTitle: () => {},
 });
 
@@ -18,7 +18,7 @@ const UpdateHelmetContext = React.createContext<{
 //  controlling Helmet. Probably want to "build it into" React Router configuration.
 const UpdateHelmetProvider = ({ children }: BaseComponentProps) => {
     const [title, setTitle] = useState<string | null>(null);
-    const [ogDescription, setOgDescription] = useState<string | undefined>(
+    const [description, setDescription] = useState<string | undefined>(
         undefined
     );
     const [ogTitle, setOgTitle] = useState<string | undefined>(undefined);
@@ -27,9 +27,9 @@ const UpdateHelmetProvider = ({ children }: BaseComponentProps) => {
         setTitle(newTitle);
     }, []);
 
-    const updateOgDescription = useCallback(
+    const updateDescription = useCallback(
         (newDescription: string | undefined) => {
-            setOgDescription(newDescription);
+            setDescription(newDescription);
         },
         []
     );
@@ -42,15 +42,17 @@ const UpdateHelmetProvider = ({ children }: BaseComponentProps) => {
         <HelmetProvider>
             <UpdateHelmetContext.Provider
                 value={{
-                    updateOgDescription,
+                    updateDescription,
                     updateOgTitle,
                     updateTitle,
                 }}
             >
                 <Helmet>
                     <title>{title}</title>
+                    <meta name="description" content={description} />
+
                     <meta property="og:title" content={ogTitle} />
-                    <meta property="og:description" content={ogDescription} />
+                    <meta property="og:description" content={description} />
                 </Helmet>
                 {children}
             </UpdateHelmetContext.Provider>

--- a/src/hooks/useBrowserTitle.ts
+++ b/src/hooks/useBrowserTitle.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 
 interface MetaSettings {
-    ogDescriptionKey?: string;
+    descriptionKey?: string;
     ogTitleKey?: string;
 }
 
@@ -14,40 +14,41 @@ function useBrowserTitle(
 ) {
     const intl = useIntl();
 
-    const { updateOgDescription, updateOgTitle, updateTitle } =
-        useUpdateHelmet();
+    const { updateDescription, updateOgTitle, updateTitle } = useUpdateHelmet();
 
     useEffect(() => {
-        updateTitle(
-            `${intl.formatMessage({
-                id: prefixKey ?? 'common.browserTitle',
-            })} | ${intl.formatMessage({
-                id: titleKey,
-            })}`
-        );
+        const newTitle = `${intl.formatMessage({
+            id: prefixKey ?? 'common.browserTitle',
+        })} | ${intl.formatMessage({
+            id: titleKey,
+        })}`;
 
+        updateTitle(newTitle);
+
+        // We do not have any pass in an og:title today
+        //  but added it anyway just in case we need it
         updateOgTitle(
             metaSettings?.ogTitleKey
                 ? `${intl.formatMessage({
                       id: metaSettings.ogTitleKey,
                   })}`
-                : undefined
+                : newTitle
         );
 
-        updateOgDescription(
+        updateDescription(
             `${intl.formatMessage({
                 id:
-                    metaSettings?.ogDescriptionKey ??
-                    'routeTitle.default.ogDescription',
+                    metaSettings?.descriptionKey ??
+                    'routeTitle.login.description',
             })}`
         );
     }, [
         intl,
         metaSettings?.ogTitleKey,
-        metaSettings?.ogDescriptionKey,
+        metaSettings?.descriptionKey,
         prefixKey,
         titleKey,
-        updateOgDescription,
+        updateDescription,
         updateOgTitle,
         updateTitle,
     ]);

--- a/src/lang/en-US/RouteTitles.ts
+++ b/src/lang/en-US/RouteTitles.ts
@@ -1,8 +1,5 @@
 import { CommonMessages } from './CommonMessages';
 
-const defaultDescription =
-    'Access the Estuary Flow dashboard to manage real-time data pipelines, integrations, and configurations in one place.';
-
 export const RouteTitles: Record<string, string> = {
     'routeTitle.home': `Welcome`,
     'routeTitle.dashboard': `Dashboard`,
@@ -37,14 +34,13 @@ export const RouteTitles: Record<string, string> = {
     //  The some of these strings are generated in login/Basic and login/Enterprise
     'routeTitle.login': `Manage Your Data Pipelines`,
     'routeTitle.login.prefix': `${CommonMessages.productName} Dashboard`,
+    'routeTitle.login.description': `Access the Estuary Flow dashboard to manage real-time data pipelines, integrations, and configurations in one place.`,
 
-    'routeTitle.login.sso.ogTitle': `Estuary Flow SSO Login | Secure Access to Your Account`,
-    'routeTitle.login.sso.ogDescription': `Log in securely to Estuary Flow using Single Sign-On (SSO) and manage your data pipelines with ease.`,
+    'routeTitle.login.sso': `Secure Access to Your Account`,
+    'routeTitle.login.sso.prefix': `Estuary Flow SSO Login`,
+    'routeTitle.login.sso.description': `Log in securely to Estuary Flow using Single Sign-On (SSO) and manage your data pipelines with ease.`,
 
     'routeTitle.register': `Build Data Pipelines`,
     'routeTitle.register.prefix': `Register for ${CommonMessages.productName}`,
-    'routeTitle.register.ogTitle': `Register for Estuary Flow | Build Data Pipelines`,
-    'routeTitle.register.ogDescription': `Create your free Estuary Flow account and start building real-time data pipelines with ease. No credit card required, and enjoy a 30-day free trial`,
-
-    'routeTitle.default.ogDescription': `${defaultDescription}`,
+    'routeTitle.register.description': `Create your free Estuary Flow account and start building real-time data pipelines with ease. No credit card required, and enjoy a 30-day free trial`,
 };

--- a/src/pages/login/Basic.tsx
+++ b/src/pages/login/Basic.tsx
@@ -25,16 +25,11 @@ const BasicLogin = ({ showRegistration }: Props) => {
     const { grantToken, isRegister, tabIndex, handleChange } =
         useLoginStateHandler(showRegistration);
 
-    useBrowserTitle(
-        'routeTitle.login',
-        'routeTitle.login.prefix',
-        isRegister
-            ? {
-                  ogDescriptionKey: `routeTitle.register.ogDescription`,
-                  ogTitleKey: `routeTitle.register.ogTitle`,
-              }
-            : undefined
-    );
+    const titleKey = isRegister ? 'routeTitle.login' : 'routeTitle.register';
+
+    useBrowserTitle(titleKey, `${titleKey}.prefix`, {
+        descriptionKey: `${titleKey}.description`,
+    });
 
     return (
         <LoginWrapper

--- a/src/pages/login/Basic.tsx
+++ b/src/pages/login/Basic.tsx
@@ -25,7 +25,7 @@ const BasicLogin = ({ showRegistration }: Props) => {
     const { grantToken, isRegister, tabIndex, handleChange } =
         useLoginStateHandler(showRegistration);
 
-    const titleKey = isRegister ? 'routeTitle.login' : 'routeTitle.register';
+    const titleKey = isRegister ? 'routeTitle.register' : 'routeTitle.login';
 
     useBrowserTitle(titleKey, `${titleKey}.prefix`, {
         descriptionKey: `${titleKey}.description`,

--- a/src/pages/login/Enterprise.tsx
+++ b/src/pages/login/Enterprise.tsx
@@ -5,12 +5,10 @@ import LoginWrapper from './Wrapper';
 
 const titleKey = 'routeTitle.login.sso';
 const ogDescriptionKey = `${titleKey}.description`;
-const metaTitleKey = `${titleKey}.ogTitle`;
 
 const EnterpriseLogin = () => {
-    useBrowserTitle('routeTitle.login', 'routeTitle.login.prefix', {
-        ogDescriptionKey,
-        ogTitleKey: metaTitleKey,
+    useBrowserTitle('routeTitle.login.sso', 'routeTitle.login.sso.prefix', {
+        descriptionKey: ogDescriptionKey,
     });
 
     const { grantToken, isRegister, tabIndex } = useLoginStateHandler(false);


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1307

## Changes

### 1307

- Forced the `description' and `og:description' to stay in sync
- Let the `title` and `og:title` fallback to stay in sync
- Removed the `description` from the `index` as that was not being removed by helmet

## Tests

### Manually tested

- Hit a few pages to check out the elements

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Login
![image](https://github.com/user-attachments/assets/a4fdd8b9-59f5-4c17-ba02-7421b4d2d2a0)

### Register
![image](https://github.com/user-attachments/assets/3a399cac-4394-4f2c-8f93-13307443dbf2)

### SSO
![image](https://github.com/user-attachments/assets/c9952aec-df7e-4a78-9e44-2a12421bac62)

