### PR TITLE
Only sending event if there is a value

### DIFF
--- a/src/components/connectors/ConnectorToolbar.tsx
+++ b/src/components/connectors/ConnectorToolbar.tsx
@@ -74,9 +74,13 @@ function ConnectorToolbar({
                 isFiltering.current = hasQuery;
 
                 setSearchQuery(hasQuery ? filterQuery : null);
-                fireGtmEvent('Connector_Search', {
-                    filterQuery,
-                });
+
+                // Only fire the event if there is a query to send back
+                if (hasQuery) {
+                    fireGtmEvent('Connector_Search', {
+                        filterQuery,
+                    });
+                }
             },
             750
         ),

--- a/src/services/gtm.ts
+++ b/src/services/gtm.ts
@@ -11,8 +11,8 @@ export const fireGtmEvent = (event: EVENTS, data: Schema | undefined = {}) => {
     if (allowedToRun) {
         window.dataLayer = window.dataLayer ?? [];
         window.dataLayer.push({
-            ...data,
             event,
+            ...data,
         });
     }
 };


### PR DESCRIPTION
Flipping order so `event` is never overwritten

## Issues

https://github.com/estuary/ui/issues/1491

## Changes

### 1491

-  only fire when there is a value

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
