### PR TITLE
Present source backfill recommended warning for newly bound collections

### DIFF
--- a/src/components/collection/ResourceConfig.tsx
+++ b/src/components/collection/ResourceConfig.tsx
@@ -53,6 +53,11 @@ function ResourceConfig({
         'trialStorage'
     );
 
+    const collectionPreviouslyBound = useBinding_collectionMetadataProperty(
+        collectionName,
+        'previouslyBound'
+    );
+
     const collectionAdded = useBinding_collectionMetadataProperty(
         collectionName,
         'added'
@@ -64,7 +69,11 @@ function ResourceConfig({
                 <Box style={{ marginBottom: 16 }}>
                     <TrialOnlyPrefixAlert
                         messageId="workflows.error.oldBoundCollection.added"
-                        triggered={Boolean(trialCollection && collectionAdded)}
+                        triggered={Boolean(
+                            !collectionPreviouslyBound &&
+                                trialCollection &&
+                                collectionAdded
+                        )}
                     />
                 </Box>
             ) : null}

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -360,11 +360,6 @@ const getInitialState = (
                             targetBindingIndex
                         );
 
-                        state.collectionMetadata[collection].previouslyBound =
-                            liveBindingIndex > -1;
-
-                        state.collectionMetadata;
-
                         const liveBackfillCounter =
                             liveBindingIndex > -1
                                 ? getBackfillCounter(
@@ -378,6 +373,23 @@ const getInitialState = (
                                 draftedBackfillCounter > 0)
                         ) {
                             state.backfilledBindings.push(UUID);
+                        }
+
+                        console.log(collection);
+                        console.log(liveBindingIndex);
+
+                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                        if (state.collectionMetadata?.[collection]) {
+                            state.collectionMetadata[
+                                collection
+                            ].previouslyBound = liveBindingIndex > -1;
+                        } else {
+                            state.collectionMetadata = {
+                                ...state.collectionMetadata,
+                                [collection]: {
+                                    previouslyBound: liveBindingIndex > -1,
+                                },
+                            };
                         }
                     }
                 });
@@ -830,9 +842,12 @@ const getInitialState = (
 
                 values.forEach(({ catalog_name, updated_at }) => {
                     const added =
-                        addedCollections.includes(catalog_name) ||
                         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                        state.collectionMetadata[catalog_name]?.added;
+                        !state.collectionMetadata[catalog_name]
+                            .previouslyBound &&
+                        (addedCollections.includes(catalog_name) ||
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                            state.collectionMetadata[catalog_name]?.added);
 
                     state.collectionMetadata[catalog_name] = {
                         ...state.collectionMetadata[catalog_name],

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -360,6 +360,11 @@ const getInitialState = (
                             targetBindingIndex
                         );
 
+                        state.collectionMetadata[collection].previouslyBound =
+                            liveBindingIndex > -1;
+
+                        state.collectionMetadata;
+
                         const liveBackfillCounter =
                             liveBindingIndex > -1
                                 ? getBackfillCounter(
@@ -830,6 +835,7 @@ const getInitialState = (
                         state.collectionMetadata[catalog_name]?.added;
 
                     state.collectionMetadata[catalog_name] = {
+                        ...state.collectionMetadata[catalog_name],
                         added,
                         sourceBackfillRecommended:
                             isBeforeTrialInterval(updated_at) &&

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -841,10 +841,12 @@ const getInitialState = (
                 );
 
                 values.forEach(({ catalog_name, updated_at }) => {
-                    const added =
+                    const previouslyBound =
                         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                        !state.collectionMetadata[catalog_name]
-                            .previouslyBound &&
+                        state.collectionMetadata[catalog_name]?.previouslyBound;
+
+                    const added =
+                        !previouslyBound &&
                         (addedCollections.includes(catalog_name) ||
                             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                             state.collectionMetadata[catalog_name]?.added);

--- a/src/stores/Binding/types.ts
+++ b/src/stores/Binding/types.ts
@@ -18,6 +18,7 @@ import { StoreWithTimeTravel } from './slices/TimeTravel';
 
 export interface CollectionMetadata {
     added?: boolean;
+    previouslyBound?: boolean;
     sourceBackfillRecommended?: boolean;
     trialStorage?: boolean;
     updatedAt?: string;


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1488

## Changes

### 1488

The following features are included in this PR:

* Extend the collection metadata object to include an indication of whether the collection is bound to the live task.

* Narrow the client's understanding of an _added_ collection. The `added` collection metadata property now reflects whether the collection is newly introduced to the task specification.

## Tests

### Manually tested

Approaches to testing are as follows:

-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_
