### PR TITLE
prod: check existence of collection metadata in store action

### DIFF
--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -946,9 +946,12 @@ const getInitialState = (
         set(
             produce((state: BindingState) => {
                 collections.forEach((collection) => {
-                    state.collectionMetadata[
-                        collection
-                    ].sourceBackfillRecommended = value;
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                    if (state.collectionMetadata?.[collection]) {
+                        state.collectionMetadata[
+                            collection
+                        ].sourceBackfillRecommended = value;
+                    }
                 });
             }),
             false,


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1409

## Changes

### 1409

The following features are included in this PR:
* Ensure that target collection metadata exists before indexing in binding store action, `setSourceBackfillRecommended`.

## Tests

### Manually tested

Approaches to testing are as follows:
-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_
