### PR TITLE
prod: preserve included field constraints

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/FieldActionButton.tsx
+++ b/src/components/editor/Bindings/FieldSelection/FieldActionButton.tsx
@@ -4,7 +4,7 @@ import {
     useBinding_recommendFields,
     useBinding_setMultiSelection,
 } from 'stores/Binding/hooks';
-import { FieldSelection } from 'stores/Binding/slices/FieldSelection';
+import { FieldSelectionDictionary } from 'stores/Binding/slices/FieldSelection';
 import { evaluateRequiredIncludedFields } from 'utils/workflow-utils';
 import { CompositeProjection, FieldSelectionType } from './types';
 
@@ -21,9 +21,9 @@ const evaluateUpdatedFields = (
     recommended: boolean,
     selectedValue: FieldSelectionType
 ) => {
-    const updatedFields: FieldSelection = {};
+    const updatedFields: FieldSelectionDictionary = {};
 
-    projections.forEach(({ field, constraint }) => {
+    projections.forEach(({ field, constraint, selectionMetadata }) => {
         const includeRequired = constraint
             ? evaluateRequiredIncludedFields(constraint.type)
             : false;
@@ -37,7 +37,7 @@ const evaluateUpdatedFields = (
                     : selectedValue;
         }
 
-        updatedFields[field] = selectionType;
+        updatedFields[field] = { meta: selectionMetadata, mode: selectionType };
     });
 
     return updatedFields;

--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -24,6 +24,7 @@ import {
     useBinding_setRecommendFields,
     useBinding_setSelectionSaving,
 } from 'stores/Binding/hooks';
+import { ExpandedFieldSelection } from 'stores/Binding/slices/FieldSelection';
 import {
     useFormStateStore_isActive,
     useFormStateStore_setFormState,
@@ -67,12 +68,14 @@ const mapConstraintsToProjections = (
             : null;
 
         let selectionType: FieldSelectionType | null = 'default';
+        let selectionMetadata: Schema | undefined;
 
         if (fieldMetadata) {
             const { recommended, include, exclude } = fieldMetadata;
 
             if (include && Object.hasOwn(include, field)) {
                 selectionType = 'include';
+                selectionMetadata = include[field];
             } else if (exclude?.includes(field)) {
                 selectionType = 'exclude';
             } else if (!recommended && constraint) {
@@ -93,6 +96,7 @@ const mapConstraintsToProjections = (
             inference,
             ptr,
             constraint,
+            selectionMetadata,
             selectionType,
         };
     });
@@ -198,12 +202,18 @@ function FieldSelectionViewer({
                                 evaluatedFieldMetadata
                             );
 
-                        const selections = compositeProjections.map(
-                            ({ field, selectionType }) => ({
-                                field,
-                                selectionType,
-                            })
-                        );
+                        const selections: ExpandedFieldSelection[] =
+                            compositeProjections.map(
+                                ({
+                                    field,
+                                    selectionMetadata,
+                                    selectionType,
+                                }) => ({
+                                    field,
+                                    meta: selectionMetadata,
+                                    mode: selectionType,
+                                })
+                            );
 
                         initializeSelections(bindingUUID, selections);
                         setData(compositeProjections);

--- a/src/components/editor/Bindings/FieldSelection/types.ts
+++ b/src/components/editor/Bindings/FieldSelection/types.ts
@@ -69,4 +69,5 @@ export interface TranslatedConstraint {
 export interface CompositeProjection extends Projection {
     constraint: TranslatedConstraint | null;
     selectionType: FieldSelectionType | null;
+    selectionMetadata?: Schema;
 }

--- a/src/components/editor/Bindings/FieldSelection/useFieldSelection.ts
+++ b/src/components/editor/Bindings/FieldSelection/useFieldSelection.ts
@@ -11,6 +11,7 @@ import {
     useBinding_recommendFields,
     useBinding_selections,
 } from 'stores/Binding/hooks';
+import { ExpandedFieldSelection } from 'stores/Binding/slices/FieldSelection';
 import { Schema } from 'types';
 import { hasLength } from 'utils/misc-utils';
 import { getBindingIndex } from 'utils/workflow-utils';
@@ -51,19 +52,23 @@ function useFieldSelection(bindingUUID: string, collectionName: string) {
                     include: {},
                 };
 
-                const includedFields: string[] = Object.entries(
-                    selections[bindingUUID]
-                )
+                const includedFields: Pick<
+                    ExpandedFieldSelection,
+                    'field' | 'meta'
+                >[] = Object.entries(selections[bindingUUID])
                     .filter(
-                        ([_field, selectionType]) => selectionType === 'include'
+                        ([_field, selection]) => selection.mode === 'include'
                     )
-                    .map(([field]) => field);
+                    .map(([field, selection]) => ({
+                        field,
+                        meta: selection.meta,
+                    }));
 
                 const excludedFields: string[] = Object.entries(
                     selections[bindingUUID]
                 )
                     .filter(
-                        ([_field, selectionType]) => selectionType === 'exclude'
+                        ([_field, selection]) => selection.mode === 'exclude'
                     )
                     .map(([field]) => field);
 
@@ -76,8 +81,8 @@ function useFieldSelection(bindingUUID: string, collectionName: string) {
                     if (hasLength(includedFields)) {
                         const formattedFields: Schema = {};
 
-                        includedFields.forEach((field) => {
-                            formattedFields[field] = {};
+                        includedFields.forEach(({ field, meta }) => {
+                            formattedFields[field] = meta ?? {};
                         });
 
                         spec.bindings[bindingIndex].fields.include =

--- a/src/components/tables/cells/fieldSelection/FieldActions.tsx
+++ b/src/components/tables/cells/fieldSelection/FieldActions.tsx
@@ -43,7 +43,7 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
     // Form State Store
     const formActive = useFormStateStore_isActive();
 
-    const selectedValue = useMemo(
+    const selection = useMemo(
         () =>
             Object.hasOwn(selections, bindingUUID)
                 ? selections[bindingUUID][field]
@@ -59,10 +59,10 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
     const excludeRequired = evaluateRequiredExcludedFields(constraint.type);
 
     const coloredIncludeButton =
-        selectedValue === 'default' && includeRecommended;
+        selection?.mode === 'default' && includeRecommended;
 
     const coloredExcludeButton =
-        selectedValue === 'default' && !includeRecommended;
+        selection?.mode === 'default' && !includeRecommended;
 
     if (constraint.type === ConstraintTypes.UNSATISFIABLE) {
         return null;
@@ -77,7 +77,7 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
             >
                 <FieldActionButton
                     messageId="fieldSelection.table.cta.includeField"
-                    selectedValue={selectedValue}
+                    selectedValue={selection?.mode ?? null}
                     value="include"
                     coloredDefaultState={coloredIncludeButton}
                     disabled={
@@ -87,24 +87,29 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
                     }
                     onClick={() => {
                         const singleValue =
-                            selectedValue !== 'include' || includeRequired
+                            selection?.mode !== 'include' || includeRequired
                                 ? 'include'
                                 : null;
 
                         const selectionType = evaluateSelectionType(
                             recommendFields[bindingUUID],
                             'include',
-                            selectedValue,
+                            selection?.mode ?? null,
                             singleValue
                         );
 
-                        setSingleSelection(bindingUUID, field, selectionType);
+                        setSingleSelection(
+                            bindingUUID,
+                            field,
+                            selectionType,
+                            selection?.meta
+                        );
                     }}
                 />
 
                 <FieldActionButton
                     messageId="fieldSelection.table.cta.excludeField"
-                    selectedValue={selectedValue}
+                    selectedValue={selection?.mode ?? null}
                     value="exclude"
                     coloredDefaultState={coloredExcludeButton}
                     disabled={
@@ -114,14 +119,14 @@ function FieldActions({ bindingUUID, field, constraint }: Props) {
                     }
                     onClick={() => {
                         const singleValue =
-                            selectedValue !== 'exclude' || excludeRequired
+                            selection?.mode !== 'exclude' || excludeRequired
                                 ? 'exclude'
                                 : null;
 
                         const selectionType = evaluateSelectionType(
                             recommendFields[bindingUUID],
                             'exclude',
-                            selectedValue,
+                            selection?.mode ?? null,
                             singleValue
                         );
 

--- a/src/stores/Binding/slices/FieldSelection.ts
+++ b/src/stores/Binding/slices/FieldSelection.ts
@@ -1,36 +1,44 @@
 import { FieldSelectionType } from 'components/editor/Bindings/FieldSelection/types';
 import produce from 'immer';
+import { Schema } from 'types';
 import { NamedSet } from 'zustand/middleware';
 import { BindingState } from '../types';
 
 export interface FieldSelection {
-    [field: string]: FieldSelectionType | null;
+    mode: FieldSelectionType | null;
+    meta?: Schema;
+}
+
+export interface ExpandedFieldSelection extends FieldSelection {
+    field: string;
 }
 
 export interface FieldSelectionDictionary {
-    [uuid: string]: FieldSelection;
+    [field: string]: FieldSelection;
+}
+
+interface BindingFieldSelections {
+    [uuid: string]: FieldSelectionDictionary;
 }
 
 export interface StoreWithFieldSelection {
     recommendFields: { [uuid: string]: boolean };
     setRecommendFields: (bindingUUID: string, value: boolean) => void;
 
-    selections: FieldSelectionDictionary;
+    selections: BindingFieldSelections;
     initializeSelections: (
         bindingUUID: string,
-        selection: {
-            field: string;
-            selectionType: FieldSelectionType | null;
-        }[]
+        selections: ExpandedFieldSelection[]
     ) => void;
     setSingleSelection: (
         bindingUUID: string,
         field: string,
-        selectionType: FieldSelectionType | null
+        mode: FieldSelection['mode'],
+        meta?: FieldSelection['meta']
     ) => void;
     setMultiSelection: (
         bindingUUID: string,
-        updatedFields: FieldSelection
+        updatedFields: FieldSelectionDictionary
     ) => void;
 
     selectionSaving: boolean;
@@ -60,10 +68,10 @@ export const getStoreWithFieldSelectionSettings = (
     initializeSelections: (bindingUUID, selections) => {
         set(
             produce((state: BindingState) => {
-                selections.forEach(({ field, selectionType }) => {
+                selections.forEach(({ field, mode, meta }) => {
                     state.selections[bindingUUID] = {
                         ...state.selections[bindingUUID],
-                        [field]: selectionType,
+                        [field]: { mode, meta },
                     };
                 });
             }),
@@ -121,12 +129,12 @@ export const getStoreWithFieldSelectionSettings = (
         );
     },
 
-    setSingleSelection: (bindingUUID, field, selectionType) => {
+    setSingleSelection: (bindingUUID, field, mode, meta) => {
         set(
             produce((state: BindingState) => {
                 state.selections[bindingUUID] = {
                     ...state.selections[bindingUUID],
-                    [field]: selectionType,
+                    [field]: { mode, meta },
                 };
 
                 if (!state.selectionSaving) {


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1434

## Changes

### 1434

The following features are included in this PR:

* Create field selection-related interfaces to promote type consistency in field selection logic. The base `FieldSelection` interface includes an optional, `meta` property which is used, presently, to store additional constraints for included fields.

* Rename `FieldSelectionDictionary` to `BindingFieldSelections` and `FieldSelection` to `FieldSelectionDictionary` to clarify the information encapsulated by each interface.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that included field constraints are preserved in the materialization create workflow when taking action on other fields in the field selection table.

* Validate that included field constraints are preserved in the materialization edit workflow when taking action on other fields in the field selection table.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_
