### PR TITLE
Ensure "nullable" fields are rendered correctly in json forms

### DIFF
--- a/src/forms/renderers/nullable/Control.tsx
+++ b/src/forms/renderers/nullable/Control.tsx
@@ -21,6 +21,8 @@ const NullableControlRenderer = (props: any) => {
     const { handleChange, uischema } = props;
     const { options } = uischema;
 
+    console.log('>>>>> NullableControlRenderer', uischema);
+
     const InputComponent = useMemo(() => {
         const nullableType: AllowedNullable = options
             ? options[Options.nullable]

--- a/src/forms/renderers/nullable/Control.tsx
+++ b/src/forms/renderers/nullable/Control.tsx
@@ -18,10 +18,8 @@ export const nullableControlTester: RankedTester = rankWith(
 );
 
 const NullableControlRenderer = (props: any) => {
-    const { handleChange, uischema } = props;
+    const { uischema } = props;
     const { options } = uischema;
-
-    console.log('>>>>> NullableControlRenderer', uischema);
 
     const InputComponent = useMemo(() => {
         const nullableType: AllowedNullable = options
@@ -47,14 +45,7 @@ const NullableControlRenderer = (props: any) => {
         return null;
     }
 
-    return (
-        <InputComponent
-            {...props}
-            handleChange={(path, val) => {
-                handleChange(path, val ?? null);
-            }}
-        />
-    );
+    return <InputComponent {...props} />;
 };
 
 export const NullableControl = withJsonFormsControlProps(

--- a/src/forms/renderers/nullable/Control.tsx
+++ b/src/forms/renderers/nullable/Control.tsx
@@ -18,7 +18,7 @@ export const nullableControlTester: RankedTester = rankWith(
 );
 
 const NullableControlRenderer = (props: any) => {
-    const { uischema } = props;
+    const { handleChange, uischema } = props;
     const { options } = uischema;
 
     const InputComponent = useMemo(() => {
@@ -45,7 +45,14 @@ const NullableControlRenderer = (props: any) => {
         return null;
     }
 
-    return <InputComponent {...props} />;
+    return (
+        <InputComponent
+            {...props}
+            handleChange={(path, val) => {
+                handleChange(path, val ?? null);
+            }}
+        />
+    );
 };
 
 export const NullableControl = withJsonFormsControlProps(

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -634,14 +634,7 @@ const generateUISchema = (
     // Then we check if it is password. If it is we set the proper format. While inside that we check for
     // multi line and set the format option so the MutliLineSecret renderer will pick it up.
     // After that we check if it is just multiline.
-
     const controlObject: ControlElement = createControlElement(currentRef);
-
-    // See if we need to mark the control as nullable. This is separate from the
-    //  big block because this could apply to anything
-    if (nullableType) {
-        addNullableField(controlObject, nullableType);
-    }
 
     // Now check if the string needs any special handling when rendering the control
     if (nullableType === 'string' || jsonSchema.type === 'string') {
@@ -659,6 +652,18 @@ const generateUISchema = (
         } else if (schemaHasFormat('time', jsonSchema)) {
             addOption(controlObject, Options.format, Formats.time);
         }
+    }
+
+    // See if we need to mark the control as nullable. This is separate from the
+    //  big block because this could apply to almost anything
+    if (
+        nullableType &&
+        // "Nullable" fields only render with default renderers so we need to know if
+        //  the control is a multi line secret so we can skip adding the "nullable" option
+        //  and just use our custom renderer
+        !Boolean(controlObject.options?.[Options.multiLineSecret])
+    ) {
+        addNullableField(controlObject, nullableType);
     }
 
     // First see if we have a nullableType so that we do not need to worry about

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -79,8 +79,21 @@ const addTitle = (
     return group;
 };
 
-const isMultilineText = (schema: JsonSchema): boolean => {
-    if (schema.type === 'string' && Object.hasOwn(schema, 'multiline')) {
+type DateTimeFormats = 'date' | 'date-time' | 'time';
+const schemaHasFormat = (
+    format: DateTimeFormats,
+    schema: JsonSchema
+): boolean => {
+    if (Object.hasOwn(schema, 'format')) {
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        return schema['format'] === format;
+    } else {
+        return false;
+    }
+};
+
+const schemaHasMultilineProp = (schema: JsonSchema): boolean => {
+    if (Object.hasOwn(schema, 'multiline')) {
         // eslint-disable-next-line @typescript-eslint/dot-notation
         return schema['multiline'] === true;
     } else {
@@ -88,38 +101,10 @@ const isMultilineText = (schema: JsonSchema): boolean => {
     }
 };
 
-const isDateText = (schema: JsonSchema): boolean => {
-    if (schema.type === 'string' && Object.hasOwn(schema, 'format')) {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        return schema['format'] === 'date';
-    } else {
-        return false;
-    }
-};
-
-const isDateTimeText = (schema: JsonSchema): boolean => {
-    if (schema.type === 'string' && Object.hasOwn(schema, 'format')) {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        return schema['format'] === 'date-time';
-    } else {
-        return false;
-    }
-};
-
-const isTimeText = (schema: JsonSchema): boolean => {
-    if (schema.type === 'string' && Object.hasOwn(schema, 'format')) {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        return schema['format'] === 'time';
-    } else {
-        return false;
-    }
-};
-
-const isSecretText = (schema: JsonSchema): boolean => {
+const schemaHasSecretProp = (schema: JsonSchema): boolean => {
     if (
-        schema.type === 'string' &&
-        (Object.hasOwn(schema, 'secret') ||
-            Object.hasOwn(schema, 'airbyte_secret'))
+        Object.hasOwn(schema, 'secret') ||
+        Object.hasOwn(schema, 'airbyte_secret')
     ) {
         // eslint-disable-next-line @typescript-eslint/dot-notation
         return schema['secret'] === true || schema['airbyte_secret'] === true;
@@ -169,7 +154,7 @@ const getTypeOtherThanNull = (
     return null;
 };
 
-// Nullable is only supported for anyOf and oneOf. This is manually checked
+// This is only supported for anyOf and oneOf. This is manually checked
 //  because allOf will also return true for a combinator check. After that we only
 //  support when there is exactly two types. This is mainly here to help render
 //  pydantic inputs better.
@@ -561,16 +546,15 @@ const generateUISchema = (
         };
     }
 
-    if (types.length > 1) {
+    // We're here so it means we are not rendering a combinator and rendering a control
+    //  We need to fetch the nullableType. This only fetched the type if the array length
+    //  is exactly 2 and we can pull a proper type off one of the values
+    const nullableType = getTypeOtherThanNull(types);
+
+    // If we have multiple types and one is not null then go ahead and render a control
+    //  that way JSONForms can handle rendering the two types
+    if (types.length > 1 && !nullableType) {
         const controlObject: ControlElement = createControlElement(currentRef);
-
-        // Some fields are 1 type OR null so check this so we
-        //  can use our custom renderer to clear these values properly
-        const nullableType = getTypeOtherThanNull(types);
-        if (nullableType) {
-            addNullableField(controlObject, nullableType);
-        }
-
         schemaElements.push(controlObject);
         return controlObject;
     }
@@ -652,22 +636,34 @@ const generateUISchema = (
     // After that we check if it is just multiline.
 
     const controlObject: ControlElement = createControlElement(currentRef);
-    if (isSecretText(jsonSchema)) {
-        addOption(controlObject, Options.format, Formats.password);
-        if (isMultilineText(jsonSchema)) {
-            addOption(controlObject, Options.multiLineSecret, true);
-        }
-    } else if (isMultilineText(jsonSchema)) {
-        addOption(controlObject, Options.multi, true);
-    } else if (isDateTimeText(jsonSchema)) {
-        addOption(controlObject, Options.format, Formats.dateTime);
-    } else if (isDateText(jsonSchema)) {
-        addOption(controlObject, Options.format, Formats.date);
-    } else if (isTimeText(jsonSchema)) {
-        addOption(controlObject, Options.format, Formats.time);
+
+    // See if we need to mark the control as nullable. This is separate from the
+    //  big block because this could apply to anything
+    if (nullableType) {
+        addNullableField(controlObject, nullableType);
     }
 
-    switch (types[0]) {
+    // Now check if the string needs any special handling when rendering the control
+    if (nullableType === 'string' || jsonSchema.type === 'string') {
+        if (schemaHasSecretProp(jsonSchema)) {
+            addOption(controlObject, Options.format, Formats.password);
+            if (schemaHasMultilineProp(jsonSchema)) {
+                addOption(controlObject, Options.multiLineSecret, true);
+            }
+        } else if (schemaHasMultilineProp(jsonSchema)) {
+            addOption(controlObject, Options.multi, true);
+        } else if (schemaHasFormat('date-time', jsonSchema)) {
+            addOption(controlObject, Options.format, Formats.dateTime);
+        } else if (schemaHasFormat('date', jsonSchema)) {
+            addOption(controlObject, Options.format, Formats.date);
+        } else if (schemaHasFormat('time', jsonSchema)) {
+            addOption(controlObject, Options.format, Formats.time);
+        }
+    }
+
+    // First see if we have a nullableType so that we do not need to worry about
+    //  sorting the types array when it can be nullable
+    switch (nullableType ?? types[0]) {
         case 'object': // object items will be handled by the object control itself
         /* falls through */
         case 'array': // array items will be handled by the array control itself

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -666,8 +666,6 @@ const generateUISchema = (
         addNullableField(controlObject, nullableType);
     }
 
-    // First see if we have a nullableType so that we do not need to worry about
-    //  sorting the types array when it can be nullable
     switch (nullableType ?? types[0]) {
         case 'object': // object items will be handled by the object control itself
         /* falls through */


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1442

## Changes

### 1442

- Get the "nullable" type from the schema and properly create a control for types other than `anyOf` or `oneOf`.
- Check for type of `string` before checking format, secret, etc. to make those functions easier to handle and so they can check the "nullable" types as well

### Misc

- Updated how we add date/time formats to the schema to reduce duplication
- Renamed functions that check things on the schema

## Tests

### Manually tested

- Different schemas

### Automated tests

- n/a

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Test cases
![image](https://github.com/user-attachments/assets/8529fc9e-a277-4552-b788-4657e6579184)

Used this schema to test
```json
{
  "$schema": "https://json-schema.org/draft/2019-09/schema",
  "title": "EndpointConfig",
  "type": "object",
  "properties": {
    "stringSecret": {
      "title": "String Secret",
      "description": "",
      "type": "string",
      "secret": true
    },
    "stringNullSecret": {
      "title": "String/Null Secret",
      "description": "",
      "type": ["string", "null"],
      "secret": true
    },
    "stringNonSecret": {
      "title": "String NOT Secret",
      "description": "",
      "type": "string"
    },
    "stringNullNonSecret": {
      "title": "String/Null NOT Secret",
      "description": "",
      "type": ["string", "null"]
    },
    "multiLineNullSecret": {
      "title": "MultiLine Null Secret",
      "description": "",
      "type": ["string", "null"],
      "multiline": true,
      "secret": true
    },
    "multiLineNullNonSecret": {
      "title": "MultiLine Null NOT Secret",
      "description": "",
      "type": ["string", "null"],
      "multiline": true
    },
    "multiLineSecret": {
      "title": "MultiLine Secret",
      "description": "",
      "type": "string",
      "multiline": true,
      "secret": true
    },
    "multiLineNonSecret": {
      "title": "MultiLine NOT Secret",
      "description": "",
      "type": "string",
      "multiline": true
    }
  }
}
```