### PR TITLE
Adding ability for collapsible group to reset data and details graph message

### DIFF
--- a/src/components/shared/Entity/Details/Usage/DelayWarning.tsx
+++ b/src/components/shared/Entity/Details/Usage/DelayWarning.tsx
@@ -1,0 +1,29 @@
+import { Stack, Tooltip, Typography } from '@mui/material';
+import { useSyncScheduleDelayWarning } from 'hooks/details/useSyncScheduleDelayWarning';
+import { HelpCircle } from 'iconoir-react';
+import { useIntl } from 'react-intl';
+
+function DelayWarning() {
+    const intl = useIntl();
+
+    const reportingDelayMessage = useSyncScheduleDelayWarning();
+
+    if (!reportingDelayMessage) {
+        return null;
+    }
+
+    return (
+        <Stack direction="row" spacing={1} sx={{ justifyContent: 'end' }}>
+            <Typography variant="caption">{reportingDelayMessage}</Typography>
+            <Tooltip
+                title={intl.formatMessage({
+                    id: 'detailsPanel.graph.syncDelay.tooltip',
+                })}
+            >
+                <HelpCircle style={{ fontSize: 11 }} />
+            </Tooltip>
+        </Stack>
+    );
+}
+
+export default DelayWarning;

--- a/src/components/shared/Entity/Details/Usage/index.tsx
+++ b/src/components/shared/Entity/Details/Usage/index.tsx
@@ -10,6 +10,7 @@ import useDetailsStats from 'hooks/useDetailsStats';
 import { FormattedMessage } from 'react-intl';
 import { checkErrorMessage, FAILED_TO_FETCH } from 'services/shared';
 import { hasLength } from 'utils/misc-utils';
+import DelayWarning from './DelayWarning';
 
 interface Props {
     catalogName: string;
@@ -59,6 +60,8 @@ function Usage({ catalogName }: Props) {
                     }
                 />
             )}
+
+            <DelayWarning />
         </CardWrapper>
     );
 }

--- a/src/forms/README.md
+++ b/src/forms/README.md
@@ -1,0 +1,3 @@
+# What is this?
+
+This houses all the custom/overwritten **renderers** that we use. However, this is not everything related to customization. Make sure you also look in `/src/services/jsonforms/` for more.

--- a/src/forms/renderers/CollapsibleGroup.tsx
+++ b/src/forms/renderers/CollapsibleGroup.tsx
@@ -3,20 +3,25 @@ import {
     MaterialLayoutRenderer,
     MaterialLayoutRendererProps,
 } from '@jsonforms/material-renderers';
-import { withJsonFormsLayoutProps } from '@jsonforms/react';
 import {
     Accordion,
     AccordionDetails,
     AccordionSummary,
+    Button,
+    Box,
     Hidden,
     Typography,
     useTheme,
+    Tooltip,
 } from '@mui/material';
 import { defaultOutline, jsonFormsGroupHeaders } from 'context/Theme';
-import { NavArrowDown } from 'iconoir-react';
+import { NavArrowDown, Xmark } from 'iconoir-react';
+import { useIntl } from 'react-intl';
+import { withCustomJsonFormsLayoutProps } from 'services/jsonforms/JsonFormsContext';
 import {
     ADVANCED,
     CONTAINS_REQUIRED_FIELDS,
+    LAYOUT_PATH,
     SHOW_INFO_SSH_ENDPOINT,
 } from 'services/jsonforms/shared';
 import SshEndpointInfo from './Informational/SshEndpoint';
@@ -31,18 +36,19 @@ export const collapsibleGroupTester: RankedTester = rankWith(
 // TODO (typing) Just used any here as it makes things easier.
 //  previous versions had more typing but the typing wasn't 100% correct
 const CollapsibleGroupRenderer = ({
+    childrenHaveValue,
     uischema,
     schema,
-    path,
     visible,
     renderers,
+    handleChange,
 }: any) => {
+    const intl = useIntl();
     const theme = useTheme();
 
     const layoutProps = {
         elements: uischema.elements,
         schema,
-        path,
         direction: 'column' as MaterialLayoutRendererProps['direction'],
         visible,
         uischema,
@@ -50,10 +56,11 @@ const CollapsibleGroupRenderer = ({
     };
 
     const uiSchemaOptions = uischema.options ?? {};
+
+    const hasRequiredFields =
+        uiSchemaOptions[CONTAINS_REQUIRED_FIELDS] === true;
     const expand =
-        uiSchemaOptions[CONTAINS_REQUIRED_FIELDS] === true ||
-        uiSchemaOptions[ADVANCED] !== true ||
-        false;
+        hasRequiredFields || uiSchemaOptions[ADVANCED] !== true || false;
 
     return (
         <Hidden xsUp={!visible}>
@@ -86,6 +93,49 @@ const CollapsibleGroupRenderer = ({
                         <SshEndpointInfo />
                     ) : null}
 
+                    {uiSchemaOptions[LAYOUT_PATH] ? (
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                justifyContent: 'end',
+                                my: 1,
+                            }}
+                        >
+                            <Tooltip
+                                title={intl.formatMessage({
+                                    id: 'jsonForms.clearGroup.message',
+                                })}
+                            >
+                                <Button
+                                    disabled={!Boolean(childrenHaveValue)}
+                                    variant="text"
+                                    size="small"
+                                    onClick={() => {
+                                        handleChange(
+                                            uiSchemaOptions[LAYOUT_PATH],
+                                            undefined
+                                        );
+                                    }}
+                                    startIcon={
+                                        <Xmark style={{ fontSize: 13 }} />
+                                    }
+                                    sx={{
+                                        maxWidth: '75%',
+                                    }}
+                                >
+                                    {intl.formatMessage(
+                                        {
+                                            id: 'jsonForms.clearGroup',
+                                        },
+                                        {
+                                            label: uischema.label,
+                                        }
+                                    )}
+                                </Button>
+                            </Tooltip>
+                        </Box>
+                    ) : null}
+
                     <MaterialLayoutRenderer {...layoutProps} />
                 </AccordionDetails>
             </Accordion>
@@ -93,6 +143,6 @@ const CollapsibleGroupRenderer = ({
     );
 };
 
-export const CollapsibleGroup = withJsonFormsLayoutProps(
+export const CollapsibleGroup = withCustomJsonFormsLayoutProps(
     CollapsibleGroupRenderer
 );

--- a/src/forms/renderers/CollapsibleGroup.tsx
+++ b/src/forms/renderers/CollapsibleGroup.tsx
@@ -20,8 +20,8 @@ import { useIntl } from 'react-intl';
 import { withCustomJsonFormsLayoutProps } from 'services/jsonforms/JsonFormsContext';
 import {
     ADVANCED,
+    CHILDREN_HAVE_VALUE,
     CONTAINS_REQUIRED_FIELDS,
-    LAYOUT_PATH,
     SHOW_INFO_SSH_ENDPOINT,
 } from 'services/jsonforms/shared';
 import SshEndpointInfo from './Informational/SshEndpoint';
@@ -36,12 +36,11 @@ export const collapsibleGroupTester: RankedTester = rankWith(
 // TODO (typing) Just used any here as it makes things easier.
 //  previous versions had more typing but the typing wasn't 100% correct
 const CollapsibleGroupRenderer = ({
-    childrenHaveValue,
     uischema,
     schema,
     visible,
     renderers,
-    handleChange,
+    clearSettings,
 }: any) => {
     const intl = useIntl();
     const theme = useTheme();
@@ -93,7 +92,7 @@ const CollapsibleGroupRenderer = ({
                         <SshEndpointInfo />
                     ) : null}
 
-                    {uiSchemaOptions[LAYOUT_PATH] ? (
+                    {clearSettings ? (
                         <Box
                             sx={{
                                 display: 'flex',
@@ -107,15 +106,14 @@ const CollapsibleGroupRenderer = ({
                                 })}
                             >
                                 <Button
-                                    disabled={!Boolean(childrenHaveValue)}
+                                    disabled={
+                                        !Boolean(
+                                            uiSchemaOptions[CHILDREN_HAVE_VALUE]
+                                        )
+                                    }
                                     variant="text"
                                     size="small"
-                                    onClick={() => {
-                                        handleChange(
-                                            uiSchemaOptions[LAYOUT_PATH],
-                                            undefined
-                                        );
-                                    }}
+                                    onClick={clearSettings}
                                     startIcon={
                                         <Xmark style={{ fontSize: 13 }} />
                                     }

--- a/src/forms/renderers/CollapsibleGroup.tsx
+++ b/src/forms/renderers/CollapsibleGroup.tsx
@@ -57,10 +57,10 @@ const CollapsibleGroupRenderer = ({
 
     const uiSchemaOptions = uischema.options ?? {};
 
-    const hasRequiredFields =
-        uiSchemaOptions[CONTAINS_REQUIRED_FIELDS] === true;
     const expand =
-        hasRequiredFields || uiSchemaOptions[ADVANCED] !== true || false;
+        uiSchemaOptions[CONTAINS_REQUIRED_FIELDS] === true ||
+        uiSchemaOptions[ADVANCED] !== true ||
+        false;
 
     return (
         <Hidden xsUp={!visible}>

--- a/src/hooks/details/useSyncScheduleDelayWarning.ts
+++ b/src/hooks/details/useSyncScheduleDelayWarning.ts
@@ -1,0 +1,63 @@
+import { useEditorStore_currentCatalog } from 'components/editor/Store/hooks';
+import { useMemo } from 'react';
+import { useIntl } from 'react-intl';
+import { logRocketEvent } from 'services/shared';
+import { Duration } from 'luxon';
+import { CustomEvents } from 'services/types';
+
+export function useSyncScheduleDelayWarning() {
+    const intl = useIntl();
+
+    const currentCatalog = useEditorStore_currentCatalog({
+        localScope: true,
+    });
+
+    return useMemo(() => {
+        const syncFrequency =
+            currentCatalog?.spec?.endpoint?.connector?.config?.syncSchedule
+                ?.syncFrequency;
+
+        if (syncFrequency) {
+            if (syncFrequency === '0s') {
+                logRocketEvent(CustomEvents.SYNC_SCHEDULE, {
+                    zeroSeconds: true,
+                });
+                return intl.formatMessage({
+                    id: 'detailsPanel.graph.syncDelay.default',
+                });
+            }
+
+            // The pattern we have is pretty close to ISO 8601 so
+            //  preface with PT and hope it works
+            const syncDuration = Duration.fromISO(
+                `PT${syncFrequency.toUpperCase()}`
+            );
+
+            // If we cannot parse the duration fire event and use default message
+            if (!syncDuration.isValid) {
+                logRocketEvent(CustomEvents.SYNC_SCHEDULE, {
+                    invalid: true,
+                    frequency: syncFrequency,
+                });
+                return intl.formatMessage({
+                    id: 'detailsPanel.graph.syncDelay.default',
+                });
+            }
+
+            // Add duration to itself to double the time
+            const reportingDelay = syncDuration.plus(syncDuration).toHuman();
+            return intl.formatMessage(
+                { id: 'detailsPanel.graph.syncDelay' },
+                {
+                    reportingDelay,
+                }
+            );
+        }
+
+        return undefined;
+    }, [
+        currentCatalog?.spec?.endpoint?.connector?.config?.syncSchedule
+            ?.syncFrequency,
+        intl,
+    ]);
+}

--- a/src/hooks/details/useSyncScheduleDelayWarning.ts
+++ b/src/hooks/details/useSyncScheduleDelayWarning.ts
@@ -18,7 +18,13 @@ export function useSyncScheduleDelayWarning() {
                 ?.syncFrequency;
 
         if (syncFrequency) {
-            if (syncFrequency === '0s') {
+            // Upper case to match the ISO 8601 duration format AND make it
+            //  safer to check the string value
+            const formattedSyncFrequency = syncFrequency.toUpperCase();
+
+            // If the requency is 0 then just show default otherwise the math and
+            //  message would make no sense
+            if (formattedSyncFrequency === '0S') {
                 logRocketEvent(CustomEvents.SYNC_SCHEDULE, {
                     zeroSeconds: true,
                 });
@@ -30,7 +36,7 @@ export function useSyncScheduleDelayWarning() {
             // The pattern we have is pretty close to ISO 8601 so
             //  preface with PT and hope it works
             const syncDuration = Duration.fromISO(
-                `PT${syncFrequency.toUpperCase()}`
+                `PT${formattedSyncFrequency}`
             );
 
             // If we cannot parse the duration fire event and use default message

--- a/src/hooks/details/useSyncScheduleDelayWarning.ts
+++ b/src/hooks/details/useSyncScheduleDelayWarning.ts
@@ -12,6 +12,9 @@ export function useSyncScheduleDelayWarning() {
         localScope: true,
     });
 
+    // TODO (delay warning) - we may want to add file based support
+    // file based materializations (iceberg, parquet/csv sinks etc.) use a
+    //  similar mechanism for commit delaying is under a different option
     return useMemo(() => {
         const syncFrequency =
             currentCatalog?.spec?.endpoint?.connector?.config?.syncSchedule

--- a/src/lang/en-US/Details.ts
+++ b/src/lang/en-US/Details.ts
@@ -55,4 +55,6 @@ export const Details: Record<string, string> = {
     'detailsPanel.details.linkToCollection': `View details for {catalogName}`,
 
     'detailsPanel.graph.timezone': `{relativeUnit} in`,
+    'detailsPanel.graph.syncDelay': `Reporting can be delayed by up to {reportingDelay}`,
+    'detailsPanel.graph.syncDelay.default': `Reporting can be delayed due to sync schedule`,
 };

--- a/src/lang/en-US/Details.ts
+++ b/src/lang/en-US/Details.ts
@@ -55,6 +55,7 @@ export const Details: Record<string, string> = {
     'detailsPanel.details.linkToCollection': `View details for {catalogName}`,
 
     'detailsPanel.graph.timezone': `{relativeUnit} in`,
-    'detailsPanel.graph.syncDelay': `Reporting can be delayed by up to {reportingDelay}`,
-    'detailsPanel.graph.syncDelay.default': `Reporting can be delayed due to sync schedule`,
+    'detailsPanel.graph.syncDelay': `Reporting can be delayed by up to {reportingDelay} for this materialization`,
+    'detailsPanel.graph.syncDelay.default': `Reporting can be delayed due to update delay for this materialization`,
+    'detailsPanel.graph.syncDelay.tooltip': `Reporting can be delayed by up to 2x the set update delay in the configuration.`,
 };

--- a/src/lang/en-US/JsonForms.ts
+++ b/src/lang/en-US/JsonForms.ts
@@ -5,7 +5,7 @@ export const JsonForms: Record<string, string> = {
 
     // Group
     'jsonForms.clearGroup': `Clear {label}`,
-    'jsonForms.clearGroup.message': `Will full remove this group and all children from configuration.`,
+    'jsonForms.clearGroup.message': `Remove this group and all children.`,
 
     // Custom Renderers
     'dateTimePicker.button.ariaLabel': `Open date time picker for {label}`,

--- a/src/lang/en-US/JsonForms.ts
+++ b/src/lang/en-US/JsonForms.ts
@@ -3,6 +3,10 @@ import { Errors } from './Errors';
 export const JsonForms: Record<string, string> = {
     'jsonForms.clearInput': `Clear input field`,
 
+    // Group
+    'jsonForms.clearGroup': `Clear {label}`,
+    'jsonForms.clearGroup.message': `Will full remove this group and all children from configuration.`,
+
     // Custom Renderers
     'dateTimePicker.button.ariaLabel': `Open date time picker for {label}`,
     'dateTimePicker.picker.currentStep': `Selecting: {currentStep}`,

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -36,6 +36,7 @@ import {
     Layout,
     resolveSchema,
     toDataPath,
+    toDataPathSegments,
     UISchemaElement,
 } from '@jsonforms/core';
 import { concat, includes, isPlainObject, orderBy } from 'lodash';
@@ -49,6 +50,7 @@ import {
     ADVANCED,
     allowedNullableTypes,
     CONTAINS_REQUIRED_FIELDS,
+    LAYOUT_PATH,
     SHOW_INFO_SSH_ENDPOINT,
 } from './shared';
 
@@ -201,6 +203,16 @@ const addRequiredGroupOptions = (
 const addInfoSshEndpoint = (elem: Layout | ControlElement | GroupLayout) => {
     if (!Object.hasOwn(elem.options ?? {}, SHOW_INFO_SSH_ENDPOINT)) {
         addOption(elem, SHOW_INFO_SSH_ENDPOINT, true);
+    }
+};
+
+const addLayoutPath = (
+    elem: Layout | ControlElement | GroupLayout,
+    path: string
+) => {
+    if (!Object.hasOwn(elem.options ?? {}, LAYOUT_PATH)) {
+        // Based on `fromScoped` in jsonforms/packages/core/src/util/util.ts
+        addOption(elem, LAYOUT_PATH, toDataPathSegments(path).join('.'));
     }
 };
 
@@ -441,6 +453,8 @@ const generateUISchema = (
     const isRequired = isRequiredField(schemaName, rootSchema);
 
     if (isPlainObject(jsonSchema)) {
+        console.log('jsonSchema', jsonSchema);
+
         if (isCombinator(jsonSchema) && isAdvancedConfig(jsonSchema)) {
             // Always create a Group for "advanced" configuration objects, so that we can collapse it and
             // see the label.
@@ -557,6 +571,11 @@ const generateUISchema = (
                 if (containsSshEndpoint(jsonSchema)) {
                     addInfoSshEndpoint(layout);
                 }
+
+                // This is only used within the CollapsibleGroup (Q4 2024)
+                // Need to add a path to group layouts so we can allow users to clear them
+                //  out when they are optional.
+                addLayoutPath(layout, currentRef);
             }
         } else {
             layout = createLayout(layoutType);

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -180,22 +180,15 @@ const isOAuthConfig = (schema: JsonSchema): boolean => {
     return Object.hasOwn(schema, Annotations.oAuthProvider);
 };
 
-const hasOnlyOneChildAsObject = (schema: JsonSchema) => {
-    if (!schema.properties) {
-        return false;
-    }
-
-    // Many or zero can both return false as this is mainly just checking
-    //  so we don't show the "clear section" button nested.
-    //  An example of a config that this helps is Network Tunneling
-    const propertiesAsArray = Object.values(schema.properties);
-    if (propertiesAsArray.length !== 1) {
-        return false;
-    }
-
-    // Make sure the child is an object
-    return propertiesAsArray[0].type === 'object';
-};
+// TODO (reset section) might want to know if there are multiple children in future
+// const getChildObjectCount = (schema: JsonSchema) => {
+//     if (!schema.properties) {
+//         return 0;
+//     }
+//     return Object.values(schema.properties).map(
+//         (property) => property.type === 'object'
+//     ).length;
+// };
 
 const copyAdvancedOption = (elem: Layout, schema: JsonSchema) => {
     if (isAdvancedConfig(schema)) {
@@ -587,13 +580,7 @@ const generateUISchema = (
                     addInfoSshEndpoint(layout);
                 }
 
-                // Check if the group only houses one child that is an object.
-                //  that way we do not add the layoutPath and cause two
-                //  "clear section" buttons to be shown really close to each other.
-                if (!hasOnlyOneChildAsObject(jsonSchema)) {
-                    // This is only used within the CollapsibleGroup (Q4 2024)
-                    addLayoutPath(layout, currentRef);
-                }
+                addLayoutPath(layout, currentRef);
             }
         } else {
             layout = createLayout(layoutType);

--- a/src/services/jsonforms/shared.ts
+++ b/src/services/jsonforms/shared.ts
@@ -1,6 +1,7 @@
 import { ValidationMode } from '@jsonforms/core';
 
 export const CONTAINS_REQUIRED_FIELDS = 'containsRequiredFields';
+export const LAYOUT_PATH = 'layoutPath';
 export const SHOW_INFO_SSH_ENDPOINT = 'showInfo_sshEndpoint';
 export const ADVANCED = 'advanced';
 

--- a/src/services/jsonforms/shared.ts
+++ b/src/services/jsonforms/shared.ts
@@ -1,6 +1,7 @@
 import { ValidationMode } from '@jsonforms/core';
 
 export const CONTAINS_REQUIRED_FIELDS = 'containsRequiredFields';
+export const CHILDREN_HAVE_VALUE = 'childrenHaveValue';
 export const LAYOUT_PATH = 'layoutPath';
 export const SHOW_INFO_SSH_ENDPOINT = 'showInfo_sshEndpoint';
 export const ADVANCED = 'advanced';

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -55,6 +55,7 @@ export enum CustomEvents {
     OAUTH_WINDOW_OPENER = 'Oauth_Window_Opener',
     REPUBLISH_PREFIX_FAILED = 'Republish_Prefix:Failed',
     STRIPE_FORM_LOADING_FAILED = 'Stripe_Form_Loading_Failed',
+    SYNC_SCHEDULE = 'Sync_Schedule',
     SUPABASE_CALL_FAILED = 'Supabase_Call_Failed',
     SUPABASE_CALL_UNAUTHENTICATED = 'Supabase_Call_Unauthenticated',
     SWR_LOADING_SLOW = 'SWR_Loading_Slow',

--- a/src/stores/DetailsForm/Store.ts
+++ b/src/stores/DetailsForm/Store.ts
@@ -27,7 +27,7 @@ import {
     parseDataPlaneName,
     PUBLIC_DATA_PLANE_PREFIX,
 } from 'utils/dataPlane-utils';
-import { defaultDataPlaneSuffix } from 'utils/env-utils';
+import { defaultDataPlaneSuffix, isProduction } from 'utils/env-utils';
 import { hasLength } from 'utils/misc-utils';
 import { devtoolsOptions } from 'utils/store-utils';
 import {
@@ -346,7 +346,19 @@ export const getInitialState = (
                 const connectorImage = await getConnectorImage(connectorId);
                 const dataPlane = getDataPlane(dataPlaneOptions, dataPlaneId);
 
-                if (connectorImage && dataPlane !== null) {
+                if (!isProduction && connectorImage && dataPlane === null) {
+                    get().setDetails_connector(connectorImage);
+
+                    const {
+                        data: { entityName },
+                        errors,
+                    } = initialDetails;
+
+                    get().setPreviousDetails({
+                        data: { entityName, connectorImage },
+                        errors,
+                    });
+                } else if (connectorImage && dataPlane !== null) {
                     get().setDetails_connector(connectorImage);
 
                     const {


### PR DESCRIPTION
## Issues

completes https://github.com/estuary/ui/issues/1353
completes https://github.com/estuary/ui/issues/1352

## Changes

### 1353

- Add ability to clear collapsible sections

### 1352

- Add message that informs users about potential delay
- Added a backup message in case we cannot get duration time

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### 1353
Show a button with the same label
![image](https://github.com/user-attachments/assets/70a9ce0d-5365-4bff-9da5-a923c72cd4dd)

Shows enabled when there is data
![image](https://github.com/user-attachments/assets/0737225d-b353-4362-95ba-7e3e5d387db3)

Tooltip to explain
![image](https://github.com/user-attachments/assets/db78df55-c1ee-4782-8b72-07307dc2e5c8)

We will show two clears for different objects to keep it simple right now
![image](https://github.com/user-attachments/assets/f4eecdd2-6889-4fd0-a411-2bd2c0284da8)


### 1352
Show a delay message
![image](https://github.com/user-attachments/assets/7e8e485a-6c48-4d65-a3df-c1fa520e7855)
![image](https://github.com/user-attachments/assets/042fd47f-ec09-4896-adf9-e2352d0794b9)

Show default delay if we cannot parse sync OR it is `0s`
![image](https://github.com/user-attachments/assets/5669439d-f131-4eb8-b6b1-a110241c5a53)
