### PR TITLE
Fetching latest live spec right before updating

### DIFF
--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -267,6 +267,8 @@ export interface LiveSpecsExtQuery_ByCatalogName {
     last_pub_id: string;
 }
 
+// TODO (live spec) - remove this and combine with getLatestLiveSpecByName
+//  as the cata log name is a unique index on this
 const getLiveSpecsByCatalogName = async (
     catalogName: string,
     specType: Entity
@@ -399,6 +401,26 @@ const getLiveSpecSpec = (liveSpecId: string) => {
         .single();
 };
 
+export interface LiveSpecsExtQuery_Latest {
+    spec: any;
+    id: string;
+    last_pub_id: string;
+}
+
+const getLatestLiveSpecByName = async (catalogName: string) => {
+    const data = await supabaseRetry(
+        () =>
+            supabaseClient
+                .from(TABLES.LIVE_SPECS_EXT)
+                .select(`spec, id, last_pub_id`)
+                .eq('catalog_name', catalogName)
+                .single(),
+        'getNotificationSubscriptionForUser'
+    ).then(handleSuccess<LiveSpecsExtQuery_Latest>, handleFailure);
+
+    return data;
+};
+
 const getLiveSpecShards = (tenant: string, entityType: Entity) => {
     return supabaseClient
         .from(TABLES.LIVE_SPECS_EXT)
@@ -446,6 +468,13 @@ export interface LiveSpecsExt_Related {
 // };
 
 export {
+    getLatestLiveSpecByName,
+    getLiveSpecShards,
+    getLiveSpecSpec,
+    getLiveSpecsByCatalogName,
+    getLiveSpecsByCatalogNames,
+    getLiveSpecsByConnectorId,
+    getLiveSpecsByLiveSpecId,
     getLiveSpecs_captures,
     getLiveSpecs_collections,
     getLiveSpecs_dataPlaneAuthReq,
@@ -453,10 +482,4 @@ export {
     getLiveSpecs_entitySelector,
     getLiveSpecs_existingTasks,
     getLiveSpecs_materializations,
-    getLiveSpecsByCatalogName,
-    getLiveSpecsByCatalogNames,
-    getLiveSpecsByConnectorId,
-    getLiveSpecsByLiveSpecId,
-    getLiveSpecShards,
-    getLiveSpecSpec,
 };

--- a/src/components/tables/RowActions/Shared/UpdateEntity.tsx
+++ b/src/components/tables/RowActions/Shared/UpdateEntity.tsx
@@ -141,8 +141,11 @@ function UpdateEntity({
                 newDraftId,
                 entityName,
                 newSpec,
-                generateNewSpecType(targetEntity),
-                liveSpecResponse.data.last_pub_id
+                generateNewSpecType(targetEntity)
+                // TODO (update entity) - add last pub id when we add retry for pub failure
+                //  Should use a regex like this
+                //  export const PUBLICATION_MISMATCH_ERROR = RegExp( `expected publication ID \d was not matched`, 'gi');
+                // liveSpecResponse.data.last_pub_id
             );
             if (draftSpecsResponse.error) {
                 return failed(draftSpecsResponse);

--- a/src/components/tables/RowActions/Shared/UpdateEntity.tsx
+++ b/src/components/tables/RowActions/Shared/UpdateEntity.tsx
@@ -3,16 +3,13 @@ import {
     createDraftSpec,
     draftCollectionsEligibleForDeletion,
 } from 'api/draftSpecs';
-import { CaptureQuery } from 'api/liveSpecsExt';
+import { CaptureQuery, getLatestLiveSpecByName } from 'api/liveSpecsExt';
 import { createPublication } from 'api/publications';
 import AlertBox from 'components/shared/AlertBox';
 import DraftErrors from 'components/shared/Entity/Error/DraftErrors';
 import Error from 'components/shared/Error';
 import { useZustandStore } from 'context/Zustand/provider';
-import {
-    LiveSpecsExtQueryWithSpec,
-    useLiveSpecsExtWithSpec,
-} from 'hooks/useLiveSpecsExt';
+import { LiveSpecsExtQueryWithSpec } from 'hooks/useLiveSpecsExt';
 import usePublications from 'hooks/usePublications';
 import { useEffect, useRef, useState } from 'react';
 import { jobSucceeded } from 'services/supabase';
@@ -54,7 +51,9 @@ function UpdateEntity({
     selectableStoreName,
     validateNewSpec,
 }: UpdateEntityProps) {
+    const updateStarted = useRef(false);
     const publishCompleted = useRef(false);
+
     const [state, setState] = useState<ProgressStates>(ProgressStates.RUNNING);
     const [error, setError] = useState<any | null>(null);
     const [draftId, setDraftId] = useState<string | null>(null);
@@ -74,21 +73,17 @@ function UpdateEntity({
         SelectableTableStore['actionSettings']
     >(selectableStoreName, selectableTableStoreSelectors.actionSettings.get);
 
-    const liveSpecsResponse = useLiveSpecsExtWithSpec(
-        entity.id,
-        entity.spec_type
-    );
-    const liveSpecs = liveSpecsResponse.liveSpecs;
-    const liveSpecsError = liveSpecsResponse.error;
-    const liveSpecsValidating = liveSpecsResponse.isValidating;
-
     const deleteCollections =
         selectableStoreName === SelectTableStoreNames.CAPTURE;
 
     useEffect(() => {
-        if (publishCompleted.current) {
+        // If we published or started already exit
+        if (publishCompleted.current || updateStarted.current) {
             return;
         }
+
+        // Mark that we have started updating
+        updateStarted.current = true;
 
         const done = (progressState: ProgressStates, response: any) => {
             setState(progressState);
@@ -99,29 +94,28 @@ function UpdateEntity({
             done(ProgressStates.FAILED, response);
         };
 
-        if (liveSpecsValidating) {
-            return;
-        }
+        const updateEntity = async (targetEntity: CaptureQuery) => {
+            // Fetch this as late as possible so we have the latest as possible
+            const liveSpecResponse = await getLatestLiveSpecByName(
+                targetEntity.catalog_name
+            );
 
-        if (liveSpecsError) {
-            return failed({ error: liveSpecsError });
-        }
+            // Make sure we're good to continue
+            if (liveSpecResponse.error) {
+                return failed({ error: liveSpecResponse.error });
+            }
 
-        if (liveSpecs.length <= 0) {
-            return failed({
-                error: {
-                    message: 'updateEntity.noLiveSpecs',
-                },
-            });
-        }
+            if (!liveSpecResponse.data?.spec) {
+                return failed({
+                    error: {
+                        message: 'updateEntity.noLiveSpecs',
+                    },
+                });
+            }
 
-        const updateEntity = async (
-            targetEntity: CaptureQuery,
-            spec: LiveSpecsExtQueryWithSpec['spec']
-        ) => {
             // We want to make sure there is a new spec to update before
-            //  calling anything on
-            const newSpec = generateNewSpec(spec);
+            //  calling anything on it
+            const newSpec = generateNewSpec(liveSpecResponse.data.spec);
             if (validateNewSpec && !newSpec) {
                 // If we have a skipped message ID set it to the error
                 if (skippedMessageID) {
@@ -147,7 +141,8 @@ function UpdateEntity({
                 newDraftId,
                 entityName,
                 newSpec,
-                generateNewSpecType(targetEntity)
+                generateNewSpecType(targetEntity),
+                liveSpecResponse.data.last_pub_id
             );
             if (draftSpecsResponse.error) {
                 return failed(draftSpecsResponse);
@@ -176,12 +171,8 @@ function UpdateEntity({
             setPubID(publishResponse.data[0].id);
         };
 
-        void updateEntity(entity, liveSpecs[0].spec);
-
-        // We only want to run the useEffect after the data is fetched
-        //  OR if there was an error
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [liveSpecs, liveSpecsError, liveSpecsValidating]);
+        void updateEntity(entity);
+    });
 
     // Start fetching publication status.
     //  If update is running keep checking


### PR DESCRIPTION
No longer listening to changes

## Issues

https://github.com/estuary/ui/issues/1361

## Changes

### 1361

- Fetch the latest live specs during the update and not before
- Do not listen to changes in the effect
- Check the status (overkill)

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

Failed reaching live specs ext
![image](https://github.com/user-attachments/assets/e4f19fa7-1a12-499a-b06b-214613fd41ca)

Failed reaching drafts
![image](https://github.com/user-attachments/assets/60fb5806-806b-43de-995b-59f3766a12de)

Failed reaching draft specs
![image](https://github.com/user-attachments/assets/298a5542-f1f6-4aa5-89df-4cb7267e9e48)

Failed reaching publications
![image](https://github.com/user-attachments/assets/d0cf57ad-fd17-4a28-af66-2e0600f37479)
