### PR TITLE
Updating query so it will find when the full sourceCapture is being used

### DIFF
--- a/src/hooks/useLiveSpecsExt.ts
+++ b/src/hooks/useLiveSpecsExt.ts
@@ -128,6 +128,8 @@ export function useLiveSpecsExt_related(captureName: string) {
             .or(
                 `spec->>sourceCapture.eq.${escapeReservedCharacters(
                     captureName
+                )},spec->sourceCapture->>capture.eq.${escapeReservedCharacters(
+                    captureName
                 )}`
             )
             .returns<LiveSpecsExt_Related[]>()


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1486

## Changes

### 1486

-  Add another statement to fetch nested `capture' settings in `sourceCapture`

## Tests

### Manually tested

- Used a `sourceCapture` that was set on the nested property
- Used a `sourceCapture` that was just a string

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
