### PR TITLE
Update storage mapping provider label for Amazon S3

### DIFF
--- a/playwright-tests/tests/admin.spec.ts
+++ b/playwright-tests/tests/admin.spec.ts
@@ -1,15 +1,7 @@
-import { expect, test, Page } from '@playwright/test';
-import { beforeEach } from 'node:test';
+import { expect, Page, test } from '@playwright/test';
 import { AuthProps } from '../helpers/types';
 import { USERS } from '../helpers/users';
-import {
-    defaultLocalStorage,
-    defaultPageSetup,
-    emailDomain,
-    inituser,
-    startSessionWithUser,
-    saveAndPublish,
-} from '../helpers/utils';
+import { defaultPageSetup } from '../helpers/utils';
 
 const invalidEmail = 'Fake_Invalid_Email';
 const testTokens = ['test token 1', 'test token 2', 'test token 3'];
@@ -158,7 +150,7 @@ test.describe.serial('Admin:', () => {
                 await page.getByRole('combobox', { name: 'Provider' }).click();
                 await page
                     .getByRole('option', {
-                        name: 'Amazon Simple Storage Service',
+                        name: 'Amazon S3',
                     })
                     .click();
                 await expect(page.getByLabel('Bucket *')).toBeVisible();

--- a/src/components/admin/Settings/StorageMappings/Dialog/useConfigurationSchema.ts
+++ b/src/components/admin/Settings/StorageMappings/Dialog/useConfigurationSchema.ts
@@ -43,7 +43,7 @@ const gcsProviderSchema = {
 };
 
 const s3ProviderSchema = {
-    title: 'Amazon Simple Storage Service.',
+    title: 'Amazon S3.',
     examples: [
         {
             bucket: 'my-bucket',

--- a/src/lang/en-US/AdminPage.ts
+++ b/src/lang/en-US/AdminPage.ts
@@ -164,7 +164,7 @@ export const AdminPage: Record<string, string> = {
     'storageMappings.dialog.generate.providerOption.AZURE': `Azure Object Storage Service`,
     'storageMappings.dialog.generate.providerOption.CUSTOM': `An S3-compatible Endpoint`,
     'storageMappings.dialog.generate.providerOption.GCS': `Google Cloud Storage`,
-    'storageMappings.dialog.generate.providerOption.S3': `Amazon Simple Storage Service`,
+    'storageMappings.dialog.generate.providerOption.S3': `Amazon S3`,
     'storageMappings.dialog.generate.logsHeader': `Please wait while we save and apply your storage mapping.`,
     'storageMappings.dialog.generate.error.republicationFailed': `There was an error republishing the entities in your system. Please try again.`,
     'storageMappings.dialog.generate.error.unableToFetchLogs': `There was an issue fetching the logs when applying the new storage mapping. Please contact support to confirm that your system has been updated accordingly.`,


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1462

## Changes

### 1462

The following features are included in this PR:

* Change the label for the S3 storage mapping provider option to `Amazon S3`.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate the S3 storage mapping provider option label is `Amazon S3`.

### Automated tests

Logic updated for the following Playwright tests:

* _admin.spec.ts_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**Storage mapping provider selector | Menu options**

<img width="433" alt="pr_screenshot-1463-s3_option_label-deselected" src="https://github.com/user-attachments/assets/1426a5c3-dd92-40ad-a450-ab473345df06" />

<br />
<br />

**Storage mapping provider selector | Amazon S3 option selected**

<img width="434" alt="pr_screenshot-1463-s3_option_label-selected" src="https://github.com/user-attachments/assets/089e06a8-fc36-4700-9305-3af4aeec70bd" />

<br />
<br />