### PR TITLE
Update the journals not found data preview alert

### DIFF
--- a/src/components/collection/DataPreview/NoCollectionJournalsAlert.tsx
+++ b/src/components/collection/DataPreview/NoCollectionJournalsAlert.tsx
@@ -1,0 +1,16 @@
+import { authenticatedRoutes } from 'app/routes';
+import MessageWithButton from 'components/content/MessageWithButton';
+import { useNavigate } from 'react-router';
+
+export default function NoCollectionJournalsAlert() {
+    const navigate = useNavigate();
+
+    return (
+        <MessageWithButton
+            messageId="collectionsPreview.notFound.message"
+            clickHandler={() => {
+                navigate(authenticatedRoutes.captures.fullPath);
+            }}
+        />
+    );
+}

--- a/src/components/collection/DataPreview/index.tsx
+++ b/src/components/collection/DataPreview/index.tsx
@@ -5,6 +5,7 @@ import { useEditorStore_specs } from 'components/editor/Store/hooks';
 import JournalAlerts from 'components/journals/Alerts';
 import AlertBox from 'components/shared/AlertBox';
 import CardWrapper from 'components/shared/CardWrapper';
+import useIsCollectionDerivation from 'components/shared/Entity/Details/useIsCollectionDerivation';
 import Error from 'components/shared/Error';
 import {
     useJournalData,
@@ -18,6 +19,7 @@ import { FormattedMessage } from 'react-intl';
 import { BASE_ERROR } from 'services/supabase';
 import { hasLength } from 'utils/misc-utils';
 import ListViewSkeleton from './ListViewSkeleton';
+import NoCollectionJournalsAlert from './NoCollectionJournalsAlert';
 
 interface Props {
     collectionName: string;
@@ -36,6 +38,8 @@ export function DataPreview({ collectionName }: Props) {
     // const toggleMode = (_event: any, newValue: Views) => {
     //     setPreviewMode(newValue);
     // };
+
+    const isDerivation = useIsCollectionDerivation();
 
     const { error: tenantHidesError, hide } =
         useTenantHidesDataPreview(collectionName);
@@ -132,7 +136,13 @@ export function DataPreview({ collectionName }: Props) {
                     <JournalAlerts
                         journalData={journalData}
                         journalsData={journalsData}
-                        notFoundTitleMessage="collectionsPreview.notFound.message"
+                        notFoundTitleMessage={
+                            isDerivation ? (
+                                'collectionsPreview.notFound.message.derivation'
+                            ) : (
+                                <NoCollectionJournalsAlert />
+                            )
+                        }
                     />
                 ) : null}
 

--- a/src/lang/en-US/Collections.ts
+++ b/src/lang/en-US/Collections.ts
@@ -1,9 +1,13 @@
 import { CommonMessages } from './CommonMessages';
+import { Details } from './Details';
+import { RouteTitles } from './RouteTitles';
 
 export const Collections: Record<string, string> = {
     'collectionsTable.title': `Collections`,
     'collectionsTable.cta.new': `New ${CommonMessages['terms.transformation']}`,
     'collectionsTable.detailsCTA': `Details`,
     'collectionsTable.filterLabel': `Filter collections`,
-    'collectionsPreview.notFound.message': `We were unable to find any data which could mean the capture has not ingested data yet or is not running. Check the status on the Captures page to make sure it is running.`,
+    'collectionsPreview.notFound.message': `We were unable to find any data which could mean the capture has not ingested data yet or is not running. Check the status on the {button} to make sure it is running.`,
+    'collectionsPreview.notFound.message.button': `${RouteTitles['routeTitle.captures']} page`,
+    'collectionsPreview.notFound.message.derivation': `We were unable to find any data which could mean the derivation has not ingested data yet or is not running. Check the status in the ${Details['detailsPanel.shardDetails.title']} section to make sure it is running.`,
 };


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1412

## Changes

### 1412

The following features are included in this PR:

* Update the journals not found alert data preview alert for collections. The content includes a _Sources Page_ CTA will redirect the user to the _Captures_ page. The CTA label is determined by the route title.

* Create a derivation-applicable version of the collection journals not found alert message.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the collection-specific journals not found alert functions as intended.

* Validate that the collection-specific journals not found alert does **not** appear in the _Data Preview_ section of a derivation _Details_ page.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

** Journals not found alert | _Data Preview_ section of collection _Details_ page**

<img width="454" alt="pr_screenshot-1418-data_preview_error-collection" src="https://github.com/user-attachments/assets/1da4b421-f163-427e-b194-27acb677a9b4" />

<br />
<br />

** Journals not found alert | _Data Preview_ section of derivation _Details_ page**

<img width="459" alt="pr_screenshot-1418-data_preview_error-derivation" src="https://github.com/user-attachments/assets/98e8e295-f588-4eca-ab73-e313e733ba66" />

<br />
<br />

