### PR TITLE
Constrain connector card logo width

### DIFF
--- a/src/components/connectors/card/Logo.tsx
+++ b/src/components/connectors/card/Logo.tsx
@@ -23,8 +23,8 @@ function ConnectorLogo({
                 loading="lazy"
                 alt=""
                 style={{
-                    width: 'auto',
                     maxHeight: maxHeight ?? 75,
+                    maxWidth: '100%',
                     padding: padding ?? '0 1rem',
                 }}
             />

--- a/src/components/connectors/card/index.tsx
+++ b/src/components/connectors/card/index.tsx
@@ -47,7 +47,11 @@ function ConnectorCard({
                                 marginBottom: recommended ? 1 : 2,
                             }}
                         >
-                            <Box
+                            <Stack
+                                style={{
+                                    justifyContent: 'center',
+                                    alignItems: 'center',
+                                }}
                                 sx={
                                     recommended
                                         ? {
@@ -59,21 +63,14 @@ function ConnectorCard({
                                         : connectorImageBackgroundSx
                                 }
                             >
-                                <Stack
-                                    sx={{
-                                        justifyContent: 'center',
-                                        alignItems: 'center',
-                                    }}
-                                >
-                                    <Box>{logo}</Box>
+                                {logo}
 
-                                    {docsUrl ? (
-                                        <ExternalLink link={docsUrl}>
-                                            <FormattedMessage id="terms.documentation" />
-                                        </ExternalLink>
-                                    ) : null}
-                                </Stack>
-                            </Box>
+                                {docsUrl ? (
+                                    <ExternalLink link={docsUrl}>
+                                        <FormattedMessage id="terms.documentation" />
+                                    </ExternalLink>
+                                ) : null}
+                            </Stack>
 
                             {recommended ? (
                                 <Box


### PR DESCRIPTION
## Changes

The following features are included in this PR:

* Constrain the width of logos displayed on connector cards.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that an oversized logo on a connector card does not overflow its container.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_