### PR TITLE
Allowing the schema to control the case

### DIFF
--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -40,7 +40,6 @@ import {
 } from '@jsonforms/core';
 import { concat, includes, isPlainObject, orderBy } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
-import startCase from 'lodash/startCase';
 import { logRocketConsole, logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
 import { Annotations, CustomTypes, Formats, Options } from 'types/jsonforms';
@@ -380,14 +379,15 @@ const wrapInLayoutIfNecessary = (
  */
 const addLabel = (layout: Layout, labelName: string) => {
     if (!isEmpty(labelName)) {
-        const fixedLabel = startCase(labelName);
+        // We do NOT call startCase as we want to allow
+        //  the schema to control case. Ex: "dbt Cloud Job Trigger"
         if (isGroup(layout)) {
-            layout.label = fixedLabel;
+            layout.label = labelName;
         } else {
             // add label with name
             const label: LabelElement = {
                 type: 'Label',
-                text: fixedLabel,
+                text: labelName,
             };
             layout.elements.push(label);
         }


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1359

## Changes

### 1359

- Do not call `startCase` anymore and allow the schema to have 100% control over casing

## Tests

### Manually tested

- Hit a few capture and materialization create flows
- Reviewed storage mappings forms
- Reviewed time travel
- 

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/5a698c1f-20e1-4595-b980-18b67f7e1d22)

