### PR TITLE
Let the users know if they are using marketplace for payments

### DIFF
--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -142,7 +142,7 @@ export const getPaymentMethodsForTenants = async (
     tenants.some((tenantDetail) => {
         if (
             !tenantDetail.trial_start ||
-            tenantDetail.payment_provider === 'external' ||
+            tenantDetail.payment_provider !== 'stripe' ||
             tenantDetail.gcm_account_id
         ) {
             promises.push(

--- a/src/components/admin/Billing/PricingTierDetails.tsx
+++ b/src/components/admin/Billing/PricingTierDetails.tsx
@@ -7,22 +7,33 @@ import { useTenantStore } from 'stores/Tenant/Store';
 
 function PricingTierDetails() {
     const selectedTenant = useTenantStore((state) => state.selectedTenant);
-    const externalPaymentMethod = useTenantUsesExternalPayment(selectedTenant);
+    const [externalPaymentMethod, marketPlaceProvider] =
+        useTenantUsesExternalPayment(selectedTenant);
 
     const billingStoreHydrated = useBillingStore((state) => state.hydrated);
     const paymentMethodExists = useBillingStore(
         (state) => state.paymentMethodExists
     );
 
-    const messageId = useMemo(
-        () =>
-            externalPaymentMethod
-                ? 'admin.billing.message.external'
-                : paymentMethodExists
-                ? 'admin.billing.message.paidTier'
-                : 'admin.billing.message.freeTier',
-        [externalPaymentMethod, paymentMethodExists]
-    );
+    const messageId = useMemo(() => {
+        if (externalPaymentMethod) {
+            if (marketPlaceProvider === 'gcp') {
+                return 'something goes here';
+            }
+
+            if (marketPlaceProvider === 'aws') {
+                return 'something goes here';
+            }
+
+            return 'admin.billing.message.external';
+        }
+
+        if (paymentMethodExists) {
+            return 'admin.billing.message.paidTier';
+        }
+
+        return 'admin.billing.message.freeTier';
+    }, [externalPaymentMethod, marketPlaceProvider, paymentMethodExists]);
 
     if (!billingStoreHydrated || typeof paymentMethodExists !== 'boolean') {
         return (

--- a/src/components/admin/Billing/PricingTierDetails.tsx
+++ b/src/components/admin/Billing/PricingTierDetails.tsx
@@ -18,11 +18,11 @@ function PricingTierDetails() {
     const messageId = useMemo(() => {
         if (externalPaymentMethod) {
             if (marketPlaceProvider === 'gcp') {
-                return 'something goes here';
+                return 'admin.billing.message.external.gcp';
             }
 
             if (marketPlaceProvider === 'aws') {
-                return 'something goes here';
+                return 'admin.billing.message.external.aws';
             }
 
             return 'admin.billing.message.external';

--- a/src/context/fetcher/TenantBillingDetails.tsx
+++ b/src/context/fetcher/TenantBillingDetails.tsx
@@ -81,12 +81,18 @@ export const useTenantUsesExternalPayment = (
                 tenantBillingDetail.tenant === selectedTenant
         );
 
-        const marketplaceProvider = selectedTenantDetails?.gcm_account_id
-            ? 'gcp'
-            : null; //add aws support
+        let marketplaceProvider = null;
+
+        if (selectedTenantDetails?.gcm_account_id) {
+            marketplaceProvider = 'gcp';
+        }
+
+        // TODO (marketplace) add support for AWS which is currently handled manually
+        //      https://github.com/estuary/flow/issues/1921 needs completed so we know
+        //      how to handle this.
 
         return [
-            Boolean(selectedTenantDetails?.payment_provider === 'external'),
+            Boolean(selectedTenantDetails?.payment_provider !== 'stripe'),
             marketplaceProvider,
         ];
     }, [selectedTenant, tenantBillingDetails]);

--- a/src/context/fetcher/TenantBillingDetails.tsx
+++ b/src/context/fetcher/TenantBillingDetails.tsx
@@ -66,17 +66,28 @@ export const useTenantBillingDetails = () => {
     return useContext(TenantContext);
 };
 
-export const useTenantUsesExternalPayment = (selectedTenant: string) => {
+export const useTenantUsesExternalPayment = (
+    selectedTenant: string
+): [boolean, string | null] => {
     const { tenantBillingDetails } = useTenantBillingDetails();
 
     return useMemo(() => {
-        return !tenantBillingDetails
-            ? false
-            : tenantBillingDetails.some((tenantBillingDetail) => {
-                  return (
-                      tenantBillingDetail.tenant === selectedTenant &&
-                      tenantBillingDetail.payment_provider === 'external'
-                  );
-              });
+        if (!tenantBillingDetails) {
+            return [false, null];
+        }
+
+        const selectedTenantDetails = tenantBillingDetails.find(
+            (tenantBillingDetail) =>
+                tenantBillingDetail.tenant === selectedTenant
+        );
+
+        const marketplaceProvider = selectedTenantDetails?.gcm_account_id
+            ? 'gcp'
+            : null; //add aws support
+
+        return [
+            Boolean(selectedTenantDetails?.payment_provider === 'external'),
+            marketplaceProvider,
+        ];
     }, [selectedTenant, tenantBillingDetails]);
 };

--- a/src/lang/en-US/AdminPage.ts
+++ b/src/lang/en-US/AdminPage.ts
@@ -28,6 +28,8 @@ export const AdminPage: Record<string, string> = {
     'admin.billing.message.freeTier': `The free tier lets you try Flow with up to 2 tasks and 10GB per month without entering a credit card. Usage beyond these limits automatically starts a 30 day free trial.`,
     'admin.billing.message.paidTier': `Cloud tier.`,
     'admin.billing.message.external': ` `,
+    'admin.billing.message.external.gcp': `GCP Marketplace`,
+    'admin.billing.message.external.aws': `AWS Marketplace`,
     'admin.billing.error.details.header': `There was a network issue.`,
     'admin.billing.error.details.message': `There was an error fetching your billing details. ${Errors['error.tryAgain']}`,
     'admin.billing.error.paymentMethodsError': `There was an error connecting with our payment provider. Please try again later.`,

--- a/src/lang/en-US/AdminPage.ts
+++ b/src/lang/en-US/AdminPage.ts
@@ -26,7 +26,7 @@ export const AdminPage: Record<string, string> = {
 
     'admin.billing.header': `Billing`,
     'admin.billing.message.freeTier': `The free tier lets you try Flow with up to 2 tasks and 10GB per month without entering a credit card. Usage beyond these limits automatically starts a 30 day free trial.`,
-    'admin.billing.message.paidTier': `Cloud tier.`,
+    'admin.billing.message.paidTier': `Cloud tier`,
     'admin.billing.message.external': ` `,
     'admin.billing.message.external.gcp': `GCP Marketplace`,
     'admin.billing.message.external.aws': `AWS Marketplace`,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,6 +152,7 @@ export interface StorageMappings {
     updated_at: string;
 }
 
+// TODO (marketplace) we may expand these in the future
 export type TenantPaymentProviders = 'external' | 'stripe';
 
 export interface Tenants {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1443

## Changes

### 1443

-  Check for the marketplace stuff when checking external payment being used
- Add new content to let the user know they are using GCP
- Check if `not stripe` in case we end up expanding column
- Remove `.` from end of all short payment messages for billing

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### GCP
![image](https://github.com/user-attachments/assets/3739e769-56f9-4c8b-b14e-073fa2a438da)
