### PR TITLE
Travjenkins/feature/do not ask sso for tenant

### DIFF
--- a/src/app/guards/OnboardGuard.tsx
+++ b/src/app/guards/OnboardGuard.tsx
@@ -5,6 +5,8 @@ import { createOnboardingStore } from 'directives/Onboard/Store/create';
 import { useMemo } from 'react';
 import { OnboardingStoreNames } from 'stores/names';
 import { BaseComponentProps } from 'types';
+import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { Stack } from '@mui/material';
 import useDirectiveGuard from './hooks';
 
 const SELECTED_DIRECTIVE = 'betaOnboard';
@@ -16,10 +18,16 @@ const SELECTED_DIRECTIVE = 'betaOnboard';
 //  stop passing in the grantsMutate and pass the directiveGuard mutate.
 interface Props extends BaseComponentProps {
     grantsMutate: any;
+    AlertElement?: () => EmotionJSX.Element | null;
     forceDisplay?: boolean;
 }
 
-function OnboardGuard({ children, forceDisplay, grantsMutate }: Props) {
+function OnboardGuard({
+    AlertElement,
+    children,
+    forceDisplay,
+    grantsMutate,
+}: Props) {
     const { directive, loading, status } = useDirectiveGuard(
         SELECTED_DIRECTIVE,
         { forceNew: forceDisplay }
@@ -36,11 +44,14 @@ function OnboardGuard({ children, forceDisplay, grantsMutate }: Props) {
         return (
             <FullPageWrapper fullWidth={true}>
                 <LocalZustandProvider createStore={localStore}>
-                    <BetaOnboard
-                        directive={directive}
-                        status={status}
-                        mutate={grantsMutate}
-                    />
+                    <Stack spacing={2}>
+                        {AlertElement ? <AlertElement /> : null}
+                        <BetaOnboard
+                            directive={directive}
+                            status={status}
+                            mutate={grantsMutate}
+                        />
+                    </Stack>
                 </LocalZustandProvider>
             </FullPageWrapper>
         );

--- a/src/app/guards/TenantGuard/SsoUserMessage.tsx
+++ b/src/app/guards/TenantGuard/SsoUserMessage.tsx
@@ -1,0 +1,40 @@
+import { Stack, Typography } from '@mui/material';
+import FullPageWrapper from 'app/FullPageWrapper';
+import AlertBox from 'components/shared/AlertBox';
+import { useIntl } from 'react-intl';
+
+function SsoUserMessage() {
+    const intl = useIntl();
+
+    return (
+        <FullPageWrapper fullWidth={true}>
+            <AlertBox
+                short
+                severity="info"
+                title={intl.formatMessage({ id: 'tenant.usedSso.title' })}
+            >
+                <Stack spacing={1}>
+                    <Typography>
+                        {intl.formatMessage({ id: 'tenant.usedSso.message' })}
+                    </Typography>
+
+                    <Stack>
+                        <Typography>
+                            {intl.formatMessage({
+                                id: 'tenant.usedSso.instructions1',
+                            })}
+                        </Typography>
+
+                        <Typography>
+                            {intl.formatMessage({
+                                id: 'tenant.usedSso.instructions2',
+                            })}
+                        </Typography>
+                    </Stack>
+                </Stack>
+            </AlertBox>
+        </FullPageWrapper>
+    );
+}
+
+export default SsoUserMessage;

--- a/src/app/guards/TenantGuard/index.tsx
+++ b/src/app/guards/TenantGuard/index.tsx
@@ -1,10 +1,12 @@
+import { useUserStore } from 'context/User/useUserContextStore';
 import { useUserInfoSummaryStore } from 'context/UserInfoSummary/useUserInfoSummaryStore';
 import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'hooks/searchParams/useGlobalSearchParams';
 import { useMemo } from 'react';
 import { BaseComponentProps } from 'types';
-import OnboardGuard from './OnboardGuard';
+import OnboardGuard from '../OnboardGuard';
+import SsoUserMessage from './SsoUserMessage';
 
 // This is a way to very simply "hide" the flow where anyone
 //  can create a tenant but allow us to test it out in prod.
@@ -21,9 +23,14 @@ function TenantGuard({ children }: BaseComponentProps) {
 
     const hasAnyAccess = useUserInfoSummaryStore((state) => state.hasAnyAccess);
     const mutate = useUserInfoSummaryStore((state) => state.mutate);
+    const usedSSO = useUserStore((state) => state.userDetails?.usedSSO);
 
     const showOnboarding = !hasAnyAccess || showBeta;
     if (showOnboarding) {
+        if (usedSSO && !showBeta) {
+            return <SsoUserMessage />;
+        }
+
         return (
             <OnboardGuard grantsMutate={mutate} forceDisplay={showOnboarding} />
         );

--- a/src/lang/en-US/LoggingIn.ts
+++ b/src/lang/en-US/LoggingIn.ts
@@ -110,6 +110,11 @@ export const LoggingIn: Record<string, string> = {
 
     'tenant.error.failedToFetch.message': `There was an issue while checking if you have access to a tenant.`,
 
+    'tenant.usedSso.title': `Ask admin for invite link`,
+    'tenant.usedSso.message': `Your account was created successfuly and can be added to your organization's tenant.`,
+    'tenant.usedSso.instructions1': `Your admin user needs to create an invite link and share with you.`,
+    'tenant.usedSso.instructions2': `When you access this link you will be added to the tenant.`,
+
     // Registration
     'register.heading': `We're currently accepting Beta partners.`,
     'register.main.message': `Please enter your information and our team will approve your account.`,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1391

## Changes

### 1391

- Add alerting when SSO user hits the tenant guard

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Show alert and hide tenant creation form when using SSO
![image](https://github.com/user-attachments/assets/d23b7f91-35d6-485f-aabd-624d3da80f5a)

### Users can still access the tenant creation using URL params
![image](https://github.com/user-attachments/assets/9bfa5f5e-be69-406a-a68d-f2419f998c37)

