### PR TITLE
removing duplicate label

### DIFF
--- a/src/components/inputs/PrefixedName/index.tsx
+++ b/src/components/inputs/PrefixedName/index.tsx
@@ -229,7 +229,7 @@ function PrefixedName({
                             <PrefixSelector
                                 disabled={disabled}
                                 error={Boolean(prefixError)}
-                                label={label}
+                                label={null} // No label as we render it manually up above
                                 labelId={INPUT_ID}
                                 onChange={(newValue) =>
                                     handlers.setPrefix(newValue)


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1400

## Changes

### 1400

-  do not need to send `label` as we are already rendering it manually

## Tests

### Manually tested

- hit create with multiple tenants available

### Automated tests

-  N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/aed9eaf4-8c8f-4eef-9fde-fe488a186716)

![image](https://github.com/user-attachments/assets/0845daa8-797a-43f2-9221-84bd77e134f0)

![image](https://github.com/user-attachments/assets/96f5f334-ab4b-4cf4-92dd-12e72cbb1ee1)

![image](https://github.com/user-attachments/assets/f6eb8288-c3a2-4686-97ad-98dfc1ef01a3)

