### PR TITLE
Require the region s3 storage mapping configuration form field

### DIFF
--- a/src/components/admin/Settings/StorageMappings/Dialog/useConfigurationSchema.ts
+++ b/src/components/admin/Settings/StorageMappings/Dialog/useConfigurationSchema.ts
@@ -51,7 +51,7 @@ const s3ProviderSchema = {
         },
     ],
     type: 'object',
-    required: ['bucket'],
+    required: ['bucket', 'region'],
     properties: {
         bucket: {
             description: 'Bucket into which Flow will store data.',
@@ -60,8 +60,7 @@ const s3ProviderSchema = {
                 '(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)',
         },
         region: {
-            description:
-                'AWS region of the S3 bucket. Uses the default value from the AWS credentials of the Gazette broker if unset.',
+            description: 'AWS region of the S3 bucket.',
             type: 'string',
         },
         prefix: {


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1406

## Changes

### 1406

The following features are included in this PR:

* Require the `region` S3 storage mapping configuration form field.

* Remove the following sentence from the `region` field description: _Uses the default value from the AWS credentials of the Gazette broker if unset._

## Tests

### Manually tested

* Validate that the `region` S3 storage mapping configuration form field is required.

* Validate that the `region` S3 storage mapping configuration form field description has the aforementioned content removed.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
