### PR TITLE
handle missing draft id better for data flow resets

### DIFF
--- a/src/components/capture/useDiscoverStartDiscovery.ts
+++ b/src/components/capture/useDiscoverStartDiscovery.ts
@@ -13,6 +13,8 @@ import { useFormStateStore_setFormState } from 'stores/FormState/hooks';
 
 import { useDetailsFormStore } from 'stores/DetailsForm/Store';
 import { Entity } from 'types';
+import { logRocketEvent } from 'services/shared';
+import { CustomEvents } from 'services/types';
 import useDiscoverStartSubscription from './useDiscoverStartSubscription';
 
 function useDiscoverStartDiscovery(entityType: Entity) {
@@ -76,6 +78,11 @@ function useDiscoverStartDiscovery(entityType: Entity) {
             );
 
             if (discoverResponse.error) {
+                logRocketEvent(CustomEvents.DRAFT_ID_SET, {
+                    newValue: null,
+                    component: 'useDiscoverStartDiscovery',
+                });
+
                 // If we failed at discovery we need to clear draft ID like we do
                 //  when we createDiscoversSubscription. Otherwise, the Test|Save
                 //  buttons will appear.

--- a/src/components/capture/useDiscoverStartSubscription.ts
+++ b/src/components/capture/useDiscoverStartSubscription.ts
@@ -74,6 +74,11 @@ function useDiscoverStartSubscription(entityType: Entity) {
             existingEndpointConfig: any, // JsonFormsData
             skipUpdate?: boolean
         ) => {
+            logRocketEvent(CustomEvents.DRAFT_ID_SET, {
+                newValue: null,
+                component: 'useDiscoverStartSubscription',
+            });
+
             setDraftId(null);
             setDiscoveredDraftId(discoverDraftId);
 

--- a/src/components/editor/Store/LiveSpecsHydrator.tsx
+++ b/src/components/editor/Store/LiveSpecsHydrator.tsx
@@ -7,6 +7,8 @@ import { useEntityType } from 'context/EntityContext';
 import { useLiveSpecs_details } from 'hooks/useLiveSpecs';
 import EntityNotFound from 'pages/error/EntityNotFound';
 import { useEffect } from 'react';
+import { logRocketEvent } from 'services/shared';
+import { CustomEvents } from 'services/types';
 import { BaseComponentProps } from 'types';
 import { hasLength } from 'utils/misc-utils';
 
@@ -32,6 +34,10 @@ function LiveSpecsHydrator({
 
     useEffect(() => {
         if (hasLength(liveSpecs)) {
+            logRocketEvent(CustomEvents.DRAFT_ID_SET, {
+                newValue: liveSpecs[0].last_pub_id,
+                component: 'liveSpecHydrator',
+            });
             setSpecs(liveSpecs);
             setId(liveSpecs[0].last_pub_id);
         }

--- a/src/components/materialization/useGenerateCatalog.ts
+++ b/src/components/materialization/useGenerateCatalog.ts
@@ -16,6 +16,8 @@ import useEntityWorkflowHelpers from 'components/shared/Entity/hooks/useEntityWo
 import { useEntityWorkflow_Editing } from 'context/Workflow';
 import useEntityNameSuffix from 'hooks/useEntityNameSuffix';
 import { useCallback } from 'react';
+import { logRocketEvent } from 'services/shared';
+import { CustomEvents } from 'services/types';
 import {
     useBinding_bindings,
     useBinding_fullSourceConfigs,
@@ -278,6 +280,12 @@ function useGenerateCatalog() {
                         .config,
                 });
                 setPreviousEndpointConfig({ data: endpointConfigData });
+
+                logRocketEvent(CustomEvents.DRAFT_ID_SET, {
+                    newValue: evaluatedDraftId,
+                    component: 'useDiscoverStartDiscovery',
+                });
+
                 setDraftId(evaluatedDraftId);
                 setPersistedDraftId(evaluatedDraftId);
                 setDraftedEntityName(draftSpecsResponse.data[0].catalog_name);

--- a/src/components/shared/Entity/Edit/index.tsx
+++ b/src/components/shared/Entity/Edit/index.tsx
@@ -20,7 +20,9 @@ import useBrowserTitle from 'hooks/useBrowserTitle';
 import { DraftSpecSwrMetadata } from 'hooks/useDraftSpecs';
 import { ReactNode, useEffect, useMemo } from 'react';
 import { useIntl } from 'react-intl';
+import { logRocketEvent } from 'services/shared';
 import { BASE_ERROR } from 'services/supabase';
+import { CustomEvents } from 'services/types';
 import { useBinding_serverUpdateRequired } from 'stores/Binding/hooks';
 import { useDetailsFormStore } from 'stores/DetailsForm/Store';
 import {
@@ -126,7 +128,14 @@ function EntityEdit({
             endpointConfigServerUpdateRequired ||
             resourceConfigServerUpdateRequired;
 
-        setDraftId(resetDraftIdFlag ? null : persistedDraftId);
+        const newValue = resetDraftIdFlag ? null : persistedDraftId;
+
+        logRocketEvent(CustomEvents.DRAFT_ID_SET, {
+            newValue,
+            component: 'EntityEdit',
+        });
+
+        setDraftId(newValue);
     }, [
         setDraftId,
         endpointConfigServerUpdateRequired,

--- a/src/components/shared/Entity/Edit/useInitializeTaskDraft.ts
+++ b/src/components/shared/Entity/Edit/useInitializeTaskDraft.ts
@@ -22,6 +22,8 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import { Dispatch, SetStateAction, useCallback } from 'react';
+import { logRocketEvent } from 'services/shared';
+import { CustomEvents } from 'services/types';
 import { useFormStateStore_setFormState } from 'stores/FormState/hooks';
 import { FormStatus } from 'stores/FormState/types';
 
@@ -227,6 +229,10 @@ function useInitializeTaskDraft() {
                     );
 
                     if (!draftSpecsError) {
+                        logRocketEvent(CustomEvents.DRAFT_ID_SET, {
+                            newValue: evaluatedDraftId,
+                            component: 'useInitializeTaskDraft',
+                        });
                         setDraftId(evaluatedDraftId);
                         setPersistedDraftId(evaluatedDraftId);
 

--- a/src/components/shared/Entity/prompts/steps/dataFlowReset/DisableCapture/index.tsx
+++ b/src/components/shared/Entity/prompts/steps/dataFlowReset/DisableCapture/index.tsx
@@ -14,6 +14,7 @@ import useStepIsIdle from 'hooks/prompts/useStepIsIdle';
 import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { logRocketEvent } from 'services/shared';
+import { BASE_ERROR } from 'services/supabase';
 import { CustomEvents } from 'services/types';
 import { useDetailsFormStore } from 'stores/DetailsForm/Store';
 import { generateDisabledSpec } from 'utils/entity-utils';
@@ -68,6 +69,19 @@ function DisableCapture() {
             );
 
             const captureName = draftSpecs[0].catalog_name;
+
+            if (!draftId) {
+                updateStep(stepIndex, {
+                    error: {
+                        ...BASE_ERROR,
+                        message: intl.formatMessage({
+                            id: 'resetDataFlow.errors.missingDraftId',
+                        }),
+                    },
+                    progress: ProgressStates.FAILED,
+                });
+                return;
+            }
 
             // Update the Capture to be disabled
             const updateResponse = await modifyDraftSpec(

--- a/src/components/shared/Entity/prompts/steps/dataFlowReset/DisableCapture/index.tsx
+++ b/src/components/shared/Entity/prompts/steps/dataFlowReset/DisableCapture/index.tsx
@@ -2,7 +2,7 @@ import { modifyDraftSpec } from 'api/draftSpecs';
 import { createPublication } from 'api/publications';
 import { useBindingsEditorStore_setIncompatibleCollections } from 'components/editor/Bindings/Store/hooks';
 import {
-    useEditorStore_id,
+    useEditorStore_persistedDraftId,
     useEditorStore_queryResponse_draftSpecs,
 } from 'components/editor/Store/hooks';
 import DraftErrors from 'components/shared/Entity/Error/DraftErrors';
@@ -29,7 +29,7 @@ function DisableCapture() {
         (state) => state.details.data.dataPlane?.dataPlaneName.whole
     );
 
-    const draftId = useEditorStore_id();
+    const persistedDraftId = useEditorStore_persistedDraftId();
     const draftSpecs = useEditorStore_queryResponse_draftSpecs();
 
     const checkPublicationForIncompatibleCollections =
@@ -70,7 +70,7 @@ function DisableCapture() {
 
             const captureName = draftSpecs[0].catalog_name;
 
-            if (!draftId) {
+            if (!persistedDraftId) {
                 updateStep(stepIndex, {
                     error: {
                         ...BASE_ERROR,
@@ -87,7 +87,7 @@ function DisableCapture() {
             const updateResponse = await modifyDraftSpec(
                 newSpec,
                 {
-                    draft_id: draftId,
+                    draft_id: persistedDraftId,
                     catalog_name: captureName,
                     spec_type: 'capture',
                 },
@@ -106,7 +106,7 @@ function DisableCapture() {
 
             // Start publishing it
             const publishResponse = await createPublication(
-                draftId,
+                persistedDraftId,
                 false,
                 `${CustomEvents.DATA_FLOW_RESET} : disable capture : ${initUUID}`,
                 dataPlaneName
@@ -161,7 +161,7 @@ function DisableCapture() {
     }, [
         checkPublicationForIncompatibleCollections,
         dataPlaneName,
-        draftId,
+        persistedDraftId,
         draftSpecs,
         initUUID,
         intl,
@@ -174,7 +174,7 @@ function DisableCapture() {
         updateStep,
     ]);
 
-    return <DraftErrors draftId={draftId} />;
+    return <DraftErrors draftId={persistedDraftId} />;
 }
 
 export default DisableCapture;

--- a/src/components/shared/Entity/prompts/steps/dataFlowReset/DisableCapture/index.tsx
+++ b/src/components/shared/Entity/prompts/steps/dataFlowReset/DisableCapture/index.tsx
@@ -14,7 +14,6 @@ import useStepIsIdle from 'hooks/prompts/useStepIsIdle';
 import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { logRocketEvent } from 'services/shared';
-import { BASE_ERROR } from 'services/supabase';
 import { CustomEvents } from 'services/types';
 import { useDetailsFormStore } from 'stores/DetailsForm/Store';
 import { generateDisabledSpec } from 'utils/entity-utils';
@@ -57,6 +56,16 @@ function DisableCapture() {
             progress: ProgressStates.RUNNING,
         });
 
+        if (!persistedDraftId) {
+            updateStep(stepIndex, {
+                error: {
+                    message: 'resetDataFlow.errors.missingDraftId',
+                },
+                progress: ProgressStates.FAILED,
+            });
+            return;
+        }
+
         updateContext({
             disableClose: true,
         });
@@ -69,19 +78,6 @@ function DisableCapture() {
             );
 
             const captureName = draftSpecs[0].catalog_name;
-
-            if (!persistedDraftId) {
-                updateStep(stepIndex, {
-                    error: {
-                        ...BASE_ERROR,
-                        message: intl.formatMessage({
-                            id: 'resetDataFlow.errors.missingDraftId',
-                        }),
-                    },
-                    progress: ProgressStates.FAILED,
-                });
-                return;
-            }
 
             // Update the Capture to be disabled
             const updateResponse = await modifyDraftSpec(

--- a/src/hooks/useInitializeCollectionDraft.ts
+++ b/src/hooks/useInitializeCollectionDraft.ts
@@ -16,6 +16,8 @@ import {
     useEditorStore_setPersistedDraftId,
 } from 'components/editor/Store/hooks';
 import { useCallback } from 'react';
+import { logRocketEvent } from 'services/shared';
+import { CustomEvents } from 'services/types';
 
 const specType = 'collection';
 
@@ -171,6 +173,11 @@ function useInitializeCollectionDraft() {
                         liveSpec
                     );
                 }
+
+                logRocketEvent(CustomEvents.DRAFT_ID_SET, {
+                    newValue: newDraftId,
+                    component: 'useInitializeCollectionDraft',
+                });
 
                 setLocalDraftId(newDraftId);
                 setDraftId(newDraftId);

--- a/src/hooks/useStoreDiscoveredCaptures.ts
+++ b/src/hooks/useStoreDiscoveredCaptures.ts
@@ -8,6 +8,8 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import { useCallback } from 'react';
+import { logRocketEvent } from 'services/shared';
+import { CustomEvents } from 'services/types';
 import { useBinding_evaluateDiscoveredBindings } from 'stores/Binding/hooks';
 import { useDetailsFormStore } from 'stores/DetailsForm/Store';
 import { useEndpointConfigStore_setEncryptedEndpointConfig } from 'stores/EndpointConfig/hooks';
@@ -111,6 +113,10 @@ function useStoreDiscoveredCaptures() {
                     });
                 }
 
+                logRocketEvent(CustomEvents.DRAFT_ID_SET, {
+                    newValue: newDraftId,
+                    component: 'useStoreDiscoveredCaptures',
+                });
                 setDraftId(newDraftId);
                 setPersistedDraftId(newDraftId);
             }

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -156,6 +156,7 @@ export const Workflows: Record<string, string> = {
 
     'resetDataFlow.publish.title': `Publish data flow reset`,
 
+    'resetDataFlow.errors.missingDraftId': `Cannot find draft to update.`,
     'resetDataFlow.errors.publishFailed': `Publishing failed.`,
     'resetDataFlow.errors.missingSession': `Cannot find user session.`,
     'resetDataFlow.errors.incompatibleCollections': `Publishing ${changesRejected}. Please reach out to support for assistance.`,

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -156,8 +156,8 @@ export const Workflows: Record<string, string> = {
 
     'resetDataFlow.publish.title': `Publish data flow reset`,
 
-    'resetDataFlow.errors.missingDraftId': `Cannot find draft to update.`,
     'resetDataFlow.errors.publishFailed': `Publishing failed.`,
+    'resetDataFlow.errors.missingDraftId': `Cannot find draft to update.`,
     'resetDataFlow.errors.missingSession': `Cannot find user session.`,
     'resetDataFlow.errors.incompatibleCollections': `Publishing ${changesRejected}. Please reach out to support for assistance.`,
     'resetDataFlow.disableCapture.errors.incompatibleCollections': `Publishing ${changesRejected}. Please reversion the collections, mark backfills and try again.`,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -23,6 +23,7 @@ export enum CustomEvents {
     DIRECTIVE = 'Directive',
     DIRECTIVE_EXCHANGE_TOKEN = 'Directive:ExchangeToken',
     DIRECTIVE_GUARD_STATE = 'Directive:Guard:State',
+    DRAFT_ID_SET = 'Draft_Id_Set',
     ENTITY_SAVE = 'Entity_Save',
     ENTITY_NOT_FOUND = 'Entity_Not_Found',
     ERROR_BOUNDARY_DISPLAYED = 'Error_Boundary_Displayed',


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1366

## Changes

### 1366

- Use the `persistedDraftId` as it is a safer option
- Check for draft id and throw an error
- Getting event logging setup to better handle draft id setting in production

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

New error handling
![image](https://github.com/user-attachments/assets/8ca03b05-5ce9-4238-bb36-7065a55616bc)

