### PR TITLE
Toggling binding disable/enable selects the binding

### DIFF
--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -161,6 +161,28 @@ function CollectionSelectorList({
         [isCapture]
     );
 
+    const selectBinding = useCallback(
+        (id: any) => {
+            if (!setCurrentBinding) {
+                return;
+            }
+
+            // TODO (JSONForms) This is hacky but it works.
+            // It clears out the current binding before switching.
+            //  If a user is typing quickly in a form and then selects a
+            //  different binding VERY quickly it could cause the updates
+            //  to go into the wrong form.
+            setCurrentBinding(null);
+
+            if (typeof id === 'string') {
+                hackyTimeout.current = window.setTimeout(() => {
+                    setCurrentBinding(id);
+                });
+            }
+        },
+        [setCurrentBinding]
+    );
+
     const columns = useMemo(() => {
         const response: GridColDef[] = [
             {
@@ -316,7 +338,6 @@ function CollectionSelectorList({
                 apiRef={apiRef}
                 columns={columns}
                 components={{ NoRowsOverlay: SelectorEmpty }}
-                disableColumnFilter //prevents the filter icon from showing up
                 disableColumnMenu
                 disableColumnSelector
                 disableRowSelectionOnClick={!selectionEnabled}
@@ -341,18 +362,7 @@ function CollectionSelectorList({
                             field === COLLECTION_SELECTOR_TOGGLE_COL) &&
                         id !== currentBindingUUID
                     ) {
-                        // TODO (JSONForms) This is hacky but it works.
-                        // It clears out the current binding before switching.
-                        //  If a user is typing quickly in a form and then selects a
-                        //  different binding VERY quickly it could cause the updates
-                        //  to go into the wrong form.
-                        setCurrentBinding(null);
-
-                        if (typeof id === 'string') {
-                            hackyTimeout.current = window.setTimeout(() => {
-                                setCurrentBinding(id);
-                            });
-                        }
+                        selectBinding(id);
                     }
                 }}
             />

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -31,6 +31,7 @@ import CollectionSelectorHeaderToggle from './Header/Toggle';
 import {
     COLLECTION_SELECTOR_NAME_COL,
     COLLECTION_SELECTOR_STRIPPED_PATH_NAME,
+    COLLECTION_SELECTOR_TOGGLE_COL,
     COLLECTION_SELECTOR_UUID_COL,
     getCollectionSelector,
 } from './shared';
@@ -196,7 +197,7 @@ function CollectionSelectorList({
             response.unshift({
                 cellClassName: cellClass_noPadding,
                 headerClassName: cellClass_noPadding,
-                field: 'disable',
+                field: COLLECTION_SELECTOR_TOGGLE_COL,
                 sortable: false,
                 minWidth: 110,
                 maxWidth: 125,
@@ -336,7 +337,8 @@ function CollectionSelectorList({
                     if (
                         selectionEnabled &&
                         (field === COLLECTION_SELECTOR_STRIPPED_PATH_NAME ||
-                            field === COLLECTION_SELECTOR_NAME_COL) &&
+                            field === COLLECTION_SELECTOR_NAME_COL ||
+                            field === COLLECTION_SELECTOR_TOGGLE_COL) &&
                         id !== currentBindingUUID
                     ) {
                         // TODO (JSONForms) This is hacky but it works.

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -161,28 +161,6 @@ function CollectionSelectorList({
         [isCapture]
     );
 
-    const selectBinding = useCallback(
-        (id: any) => {
-            if (!setCurrentBinding) {
-                return;
-            }
-
-            // TODO (JSONForms) This is hacky but it works.
-            // It clears out the current binding before switching.
-            //  If a user is typing quickly in a form and then selects a
-            //  different binding VERY quickly it could cause the updates
-            //  to go into the wrong form.
-            setCurrentBinding(null);
-
-            if (typeof id === 'string') {
-                hackyTimeout.current = window.setTimeout(() => {
-                    setCurrentBinding(id);
-                });
-            }
-        },
-        [setCurrentBinding]
-    );
-
     const columns = useMemo(() => {
         const response: GridColDef[] = [
             {
@@ -362,7 +340,18 @@ function CollectionSelectorList({
                             field === COLLECTION_SELECTOR_TOGGLE_COL) &&
                         id !== currentBindingUUID
                     ) {
-                        selectBinding(id);
+                        // TODO (JSONForms) This is hacky but it works.
+                        // It clears out the current binding before switching.
+                        //  If a user is typing quickly in a form and then selects a
+                        //  different binding VERY quickly it could cause the updates
+                        //  to go into the wrong form.
+                        setCurrentBinding(null);
+
+                        if (typeof id === 'string') {
+                            hackyTimeout.current = window.setTimeout(() => {
+                                setCurrentBinding(id);
+                            });
+                        }
                     }
                 }}
             />

--- a/src/components/collection/Selector/List/shared.ts
+++ b/src/components/collection/Selector/List/shared.ts
@@ -1,3 +1,4 @@
+export const COLLECTION_SELECTOR_TOGGLE_COL = 'disable';
 export const COLLECTION_SELECTOR_UUID_COL = 'id';
 export const COLLECTION_SELECTOR_NAME_COL = 'name';
 export const COLLECTION_SELECTOR_STRIPPED_PATH_NAME = 'strippedPathName';

--- a/src/components/editor/Bindings/Row/Toggle.tsx
+++ b/src/components/editor/Bindings/Row/Toggle.tsx
@@ -28,8 +28,7 @@ function BindingsSelectorToggle({ bindingUUID, disableButton }: Props) {
             disabled={disableButton}
             sx={dataGridEntireCellButtonStyling}
             variant="text"
-            onClick={(event) => {
-                event.stopPropagation();
+            onClick={() => {
                 toggleDisable(bindingUUID);
             }}
         >


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1445

## Changes

### 1445

- No longer stopping event bubbling
- Minor refactor to make function more usable
- Adding the `disable` field to select the binding

## Tests

### Manually tested

-  Toggled and clicked around in the binding selector

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

N/A