### PR TITLE
Bypass trial storage evaluation for bound collections in capture workflows

### DIFF
--- a/src/components/editor/Bindings/Backfill/BackfillButton.tsx
+++ b/src/components/editor/Bindings/Backfill/BackfillButton.tsx
@@ -162,20 +162,22 @@ function BackfillButton({
 
                         setBackfilledBindings(increment, targetBindingUUID);
 
-                        evaluateTrialCollections(
-                            changes.counterIncremented
-                        ).then(
-                            (response) => {
-                                setCollectionMetadata(response, []);
-                            },
-                            () => {}
-                        );
-
-                        if (hasLength(changes.counterDecremented)) {
-                            setSourceBackfillRecommended(
-                                changes.counterDecremented,
-                                false
+                        if (workflow === 'materialization_edit') {
+                            evaluateTrialCollections(
+                                changes.counterIncremented
+                            ).then(
+                                (response) => {
+                                    setCollectionMetadata(response, []);
+                                },
+                                () => {}
                             );
+
+                            if (hasLength(changes.counterDecremented)) {
+                                setSourceBackfillRecommended(
+                                    changes.counterDecremented,
+                                    false
+                                );
+                            }
                         }
 
                         setFormState({ status: FormStatus.UPDATED });
@@ -204,6 +206,7 @@ function BackfillButton({
             setFormState,
             setSourceBackfillRecommended,
             updateBackfillCounter,
+            workflow,
         ]
     );
 

--- a/src/components/materialization/TrialOnlyPrefixAlert.tsx
+++ b/src/components/materialization/TrialOnlyPrefixAlert.tsx
@@ -1,5 +1,6 @@
 import { Typography } from '@mui/material';
 import AlertBox from 'components/shared/AlertBox';
+import { useEntityType } from 'context/EntityContext';
 import { useIntl } from 'react-intl';
 import { TrialOnlyPrefixAlertProps } from './types';
 
@@ -8,8 +9,9 @@ export default function TrialOnlyPrefixAlert({
     triggered,
 }: TrialOnlyPrefixAlertProps) {
     const intl = useIntl();
+    const entityType = useEntityType();
 
-    if (!triggered) {
+    if (entityType !== 'materialization' || !triggered) {
         return null;
     }
 

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -267,7 +267,10 @@ const getInitialState = (
 
             const boundCollections = Object.keys(get().bindings);
 
-            if (hasLength(boundCollections)) {
+            if (
+                entityType === 'materialization' &&
+                hasLength(boundCollections)
+            ) {
                 const trialCollections = await evaluateTrialCollections(
                     boundCollections,
                     getTrialOnlyPrefixes


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1409

## Changes

### 1409

The following features are included in this PR:

* Bypass the trial storage evaluation for bound collections when hydrating capture workflows.

* Bypass the trial storage evaluation for bound collections when backfilling binding(s) in capture workflows.

* Prevent trial storage alert from appearing outside of materialization workflows.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_