### PR TITLE
Switch to new gtag container

### DIFF
--- a/.env
+++ b/.env
@@ -54,7 +54,7 @@ VITE_LOGROCKET_ID_USER_INCLUDE_EMAIL=true
 
 # Analytics settings
 VITE_GOOGLE_TAG_MANAGER_ENABLED=true
-VITE_GOOGLE_TAG_MANAGER_ID=GTM-WK8SB2L
+VITE_GOOGLE_TAG_MANAGER_ID=GTM-W5CPN35W
 
 # Used to post message to docs for Dark/Light mode toggle
 VITE_DOCS_ORIGIN=https://docs.estuary.dev

--- a/src/services/gtm.ts
+++ b/src/services/gtm.ts
@@ -1,22 +1,25 @@
 import { Schema } from 'types';
-import { getGoogleTageManagerSettings, isProduction } from 'utils/env-utils';
-
-const googleTagManagerSettings = getGoogleTageManagerSettings();
-
-type EVENTS = 'Connector_Search' | 'Register' | 'Payment_Entered';
+import { getGoogleTageManagerSettings } from 'utils/env-utils';
 
 // GTM is loaded/initialized in index.html
 
+type EVENTS = 'Connector_Search' | 'Register' | 'Payment_Entered';
+
+const { allowedToRun } = getGoogleTageManagerSettings();
+
 export const fireGtmEvent = (event: EVENTS, data: Schema | undefined = {}) => {
-    if (
-        isProduction &&
-        googleTagManagerSettings.enabled &&
-        googleTagManagerSettings.id
-    ) {
+    if (allowedToRun) {
         window.dataLayer = window.dataLayer ?? [];
         window.dataLayer.push({
             ...data,
             event,
         });
+    }
+};
+
+export const setGtmData = (data?: Schema) => {
+    if (allowedToRun) {
+        window.dataLayer = window.dataLayer ?? [];
+        window.dataLayer.push(data);
     }
 };

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -195,7 +195,9 @@ export const getGoogleTageManagerSettings = () => {
         id: import.meta.env.VITE_GOOGLE_TAG_MANAGER_ID,
     };
 
-    return settings;
+    return {
+        allowedToRun: Boolean(isProduction && settings.enabled && settings.id),
+    };
 };
 
 export const getDocsSettings = () => {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1354

## Changes

### 1354

- Switch out and use the new container id
- Add/test (the pull out) new function to set `dataLayer` data
- Changed how we fetch settings as we just really care about the `if`

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
