### PR TITLE
Do not assume a config can be empty

### DIFF
--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -203,7 +203,11 @@ export const getDereffedSchema = async (val: any) => {
 };
 
 export const configCanBeEmpty = (schema: any) => {
-    return Boolean(!schema?.properties || isEmpty(schema?.properties));
+    if (!schema) {
+        return false;
+    }
+
+    return Boolean(!schema.properties || isEmpty(schema.properties));
 };
 
 export const isReactElement = (value: ReactNode): value is ReactElement =>


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1454

## Changes

### 1454

- I think we should always assume the config cannot be empty until we are proven otherwise.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
