### PR TITLE
Evaluate backfilled bindings to set top-level backfill button state

### DIFF
--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -384,6 +384,10 @@ const getInitialState = (
                 state.resourceConfigs = sortedResourceConfigs;
                 populateResourceConfigErrors(state, sortedResourceConfigs);
 
+                state.backfillAllBindings =
+                    state.backfilledBindings.length ===
+                    Object.keys(state.resourceConfigs).length;
+
                 state.bindingErrorsExist = isEmpty(state.bindings);
                 initializeCurrentBinding(
                     state,


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1471

## Changes

### 1471

The following features are included in this PR:

* Set the binding store state property, `backfillAllBindings`, in store action, `prefillBindingDependentState`, by comparing the length of `backfilledBindings` to that of `resourceConfigs` keys.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the top-level, _Backfill_ button state is properly set depending upon whether all bindings are backfilled.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_

