### PR TITLE
 Update `collection` table headers for data and docs

### DIFF
--- a/src/components/tables/Captures/useCaptureColumns.tsx
+++ b/src/components/tables/Captures/useCaptureColumns.tsx
@@ -17,7 +17,7 @@ const defaultColumns: ColumnProps[] = [
             return (
                 <StatsHeader
                     key={`captures-statsHeader-${index}`}
-                    headerSuffix="data.written"
+                    firstHeaderSuffix="data.written"
                     selectableTableStoreName={selectableTableStoreName}
                 />
             );

--- a/src/components/tables/Collections/useCollectionColumns.tsx
+++ b/src/components/tables/Collections/useCollectionColumns.tsx
@@ -20,6 +20,8 @@ const defaultColumns: ColumnProps[] = [
                     hideFilter
                     key={`collection-docsStatsHeader-${index}`}
                     header="data.data"
+                    firstHeaderSuffix="data.in"
+                    secondHeaderSuffix="data.out"
                     selectableTableStoreName={selectableTableStoreName}
                 />
             );
@@ -33,6 +35,8 @@ const defaultColumns: ColumnProps[] = [
                 <StatsHeader
                     key={`collection-docsStatsHeader-${index}`}
                     header="data.docs"
+                    firstHeaderSuffix="data.in"
+                    secondHeaderSuffix="data.out"
                     selectableTableStoreName={selectableTableStoreName}
                 />
             );

--- a/src/components/tables/Materializations/useMaterializationColumns.tsx
+++ b/src/components/tables/Materializations/useMaterializationColumns.tsx
@@ -22,7 +22,7 @@ const defaultColumns: ColumnProps[] = [
             return (
                 <StatsHeader
                     key={`materializations-statsHeader-${index}`}
-                    headerSuffix="data.read"
+                    firstHeaderSuffix="data.read"
                     selectableTableStoreName={selectableTableStoreName}
                 />
             );

--- a/src/components/tables/cells/stats/Header.tsx
+++ b/src/components/tables/cells/stats/Header.tsx
@@ -5,25 +5,19 @@ import { useUserInfoSummaryStore } from 'context/UserInfoSummary/useUserInfoSumm
 import { useZustandStore } from 'context/Zustand/provider';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
-import { SelectTableStoreNames } from 'stores/names';
 import {
     SelectableTableStore,
     selectableTableStoreSelectors,
 } from 'stores/Tables/Store';
-
-interface Props {
-    selectableTableStoreName: SelectTableStoreNames;
-    header?: string;
-    hideFilter?: boolean;
-    headerSuffix?: 'data.written' | 'data.read';
-}
+import { StatsHeaderProps } from './types';
 
 const StatsHeader = ({
     selectableTableStoreName,
     header,
     hideFilter,
-    headerSuffix,
-}: Props) => {
+    firstHeaderSuffix,
+    secondHeaderSuffix,
+}: StatsHeaderProps) => {
     const intl = useIntl();
     const hasAnyAccess = useUserInfoSummaryStore((state) => state.hasAnyAccess);
 
@@ -51,7 +45,7 @@ const StatsHeader = ({
         return [
             intl.formatMessage(
                 {
-                    id: headerSuffix ? headerSuffix : 'data.written',
+                    id: firstHeaderSuffix ? firstHeaderSuffix : 'data.written',
                 },
                 {
                     type: intl.formatMessage({
@@ -61,7 +55,7 @@ const StatsHeader = ({
             ),
             intl.formatMessage(
                 {
-                    id: headerSuffix ? headerSuffix : 'data.read',
+                    id: secondHeaderSuffix ? secondHeaderSuffix : 'data.read',
                 },
                 {
                     type: intl.formatMessage({
@@ -70,7 +64,7 @@ const StatsHeader = ({
                 }
             ),
         ];
-    }, [header, headerSuffix, intl]);
+    }, [firstHeaderSuffix, header, intl, secondHeaderSuffix]);
 
     return (
         <>

--- a/src/components/tables/cells/stats/types.ts
+++ b/src/components/tables/cells/stats/types.ts
@@ -1,3 +1,5 @@
+import { SelectTableStoreNames } from 'stores/names';
+
 export interface BaseStatsProps {
     failed?: boolean;
     read?: boolean;
@@ -7,4 +9,12 @@ export interface BaseStatsProps {
 export interface StatsCellProps extends BaseStatsProps {
     formatter: (val: number) => string;
     statType: 'bytes' | 'docs';
+}
+
+export interface StatsHeaderProps {
+    selectableTableStoreName: SelectTableStoreNames;
+    header?: string;
+    hideFilter?: boolean;
+    firstHeaderSuffix?: 'data.written' | 'data.read' | 'data.in' | 'data.out';
+    secondHeaderSuffix?: 'data.written' | 'data.read' | 'data.in' | 'data.out';
 }


### PR DESCRIPTION
Moving type declaration out of component

## Issues

https://github.com/estuary/ui/issues/1380

## Changes

### 1380

- Added ability to control two column suffixes independently
- Updated content

### Misc
- Moved tying out from component

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/84324ab6-d313-45d0-b2b3-0ebe916c12d1)
