### PR TITLE
disable button while adding source capture collections

### DIFF
--- a/src/components/editor/Bindings/UpdateResourceConfigButton.tsx
+++ b/src/components/editor/Bindings/UpdateResourceConfigButton.tsx
@@ -2,6 +2,7 @@ import { Button } from '@mui/material';
 import { AddCollectionDialogCTAProps } from 'components/shared/Entity/types';
 import invariableStores from 'context/Zustand/invariableStores';
 import useTrialCollections from 'hooks/trialStorage/useTrialCollections';
+import { useState } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 import {
@@ -15,6 +16,8 @@ import { hasLength } from 'utils/misc-utils';
 import { useStore } from 'zustand';
 
 function UpdateResourceConfigButton({ toggle }: AddCollectionDialogCTAProps) {
+    const [updating, setUpdating] = useState(false);
+
     const [selected] = useStore(
         invariableStores['Entity-Selector-Table'],
         (state) => {
@@ -35,6 +38,8 @@ function UpdateResourceConfigButton({ toggle }: AddCollectionDialogCTAProps) {
         useBinding_setRestrictedDiscoveredCollections();
 
     const close = () => {
+        setUpdating(true);
+
         const value = Array.from(selected).map(([_id, row]) => {
             return {
                 name: row.catalog_name,
@@ -60,13 +65,14 @@ function UpdateResourceConfigButton({ toggle }: AddCollectionDialogCTAProps) {
             }
         }
 
+        setUpdating(false);
         toggle(false);
     };
 
     return (
         <Button
             variant="contained"
-            disabled={selected.size < 1}
+            disabled={selected.size < 1 || updating}
             onClick={close}
         >
             <FormattedMessage id="cta.continue" />

--- a/src/components/materialization/SourceCapture/AddSourceCaptureToSpecButton.tsx
+++ b/src/components/materialization/SourceCapture/AddSourceCaptureToSpecButton.tsx
@@ -2,6 +2,7 @@ import { Button } from '@mui/material';
 import { AddCollectionDialogCTAProps } from 'components/shared/Entity/types';
 import invariableStores from 'context/Zustand/invariableStores';
 import useTrialCollections from 'hooks/trialStorage/useTrialCollections';
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
     useBinding_prefillResourceConfigs,
@@ -14,6 +15,8 @@ import { useStore } from 'zustand';
 import useSourceCapture from '../useSourceCapture';
 
 function AddSourceCaptureToSpecButton({ toggle }: AddCollectionDialogCTAProps) {
+    const [updating, setUpdating] = useState(false);
+
     const [selected] = useStore(
         invariableStores['Entity-Selector-Table'],
         (state) => {
@@ -44,6 +47,8 @@ function AddSourceCaptureToSpecButton({ toggle }: AddCollectionDialogCTAProps) {
     const prefillResourceConfigs = useBinding_prefillResourceConfigs();
 
     const close = async () => {
+        setUpdating(true);
+
         const selectedRow = Array.from(selected).map(([_key, row]) => row)[0];
         const updatedSourceCaptureName = selectedRow
             ? selectedRow.catalog_name
@@ -83,7 +88,10 @@ function AddSourceCaptureToSpecButton({ toggle }: AddCollectionDialogCTAProps) {
             if (nameUpdated) {
                 setSourceCapture(updatedSourceCapture.capture);
 
-                if (selectedRow?.writes_to) {
+                if (
+                    selectedRow?.writes_to &&
+                    selectedRow?.writes_to.length > 0
+                ) {
                     prefillResourceConfigs(
                         selectedRow.writes_to,
                         true,
@@ -105,11 +113,12 @@ function AddSourceCaptureToSpecButton({ toggle }: AddCollectionDialogCTAProps) {
             await updateDraft(updatedSourceCapture);
         }
 
+        setUpdating(false);
         toggle(false);
     };
 
     return (
-        <Button variant="contained" onClick={close}>
+        <Button variant="contained" onClick={close} disabled={updating}>
             <FormattedMessage id="cta.continue" />
         </Button>
     );


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1495

## Changes

### 1495

- Check the length and not just the existence of collections

### Misc

- The backfill warning can add a TON of time to simple actions. So they need to have a state of `updating` to disable the button to prevent double clicks

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Selecting capture without collections
![image](https://github.com/user-attachments/assets/1a076d1f-a465-411b-b9aa-7ad32263e889)

### Added, modal closed, and no errors
![image](https://github.com/user-attachments/assets/67f46c95-87af-432d-9396-56b57ae97975)
