### PR TITLE
Make prefix selection less bad for support folks

### DIFF
--- a/src/components/inputs/PrefixedName/PrefixSelector.tsx
+++ b/src/components/inputs/PrefixedName/PrefixSelector.tsx
@@ -1,0 +1,62 @@
+import {
+    Autocomplete,
+    AutocompleteRenderInputParams,
+    TextField,
+} from '@mui/material';
+import { autoCompleteDefaults_Virtual_Non_Clearable } from 'components/shared/AutoComplete/DefaultProps';
+import { PrefixSelectorProps } from './types';
+
+// This is not TenantSelector because we need extra customization
+//  eventually we should look into merging these. Initially this was
+//  a standard `select` component - so it being `AutoComplete` at least
+//  makes it closer to TenantSelector
+function PrefixSelector({
+    disabled,
+    error,
+    labelId,
+    onChange,
+    options,
+    value,
+}: PrefixSelectorProps) {
+    return (
+        <Autocomplete
+            {...autoCompleteDefaults_Virtual_Non_Clearable}
+            disabled={disabled}
+            defaultValue={null}
+            id={labelId}
+            onChange={(_event, newValue) => onChange(newValue)}
+            options={options}
+            componentsProps={{
+                paper: {
+                    sx: {
+                        minWidth: 'fit-content',
+                    },
+                },
+            }}
+            value={value}
+            renderInput={({
+                InputProps,
+                ...params
+            }: AutocompleteRenderInputParams) => (
+                <TextField
+                    {...params}
+                    InputProps={{
+                        ...InputProps,
+                        disableUnderline: true,
+                        sx: { borderRadius: 3 },
+                    }}
+                    error={Boolean(error)}
+                    required
+                    size="small"
+                    sx={{
+                        maxWidth: 250,
+                        minWidth: 100,
+                    }}
+                    variant="standard"
+                />
+            )}
+        />
+    );
+}
+
+export default PrefixSelector;

--- a/src/components/inputs/PrefixedName/index.tsx
+++ b/src/components/inputs/PrefixedName/index.tsx
@@ -4,9 +4,7 @@ import {
     Input,
     InputAdornment,
     InputLabel,
-    MenuItem,
     OutlinedInput,
-    Select,
     TextField,
 } from '@mui/material';
 import useValidatePrefix from 'components/inputs/PrefixedName/useValidatePrefix';
@@ -16,27 +14,8 @@ import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useMount } from 'react-use';
 import { hasLength } from 'utils/misc-utils';
-import { PrefixedName_Change } from './types';
-
-export interface Props {
-    label: string | null;
-    entityType?: string;
-    allowBlankName?: boolean;
-    allowEndSlash?: boolean;
-    defaultPrefix?: boolean;
-    disabled?: boolean;
-    hideErrorMessage?: boolean;
-    onChange?: PrefixedName_Change;
-    onNameChange?: PrefixedName_Change;
-    onPrefixChange?: PrefixedName_Change;
-    prefixOnly?: boolean;
-    required?: boolean;
-    showDescription?: boolean;
-    size?: 'small' | 'medium';
-    standardVariant?: boolean;
-    validateOnLoad?: boolean;
-    value?: string;
-}
+import { PrefixedNameProps } from './types';
+import PrefixSelector from './PrefixSelector';
 
 // const UNCLEAN_PATH_RE = new RegExp(/[^a-zA-Z0-9-_.]\.{1,2}\/?/g);
 const DESCRIPTION_ID = 'prefixed-name-description';
@@ -61,7 +40,7 @@ function PrefixedName({
     standardVariant,
     validateOnLoad,
     value,
-}: Props) {
+}: PrefixedNameProps) {
     // Hooks
     const intl = useIntl();
 
@@ -196,29 +175,14 @@ function PrefixedName({
                     {label}
                 </InputLabel>
 
-                <Select
-                    label={label}
-                    labelId={INPUT_ID}
+                <PrefixSelector
                     disabled={disabled}
                     error={Boolean(prefixError)}
-                    required
-                    size="small"
+                    labelId={INPUT_ID}
+                    onChange={(newValue) => handlers.setPrefix(newValue)}
+                    options={objectRoles}
                     value={prefix}
-                    variant="outlined"
-                    sx={{
-                        minWidth: 75,
-                        borderRadius: 3,
-                    }}
-                    onChange={(event) => {
-                        handlers.setPrefix(event.target.value);
-                    }}
-                >
-                    {objectRoles.map((objectRole) => (
-                        <MenuItem key={objectRole} value={objectRole}>
-                            {objectRole}
-                        </MenuItem>
-                    ))}
-                </Select>
+                />
 
                 <FormHelperText
                     id={DESCRIPTION_ID}
@@ -277,34 +241,16 @@ function PrefixedName({
                         {singleOption ? (
                             prefix
                         ) : (
-                            <Select
+                            <PrefixSelector
                                 disabled={disabled}
-                                disableUnderline
                                 error={Boolean(prefixError)}
-                                required
-                                size="small"
+                                labelId={INPUT_ID}
+                                onChange={(newValue) =>
+                                    handlers.setPrefix(newValue)
+                                }
+                                options={objectRoles}
                                 value={prefix}
-                                variant="standard"
-                                sx={{
-                                    'maxWidth': 150,
-                                    'minWidth': 75,
-                                    '& .MuiSelect-select': {
-                                        paddingBottom: 0.2,
-                                    },
-                                }}
-                                onChange={(event) => {
-                                    handlers.setPrefix(event.target.value);
-                                }}
-                            >
-                                {objectRoles.map((objectRole) => (
-                                    <MenuItem
-                                        key={objectRole}
-                                        value={objectRole}
-                                    >
-                                        {objectRole}
-                                    </MenuItem>
-                                ))}
-                            </Select>
+                            />
                         )}
                     </InputAdornment>
                 }

--- a/src/components/inputs/PrefixedName/types.ts
+++ b/src/components/inputs/PrefixedName/types.ts
@@ -12,3 +12,31 @@ export type PrefixedName_Change = (
         name?: PrefixedName_Errors;
     }
 ) => void;
+
+export interface PrefixedNameProps {
+    label: string | null;
+    entityType?: string;
+    allowBlankName?: boolean;
+    allowEndSlash?: boolean;
+    defaultPrefix?: boolean;
+    disabled?: boolean;
+    hideErrorMessage?: boolean;
+    onChange?: PrefixedName_Change;
+    onNameChange?: PrefixedName_Change;
+    onPrefixChange?: PrefixedName_Change;
+    prefixOnly?: boolean;
+    required?: boolean;
+    showDescription?: boolean;
+    size?: 'small' | 'medium';
+    standardVariant?: boolean;
+    validateOnLoad?: boolean;
+    value?: string;
+}
+
+export interface PrefixSelectorProps
+    extends Pick<PrefixedNameProps, 'disabled' | 'value'> {
+    error: boolean;
+    labelId: string;
+    onChange: (newVal: any) => void;
+    options: string[];
+}

--- a/src/components/inputs/PrefixedName/useValidatePrefix.ts
+++ b/src/components/inputs/PrefixedName/useValidatePrefix.ts
@@ -33,12 +33,18 @@ function useValidatePrefix({
     const objectRoles = useEntitiesStore_capabilities_adminable();
     const singleOption = objectRoles.length === 1;
 
+    // Fetch for the default value
+    // const [selectedTenant, setSelectedTenant] = useTenantStore((state) => [
+    //     state.selectedTenant,
+    //     state.setSelectedTenant,
+    // ]);
+
     // Local State for editing
     const [errors, setErrors] = useState<string | null>(null);
     const [name, setName] = useState('');
     const [nameError, setNameError] = useState<PrefixedName_Errors>(null);
     const [prefix, setPrefix] = useState(
-        singleOption || defaultPrefix ? objectRoles[0] : ''
+        singleOption || defaultPrefix ? objectRoles[0] : '' //selectedTenant
     );
     const [prefixError, setPrefixError] = useState<PrefixedName_Errors>(null);
 
@@ -97,6 +103,7 @@ function useValidatePrefix({
             );
 
             setPrefix(prefixValue);
+            // setSelectedTenant(prefixValue);
 
             if (onPrefixChange) {
                 onPrefixChange(prefixValue, errorString, {

--- a/src/stores/Tenant/Store.ts
+++ b/src/stores/Tenant/Store.ts
@@ -1,8 +1,9 @@
 import produce from 'immer';
 import { devtoolsOptions } from 'utils/store-utils';
 import { StoreApi, create } from 'zustand';
-import { NamedSet, devtools } from 'zustand/middleware';
+import { NamedSet, devtools, persist } from 'zustand/middleware';
 import { TenantState } from './types';
+import { persistOptions } from './shared';
 
 const getInitialStateData = (): Pick<TenantState, 'selectedTenant'> => ({
     selectedTenant: '',
@@ -26,5 +27,11 @@ const getInitialState = (
 });
 
 export const useTenantStore = create<TenantState>()(
-    devtools((set, get) => getInitialState(set, get), devtoolsOptions('tenant'))
+    persist(
+        devtools(
+            (set, get) => getInitialState(set, get),
+            devtoolsOptions(persistOptions.name)
+        ),
+        persistOptions
+    )
 );

--- a/src/stores/Tenant/shared.ts
+++ b/src/stores/Tenant/shared.ts
@@ -1,0 +1,9 @@
+import { TenantState } from 'stores/Tenant/types';
+import { PersistOptions } from 'zustand/middleware';
+
+// Previous persist states for testing migrations
+// v0 - {"state":{"selectedTenant":"foo/"},"version":0}
+export const persistOptions: PersistOptions<TenantState> = {
+    name: 'estuary.tenants-store',
+    version: 0,
+};


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1385

## Changes

### 1385

- Convert `PrefixedName` to use `AutoComplete` for the dropdown

### misc

- Persist the selected tenant 

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

Short and narrow list
![image](https://github.com/user-attachments/assets/3b7e72bf-2432-48b3-8a8b-3ec7657e3ea1)
