### PR TITLE
Travjenkins/bug/cannot click back on mat create

### DIFF
--- a/src/components/connectors/ConnectorTiles.tsx
+++ b/src/components/connectors/ConnectorTiles.tsx
@@ -66,7 +66,7 @@ function ConnectorTiles({ protocolPreset }: ConnectorTilesProps) {
     const primaryCtaClick = (row: ConnectorWithTagDetailQuery) => {
         navigateToCreate(row.connector_tags[0].protocol, {
             id: row.connector_tags[0].connector_id,
-            advanceToForm: row.connector_tags[0].protocol === 'capture',
+            advanceToForm: true,
         });
     };
 

--- a/src/components/connectors/ConnectorTiles.tsx
+++ b/src/components/connectors/ConnectorTiles.tsx
@@ -32,7 +32,6 @@ import ConnectorsSkeleton from './Skeleton';
 
 interface ConnectorTilesProps {
     protocolPreset?: EntityWithCreateWorkflow;
-    replaceOnNavigate?: boolean;
 }
 
 const intlConfig: TableIntlConfig = {
@@ -40,10 +39,7 @@ const intlConfig: TableIntlConfig = {
     message: 'connectors.main.message2',
 };
 
-function ConnectorTiles({
-    protocolPreset,
-    replaceOnNavigate,
-}: ConnectorTilesProps) {
+function ConnectorTiles({ protocolPreset }: ConnectorTilesProps) {
     const navigateToCreate = useEntityCreateNavigate();
     const isFiltering = useRef(false);
 
@@ -68,12 +64,10 @@ function ConnectorTiles({
     const selectData = useMemo(() => selectResponse ?? [], [selectResponse]);
 
     const primaryCtaClick = (row: ConnectorWithTagDetailQuery) => {
-        navigateToCreate(
-            row.connector_tags[0].protocol,
-            row.connector_tags[0].connector_id,
-            replaceOnNavigate,
-            row.connector_tags[0].protocol === 'capture'
-        );
+        navigateToCreate(row.connector_tags[0].protocol, {
+            id: row.connector_tags[0].connector_id,
+            advanceToForm: row.connector_tags[0].protocol === 'capture',
+        });
     };
 
     useEffect(() => {

--- a/src/components/shared/Entity/Create/Config.tsx
+++ b/src/components/shared/Entity/Create/Config.tsx
@@ -19,7 +19,10 @@ function EntityCreateConfig({ entityType }: Props) {
 
     useEffect(() => {
         if (connectorId) {
-            navigateToCreate(entityType, connectorId, true, true);
+            navigateToCreate(entityType, {
+                id: connectorId,
+                advanceToForm: true,
+            });
         }
     }, [navigateToCreate, connectorId, entityType]);
 
@@ -29,7 +32,7 @@ function EntityCreateConfig({ entityType }: Props) {
                 <FormattedMessage id="entityCreate.instructions" />
             </Typography>
 
-            <ConnectorTiles protocolPreset={entityType} replaceOnNavigate />
+            <ConnectorTiles protocolPreset={entityType} />
         </Collapse>
     );
 }

--- a/src/components/shared/Entity/DetailsForm/useConnectorField.ts
+++ b/src/components/shared/Entity/DetailsForm/useConnectorField.ts
@@ -132,13 +132,11 @@ export default function useConnectorField(
                     setEntityNameChanged(details.data.entityName);
 
                     // TODO (data-plane): Set search param of interest instead of using navigate function.
-                    navigateToCreate(
-                        entityType,
-                        selectedConnectorId,
-                        true,
-                        true,
-                        selectedDataPlaneId ?? null
-                    );
+                    navigateToCreate(entityType, {
+                        id: selectedConnectorId,
+                        advanceToForm: true,
+                        dataPlaneId: selectedDataPlaneId ?? null,
+                    });
                 }
             }
         },

--- a/src/components/shared/Entity/DetailsForm/useDataPlaneField.ts
+++ b/src/components/shared/Entity/DetailsForm/useDataPlaneField.ts
@@ -77,13 +77,11 @@ export default function useDataPlaneField(
                     setEntityNameChanged(details.data.entityName);
 
                     // TODO (data-plane): Set search param of interest instead of using navigate function.
-                    navigateToCreate(
-                        entityType,
-                        details.data.connectorImage.connectorId,
-                        true,
-                        true,
-                        selectedDataPlaneId ?? null
-                    );
+                    navigateToCreate(entityType, {
+                        id: details.data.connectorImage.connectorId,
+                        advanceToForm: true,
+                        dataPlaneId: selectedDataPlaneId ?? null,
+                    });
                 }
             }
         },

--- a/src/components/shared/Entity/hooks/useEntityCreateNavigate.ts
+++ b/src/components/shared/Entity/hooks/useEntityCreateNavigate.ts
@@ -7,19 +7,20 @@ import { ENTITY_SETTINGS } from 'settings/entity';
 import { EntityWithCreateWorkflow } from 'types';
 import { getPathWithParams, hasLength } from 'utils/misc-utils';
 
+export interface HookEntityCreateNavigateProps {
+    advanceToForm?: boolean;
+    dataPlaneId?: string | null;
+    id?: string | null | undefined;
+}
+
 export default function useEntityCreateNavigate() {
     const navigate = useNavigate();
     const appendSearchParams = useSearchParamAppend();
 
-    // TODO (optimization): Consider bundling the boolean input parameters in an "options" object
-    //   to enhance code readability when they are passed in.
     return useCallback(
         (
             entity: EntityWithCreateWorkflow,
-            id?: string | null | undefined,
-            replace?: boolean,
-            advanceToForm?: boolean,
-            dataPlaneId?: string | null
+            { id, advanceToForm, dataPlaneId }: HookEntityCreateNavigateProps
         ) => {
             const searchParamConfig: { [param: string]: any } = {};
 

--- a/src/settings/entity.ts
+++ b/src/settings/entity.ts
@@ -78,7 +78,6 @@ export const ENTITY_SETTINGS: { [k in Entity]: EntitySetting } = {
             connectorSelect:
                 authenticatedRoutes.materializations.create.fullPath,
             createNew: authenticatedRoutes.materializations.create.new.fullPath,
-
             details:
                 authenticatedRoutes.materializations.details.overview.fullPath,
             viewAll: authenticatedRoutes.materializations.fullPath,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1468

## Changes

### 1468

-  always set `advanceToForm` to true

### misc

-  cleaned up the old options to be an object
- removed a setting that was no longer used

## Tests

### Manually tested

- created materialization and then clicked back

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### After clicking back on materialization create
![image](https://github.com/user-attachments/assets/59781fd7-d3a5-4eea-b6ae-61cb38ca2f60)
