### PR TITLE
Introduce an `interval` field to capture workflows

### DIFF
--- a/src/components/capture/Interval/index.tsx
+++ b/src/components/capture/Interval/index.tsx
@@ -23,8 +23,6 @@ import { hasLength } from 'utils/misc-utils';
 import { CAPTURE_INTERVAL_RE } from 'validation';
 import { CaptureIntervalProps } from './types';
 
-const DESCRIPTION_ID = 'capture-interval-description';
-
 function CaptureInterval({ readOnly }: CaptureIntervalProps) {
     const intl = useIntl();
     const label = intl.formatMessage({
@@ -124,7 +122,7 @@ function CaptureInterval({ readOnly }: CaptureIntervalProps) {
                 value={input}
             />
 
-            <FormHelperText id={DESCRIPTION_ID} style={{ marginLeft: 0 }}>
+            <FormHelperText style={{ marginLeft: 0 }}>
                 {intl.formatMessage(
                     { id: 'captureInterval.input.description' },
                     {
@@ -137,11 +135,7 @@ function CaptureInterval({ readOnly }: CaptureIntervalProps) {
             </FormHelperText>
 
             {errorsExist ? (
-                <FormHelperText
-                    id={DESCRIPTION_ID}
-                    error={errorsExist}
-                    style={{ marginLeft: 0 }}
-                >
+                <FormHelperText error={errorsExist} style={{ marginLeft: 0 }}>
                     {intl.formatMessage({
                         id: 'captureInterval.error.intervalFormat',
                     })}

--- a/src/components/capture/Interval/index.tsx
+++ b/src/components/capture/Interval/index.tsx
@@ -115,7 +115,6 @@ function CaptureInterval({ readOnly }: CaptureIntervalProps) {
                         error={errorsExist}
                         label={label}
                         size="small"
-                        variant="outlined"
                     />
                 )}
                 sx={{ width: 400 }}

--- a/src/components/capture/Interval/index.tsx
+++ b/src/components/capture/Interval/index.tsx
@@ -74,7 +74,7 @@ function CaptureInterval({ readOnly }: CaptureIntervalProps) {
                 </Tooltip>
             </Stack>
 
-            <Typography style={{ marginBottom: 16 }}>
+            <Typography>
                 <FormattedMessage id="captureInterval.message" />
             </Typography>
 

--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -1,5 +1,6 @@
 import { Stack, Typography, useTheme } from '@mui/material';
 import AutoDiscoverySettings from 'components/capture/AutoDiscoverySettings';
+import CaptureInterval from 'components/capture/Interval';
 import BindingsEditor from 'components/editor/Bindings/Editor';
 import BindingSelector from 'components/editor/Bindings/Selector';
 import ListAndDetails from 'components/editor/ListAndDetails';
@@ -103,7 +104,7 @@ function BindingsMultiEditor({
             <Stack spacing={3} sx={{ mb: 5 }}>
                 {entityType === 'capture' ? <AutoDiscoverySettings /> : null}
 
-                {/* {entityType === 'capture' ? <CaptureInterval /> : null} */}
+                {entityType === 'capture' ? <CaptureInterval /> : null}
 
                 {entityType === 'materialization' ? <SourceCapture /> : null}
 

--- a/src/hooks/captureInterval/useCaptureInterval.ts
+++ b/src/hooks/captureInterval/useCaptureInterval.ts
@@ -5,15 +5,7 @@ import {
     useEditorStore_queryResponse_mutate,
 } from 'components/editor/Store/hooks';
 import { debounce, omit } from 'lodash';
-import {
-    Dispatch,
-    SetStateAction,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
 import { useBindingStore } from 'stores/Binding/Store';
@@ -23,11 +15,7 @@ import { Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
 import { formatCaptureInterval } from 'utils/time-utils';
 import { DEFAULT_DEBOUNCE_WAIT } from 'utils/workflow-utils';
-import {
-    CAPTURE_INTERVAL_RE,
-    NUMERIC_RE,
-    POSTGRES_INTERVAL_RE,
-} from 'validation';
+import { CAPTURE_INTERVAL_RE } from 'validation';
 
 export default function useCaptureInterval() {
     // Binding Store
@@ -123,35 +111,14 @@ export default function useCaptureInterval() {
         }, DEFAULT_DEBOUNCE_WAIT)
     );
 
-    const updateStoredInterval = (
-        input: string,
-        unit: string,
-        setUnit?: Dispatch<SetStateAction<string>>
-    ) => {
+    const updateStoredInterval = (input: string) => {
         const trimmedInput = input.trim();
 
-        const postgresIntervalFormat = POSTGRES_INTERVAL_RE.test(trimmedInput);
-        const captureIntervalFormat = CAPTURE_INTERVAL_RE.test(trimmedInput);
-
-        const unitlessInterval =
-            !hasLength(trimmedInput) ||
-            postgresIntervalFormat ||
-            captureIntervalFormat;
-
         if (
-            setUnit &&
-            hasLength(trimmedInput) &&
-            (postgresIntervalFormat || captureIntervalFormat)
+            !hasLength(trimmedInput) ||
+            CAPTURE_INTERVAL_RE.test(trimmedInput)
         ) {
-            setUnit('i');
-        }
-
-        if (unitlessInterval || NUMERIC_RE.test(trimmedInput)) {
-            const interval = unitlessInterval
-                ? trimmedInput
-                : `${trimmedInput}${unit}`;
-
-            setCaptureInterval(interval);
+            setCaptureInterval(trimmedInput);
             debounceSeverUpdate.current();
         }
     };

--- a/src/lang/en-US/Captures.ts
+++ b/src/lang/en-US/Captures.ts
@@ -96,6 +96,5 @@ export const Captures: Record<string, string> = {
     'captureInterval.input.hours': `hours`,
     'captureInterval.input.interval': `interval`,
     'captureInterval.error.updateFailed': `Polling interval update failed`,
-    'captureInterval.error.intervalFormat': `Intervals must be formatted as HH:MM:SS or [0-9]+(s|m|h).`,
-    'captureInterval.error.generalFormat': `Only numeric input is allowed.`,
+    'captureInterval.error.intervalFormat': `Intervals must be formatted as [0-9]+(s|m|h).`,
 };

--- a/src/lang/en-US/Captures.ts
+++ b/src/lang/en-US/Captures.ts
@@ -88,7 +88,7 @@ export const Captures: Record<string, string> = {
     // Capture Interval
     'captureInterval.header': `Polling Interval`,
     'captureInterval.message': `Controls how often the Capture will check for new data. Intervals are relative to the start of an invocation and not its completion.`,
-    'captureInterval.tooltip': `For example, if the interval is five minutes, and an invocation of the capture finishes after two minutes, then the next invocation will be started after three additional minutes.`,
+    'captureInterval.tooltip': `If the interval is five minutes, and an invocation of the capture finishes after two minutes, then the next invocation will be started after three additional minutes.`,
     'captureInterval.input.label': `Interval`,
     'captureInterval.input.description': `The default polling interval is {value}.`,
     'captureInterval.input.seconds': `seconds`,

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -20,7 +20,6 @@ import {
     pick,
     union,
 } from 'lodash';
-import { Duration } from 'luxon';
 import { createJSONFormDefaults } from 'services/ajv';
 import { logRocketEvent } from 'services/shared';
 import { BASE_ERROR } from 'services/supabase';
@@ -34,7 +33,7 @@ import { populateErrors } from 'stores/utils';
 import { Entity, Schema } from 'types';
 import { getDereffedSchema, hasLength } from 'utils/misc-utils';
 import { devtoolsOptions } from 'utils/store-utils';
-import { formatCaptureInterval } from 'utils/time-utils';
+import { formatCaptureInterval, parsePostgresInterval } from 'utils/time-utils';
 import {
     getBackfillCounter,
     getBindingIndex,
@@ -1021,18 +1020,10 @@ const getInitialState = (
                     defaultInterval &&
                     POSTGRES_INTERVAL_RE.test(defaultInterval)
                 ) {
-                    const intervalObject =
-                        Duration.fromISOTime(defaultInterval).toObject();
-
-                    Object.entries(intervalObject).forEach(
-                        ([timeUnit, unitValue]) => {
-                            if (unitValue === 0) {
-                                intervalObject[timeUnit] = undefined;
-                            }
-                        }
+                    state.defaultCaptureInterval = parsePostgresInterval(
+                        defaultInterval,
+                        true
                     );
-
-                    state.defaultCaptureInterval = intervalObject;
                 }
 
                 state.captureInterval = value;

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -283,7 +283,7 @@ const hydrateSpecificationDependentState = async (
 
         get().setCaptureInterval(
             targetInterval
-                ? formatCaptureInterval(targetInterval, true)
+                ? formatCaptureInterval(targetInterval)
                 : fallbackInterval,
             defaultInterval
         );
@@ -557,8 +557,7 @@ const getInitialState = (
         } else {
             get().setCaptureInterval(
                 formatCaptureInterval(
-                    connectorTagResponse?.default_capture_interval,
-                    true
+                    connectorTagResponse?.default_capture_interval
                 ) ?? fallbackInterval,
                 connectorTagResponse?.default_capture_interval
             );

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -1021,8 +1021,18 @@ const getInitialState = (
                     defaultInterval &&
                     POSTGRES_INTERVAL_RE.test(defaultInterval)
                 ) {
-                    state.defaultCaptureInterval =
+                    const intervalObject =
                         Duration.fromISOTime(defaultInterval).toObject();
+
+                    Object.entries(intervalObject).forEach(
+                        ([timeUnit, unitValue]) => {
+                            if (unitValue === 0) {
+                                intervalObject[timeUnit] = undefined;
+                            }
+                        }
+                    );
+
+                    state.defaultCaptureInterval = intervalObject;
                 }
 
                 state.captureInterval = value;

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -279,7 +279,7 @@ const hydrateSpecificationDependentState = async (
             draftSpecs[0].spec.bindings
         );
 
-        const targetInterval = draftSpecs[0].spec?.interval ?? defaultInterval;
+        const targetInterval = draftSpecs[0].spec?.interval;
 
         get().setCaptureInterval(
             targetInterval
@@ -556,9 +556,7 @@ const getInitialState = (
             }
         } else {
             get().setCaptureInterval(
-                formatCaptureInterval(
-                    connectorTagResponse?.default_capture_interval
-                ) ?? fallbackInterval,
+                fallbackInterval,
                 connectorTagResponse?.default_capture_interval
             );
         }

--- a/src/utils/__tests__/time-utils.test.ts
+++ b/src/utils/__tests__/time-utils.test.ts
@@ -37,5 +37,17 @@ describe('formatCaptureInterval', () => {
         expect(formatCaptureInterval('1h 20m 5s')).toBe('1h 20m 5s');
 
         expect(formatCaptureInterval('20m')).toBe('20m');
+
+        expect(
+            formatCaptureInterval(
+                '100000000000000000h 200000000000000000000000000000000m 5000000000000000000000000000000s'
+            )
+        ).toBe(
+            '100000000000000000h 200000000000000000000000000000000m 5000000000000000000000000000000s'
+        );
+
+        expect(formatCaptureInterval('10000000000000000000000000000m')).toBe(
+            '10000000000000000000000000000m'
+        );
     });
 });

--- a/src/utils/__tests__/time-utils.test.ts
+++ b/src/utils/__tests__/time-utils.test.ts
@@ -1,100 +1,4 @@
-import {
-    formatCaptureInterval,
-    getCaptureIntervalSegment,
-} from 'utils/time-utils';
-
-describe('getCaptureIntervalSegment', () => {
-    const postgresInterval = '01:00:00';
-    const captureInterval = '1h';
-
-    describe('returns -1', () => {
-        test('when the time unit is an empty string', () => {
-            const emptyUnit = '';
-
-            expect(getCaptureIntervalSegment(postgresInterval, emptyUnit)).toBe(
-                -1
-            );
-
-            expect(getCaptureIntervalSegment(captureInterval, emptyUnit)).toBe(
-                -1
-            );
-        });
-
-        test('when the time unit is unsupported', () => {
-            const unsupportedUnit = 'z';
-
-            expect(
-                getCaptureIntervalSegment(postgresInterval, unsupportedUnit)
-            ).toBe(-1);
-
-            expect(
-                getCaptureIntervalSegment(captureInterval, unsupportedUnit)
-            ).toBe(-1);
-        });
-
-        test(`when the time unit is 'i'`, () => {
-            const intervalUnit = 'i';
-
-            expect(
-                getCaptureIntervalSegment(postgresInterval, intervalUnit)
-            ).toBe(-1);
-
-            expect(
-                getCaptureIntervalSegment(captureInterval, intervalUnit)
-            ).toBe(-1);
-        });
-
-        test('when the interval does not contain a segment that corresponds to the time unit', () => {
-            expect(getCaptureIntervalSegment('1m 30s', 'h')).toBe(-1);
-
-            expect(getCaptureIntervalSegment(captureInterval, 'm')).toBe(-1);
-
-            expect(getCaptureIntervalSegment(captureInterval, 's')).toBe(-1);
-        });
-
-        test('when the interval is not formatted properly', () => {
-            const unit = 'm';
-
-            expect(getCaptureIntervalSegment('', unit)).toBe(-1);
-
-            expect(getCaptureIntervalSegment('  ', unit)).toBe(-1);
-
-            expect(getCaptureIntervalSegment('2', unit)).toBe(-1);
-
-            expect(getCaptureIntervalSegment('2a', unit)).toBe(-1);
-
-            expect(getCaptureIntervalSegment('20:00', unit)).toBe(-1);
-
-            expect(getCaptureIntervalSegment('1h2m', unit)).toBe(-1);
-        });
-    });
-
-    test('returns a positive number when the time unit corresponds to an interval segment that exists', () => {
-        expect(getCaptureIntervalSegment('00:01:30', 'h')).toBe(0);
-
-        expect(getCaptureIntervalSegment(postgresInterval, 'm')).toBe(0);
-
-        expect(getCaptureIntervalSegment(postgresInterval, 's')).toBe(0);
-
-        expect(getCaptureIntervalSegment('2m 0s', 's')).toBe(0);
-
-        expect(getCaptureIntervalSegment(postgresInterval, 'h')).toBe(1);
-
-        expect(getCaptureIntervalSegment('00:20:30', 'm')).toBe(20);
-
-        expect(getCaptureIntervalSegment('00:20:30', 's')).toBe(30);
-
-        expect(getCaptureIntervalSegment(captureInterval, 'h')).toBe(1);
-
-        expect(getCaptureIntervalSegment('20m 30s', 'm')).toBe(20);
-
-        expect(getCaptureIntervalSegment('20m 30s', 's')).toBe(30);
-
-        expect(getCaptureIntervalSegment('20m 3000000000s', 's')).toBe(
-            3000000000
-        );
-    });
-});
+import { formatCaptureInterval } from 'utils/time-utils';
 
 describe('formatCaptureInterval', () => {
     describe('returns null', () => {
@@ -111,63 +15,27 @@ describe('formatCaptureInterval', () => {
         expect(formatCaptureInterval('')).toBe('');
     });
 
-    describe('returns the original interval', () => {
-        test('when the interval is not in a supported format', () => {
-            expect(formatCaptureInterval('  ')).toBe('  ');
+    test('returns the original interval when the interval is not in a supported format', () => {
+        expect(formatCaptureInterval('  ')).toBe('  ');
 
-            expect(formatCaptureInterval('2')).toBe('2');
+        expect(formatCaptureInterval('2')).toBe('2');
 
-            expect(formatCaptureInterval('20:00')).toBe('20:00');
+        expect(formatCaptureInterval('20:00')).toBe('20:00');
 
-            expect(formatCaptureInterval('1h2m')).toBe('1h2m');
-        });
-
-        test('when the interval is 00:00:00', () => {
-            expect(formatCaptureInterval('00:00:00')).toBe('00:00:00');
-        });
+        expect(formatCaptureInterval('1h2m')).toBe('1h2m');
     });
 
-    describe('returns a formatted capture interval', () => {
-        test('when the interval is in a supported format and intervalUnitSupported is false', () => {
-            expect(formatCaptureInterval('01:20:00')).toBe('1h 20m');
+    test('returns a formatted capture interval when the interval is in a supported format', () => {
+        expect(formatCaptureInterval('01:20:00')).toBe('1h 20m 0s');
 
-            expect(formatCaptureInterval('01:20:05')).toBe('1h 20m 5s');
+        expect(formatCaptureInterval('01:20:05')).toBe('1h 20m 5s');
 
-            expect(formatCaptureInterval('00:20:00')).toBe('20m');
+        expect(formatCaptureInterval('00:20:00')).toBe('0h 20m 0s');
 
-            expect(formatCaptureInterval('1h 20m')).toBe('1h 20m');
+        expect(formatCaptureInterval('1h 20m')).toBe('1h 20m');
 
-            expect(formatCaptureInterval('1h 20m 5s')).toBe('1h 20m 5s');
+        expect(formatCaptureInterval('1h 20m 5s')).toBe('1h 20m 5s');
 
-            expect(formatCaptureInterval('20m')).toBe('20m');
-        });
-
-        test('when the interval is in a supported format, scalar, and intervalUnitSupported is true', () => {
-            expect(formatCaptureInterval('01:00:00', true)).toBe('1h');
-
-            expect(formatCaptureInterval('00:20:00', true)).toBe('20m');
-
-            expect(formatCaptureInterval('00:00:05', true)).toBe('5s');
-
-            expect(formatCaptureInterval('1h', true)).toBe('1h');
-
-            expect(formatCaptureInterval('20m', true)).toBe('20m');
-
-            expect(formatCaptureInterval('5s', true)).toBe('5s');
-        });
-    });
-
-    test(`returns a formatted capture interval appended with 'i' when the interval is in a supported format, compound, and intervalUnitSupported is true`, () => {
-        expect(formatCaptureInterval('01:20:00', true)).toBe('1h 20mi');
-
-        expect(formatCaptureInterval('01:20:05', true)).toBe('1h 20m 5si');
-
-        expect(formatCaptureInterval('01:00:05', true)).toBe('1h 5si');
-
-        expect(formatCaptureInterval('1h 20m', true)).toBe('1h 20mi');
-
-        expect(formatCaptureInterval('1h 20m 5s', true)).toBe('1h 20m 5si');
-
-        expect(formatCaptureInterval('1h 5s', true)).toBe('1h 5si');
+        expect(formatCaptureInterval('20m')).toBe('20m');
     });
 });

--- a/src/utils/__tests__/time-utils.test.ts
+++ b/src/utils/__tests__/time-utils.test.ts
@@ -22,16 +22,12 @@ describe('formatCaptureInterval', () => {
 
         expect(formatCaptureInterval('20:00')).toBe('20:00');
 
+        expect(formatCaptureInterval('01:20:00')).toBe('01:20:00');
+
         expect(formatCaptureInterval('1h2m')).toBe('1h2m');
     });
 
     test('returns a formatted capture interval when the interval is in a supported format', () => {
-        expect(formatCaptureInterval('01:20:00')).toBe('1h 20m 0s');
-
-        expect(formatCaptureInterval('01:20:05')).toBe('1h 20m 5s');
-
-        expect(formatCaptureInterval('00:20:00')).toBe('0h 20m 0s');
-
         expect(formatCaptureInterval('1h 20m')).toBe('1h 20m');
 
         expect(formatCaptureInterval('1h 20m 5s')).toBe('1h 20m 5s');

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -18,7 +18,7 @@ export const formatCaptureInterval = (
     if (POSTGRES_INTERVAL_RE.test(interval)) {
         formattedInterval = Duration.fromObject(
             parsePostgresInterval(interval)
-        ).toFormat("h'h' m'm' s's'");
+        ).toFormat(`h'h' m'm' s's'`);
     } else if (CAPTURE_INTERVAL_RE.test(interval)) {
         formattedInterval = interval.trim();
     }

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -1,105 +1,26 @@
-import {
-    CAPTURE_INTERVAL_RE,
-    DURATION_RE,
-    POSTGRES_INTERVAL_RE,
-} from 'validation';
+import { Duration, DurationObjectUnits } from 'luxon';
+import { CAPTURE_INTERVAL_RE, POSTGRES_INTERVAL_RE } from 'validation';
 import { hasLength } from './misc-utils';
 
-interface SegmentedInterval {
-    h: number;
-    m: number;
-    s: number;
-}
-
-const getNumericSegment = (value: string) => {
-    const numericSegment = Number(value);
-
-    return Number.isSafeInteger(numericSegment) ? numericSegment : -1;
-};
-
-const parsePostgresInterval = (interval: string): SegmentedInterval => {
-    const [hours, minutes, seconds] = interval
-        .split(':')
-        .map((segment) => getNumericSegment(segment));
-
-    return { h: hours, m: minutes, s: seconds };
-};
-
-const parseCaptureInterval = (interval: string): SegmentedInterval => {
-    let hours = -1;
-    let minutes = -1;
-    let seconds = -1;
-
-    interval.split(' ').forEach((segment) => {
-        const value = segment.substring(0, segment.length - 1);
-        const numericSegment = getNumericSegment(value);
-
-        if (segment.endsWith('h')) {
-            hours = numericSegment;
-        } else if (segment.endsWith('m')) {
-            minutes = numericSegment;
-        } else if (segment.endsWith('s')) {
-            seconds = numericSegment;
-        }
-    });
-
-    return { h: hours, m: minutes, s: seconds };
-};
-
-export const getCaptureIntervalSegment = (interval: string, unit: string) => {
-    let truncatedInterval = -1;
-
-    const granularTimeUnit = unit === 'h' || unit === 'm' || unit === 's';
-
-    if (granularTimeUnit && POSTGRES_INTERVAL_RE.test(interval)) {
-        truncatedInterval = parsePostgresInterval(interval)[unit];
-    } else if (granularTimeUnit && CAPTURE_INTERVAL_RE.test(interval)) {
-        truncatedInterval = parseCaptureInterval(interval)[unit];
-    }
-
-    return truncatedInterval;
+const parsePostgresInterval = (interval: string): DurationObjectUnits => {
+    return Duration.fromISOTime(interval).toObject();
 };
 
 export const formatCaptureInterval = (
-    interval: string | null | undefined,
-    intervalUnitSupported?: boolean
+    interval: string | null | undefined
 ): string | null => {
     if (typeof interval !== 'string') {
         return null;
     }
 
-    const segments: string[] = [];
+    let formattedInterval = '';
 
     if (POSTGRES_INTERVAL_RE.test(interval)) {
-        const {
-            h: hours,
-            m: minutes,
-            s: seconds,
-        } = parsePostgresInterval(interval);
-
-        if (hours > 0) {
-            segments.push(`${hours}h`);
-        }
-
-        if (minutes > 0) {
-            segments.push(`${minutes}m`);
-        }
-
-        if (seconds > 0) {
-            segments.push(`${seconds}s`);
-        }
+        formattedInterval = Duration.fromObject(
+            parsePostgresInterval(interval)
+        ).toFormat("h'h' m'm' s's'");
     } else if (CAPTURE_INTERVAL_RE.test(interval)) {
-        segments.push(interval);
-    }
-
-    let formattedInterval = segments.join(' ').trim();
-
-    if (
-        hasLength(formattedInterval) &&
-        intervalUnitSupported &&
-        !DURATION_RE.test(formattedInterval)
-    ) {
-        formattedInterval = formattedInterval.concat('i');
+        formattedInterval = interval.trim();
     }
 
     return hasLength(formattedInterval) ? formattedInterval : interval;

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -1,9 +1,22 @@
 import { Duration, DurationObjectUnits } from 'luxon';
-import { CAPTURE_INTERVAL_RE, POSTGRES_INTERVAL_RE } from 'validation';
+import { CAPTURE_INTERVAL_RE } from 'validation';
 import { hasLength } from './misc-utils';
 
-const parsePostgresInterval = (interval: string): DurationObjectUnits => {
-    return Duration.fromISOTime(interval).toObject();
+export const parsePostgresInterval = (
+    interval: string,
+    removeZeros?: boolean
+): DurationObjectUnits => {
+    const intervalObject = Duration.fromISOTime(interval).toObject();
+
+    if (removeZeros) {
+        Object.entries(intervalObject).forEach(([timeUnit, unitValue]) => {
+            if (unitValue === 0) {
+                intervalObject[timeUnit] = undefined;
+            }
+        });
+    }
+
+    return intervalObject;
 };
 
 export const formatCaptureInterval = (
@@ -15,11 +28,7 @@ export const formatCaptureInterval = (
 
     let formattedInterval = '';
 
-    if (POSTGRES_INTERVAL_RE.test(interval)) {
-        formattedInterval = Duration.fromObject(
-            parsePostgresInterval(interval)
-        ).toFormat(`h'h' m'm' s's'`);
-    } else if (CAPTURE_INTERVAL_RE.test(interval)) {
+    if (CAPTURE_INTERVAL_RE.test(interval)) {
         formattedInterval = interval.trim();
     }
 


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1194

## Changes

### 1194

The following features are included in this PR:

* Simplify the logic for the component that exposes the `interval` property in capture workflows.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the capture interval section does not appear in materialization workflows.

* Validate that the capture interval section does not appear in capture workflows when the selected connector does not specify a default capture interval.

* Validate that the field is prefilled with the default interval in the capture create workflow when the selected connector specifies one.

* Validate that the field is prefilled with the default interval in the capture edit workflow when the live specification does not specify an interval but a default capture interval exists.

* Validate that the field is prefilled with the interval specified in the live specification in the capture edit workflow when it exists.

* Validate that the field considers input in an **unsupported** interval format invalid.

### Automated tests

Test coverage updated for the following utils:

* `formatCaptureInterval`

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**Capture interval field | Value selected**

<img width="404" alt="pr_screenshot-1358-capture_interval-standard-single_unit_interval" src="https://github.com/user-attachments/assets/303de9ca-fc4e-45d4-a15e-525b78c23e82">

<br />
<br />

**Capture interval field | Tooltip**

<img width="221" alt="pr_screenshot-1319-capture_interval-standard-tooltip" src="https://github.com/user-attachments/assets/cdf7e327-bd24-44a6-b648-e48621b633e7">

<br />
<br />

**Capture interval field | Predefined interval options**

<img width="209" alt="pr_screenshot-1358-capture_interval-standard-menu-options" src="https://github.com/user-attachments/assets/96a3d91c-51c8-4014-a573-beb0b1b7695a">

<br />
<br />

**Capture interval field | Empty**

<img width="413" alt="pr_screenshot-1358-capture_interval-standard-empty" src="https://github.com/user-attachments/assets/562c37c8-f3ea-4e97-a00b-13392d572430">

<br />
<br />

**Capture interval field-level error**

<img width="206" alt="pr_screenshot-1358-capture_interval-standard-error-input-compound" src="https://github.com/user-attachments/assets/aaafb423-5bc9-4ff4-94dc-7703e24dcf89">