### PR TITLE
`npm audit` fix for vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16792,9 +16792,9 @@
             }
         },
         "node_modules/vitest/node_modules/vite": {
-            "version": "5.4.8",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-            "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+            "version": "5.4.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+            "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
             "devOptional": true,
             "dependencies": {
                 "esbuild": "^0.21.3",


### PR DESCRIPTION
`npm audit` called out we needed a small update to `vite` package.

We were not impacted much as we do not run the server portion of `vite` - but rather be safe and keep the issue list clean.

![image](https://github.com/user-attachments/assets/5bf06fc8-b7e8-4fe3-8347-a49fead1d021)