### PR TITLE
Show data plane prefix 

### DIFF
--- a/src/forms/renderers/DataPlaneSelector/AutoComplete.tsx
+++ b/src/forms/renderers/DataPlaneSelector/AutoComplete.tsx
@@ -136,7 +136,7 @@ export const DataPlaneAutoComplete = ({
                     <Option
                         renderOptionProps={renderOptionProps}
                         option={option}
-                        key={option.label}
+                        key={option.value.id}
                     />
                 );
             }}

--- a/src/forms/renderers/DataPlaneSelector/AutoComplete.tsx
+++ b/src/forms/renderers/DataPlaneSelector/AutoComplete.tsx
@@ -29,11 +29,15 @@ import { EnumCellProps, EnumOption, WithClassname } from '@jsonforms/core';
 import {
     Autocomplete,
     AutocompleteRenderOptionState,
+    Box,
     FilterOptionsState,
     MenuList,
+    Stack,
     Typography,
 } from '@mui/material';
 import DataPlaneIcon from 'components/shared/Entity/DataPlaneIcon';
+import { defaultOutline_hovered } from 'context/Theme';
+
 import React, { ReactNode, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import AutoCompleteInputWithStartAdornment from '../AutoCompleteInputWithStartAdornment';
@@ -116,21 +120,51 @@ export const DataPlaneAutoComplete = ({
                     <MenuList style={{ padding: 0 }}>{children}</MenuList>
                 </li>
             )}
-            renderInput={(textFieldProps) => (
-                <AutoCompleteInputWithStartAdornment
-                    textFieldProps={textFieldProps}
-                    startAdornment={
-                        currentOption ? (
-                            <DataPlaneIcon
-                                provider={
-                                    currentOption.value.dataPlaneName.provider
-                                }
-                                scope={currentOption.value.scope}
-                            />
-                        ) : null
-                    }
-                />
-            )}
+            renderInput={(textFieldProps) => {
+                return (
+                    <AutoCompleteInputWithStartAdornment
+                        textFieldProps={textFieldProps}
+                        startAdornment={
+                            currentOption ? (
+                                <Stack
+                                    direction="row"
+                                    spacing={1}
+                                    sx={{
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    {currentOption.value.dataPlaneName
+                                        .prefix ? (
+                                        <Box
+                                            sx={{
+                                                borderRight: (theme) =>
+                                                    defaultOutline_hovered[
+                                                        theme.palette.mode
+                                                    ],
+                                                fontsize: 9,
+                                                pr: 1,
+                                            }}
+                                        >
+                                            {
+                                                currentOption.value
+                                                    .dataPlaneName.prefix
+                                            }
+                                        </Box>
+                                    ) : null}
+
+                                    <DataPlaneIcon
+                                        provider={
+                                            currentOption.value.dataPlaneName
+                                                .provider
+                                        }
+                                        scope={currentOption.value.scope}
+                                    />
+                                </Stack>
+                            ) : null
+                        }
+                    />
+                );
+            }}
             renderOption={(renderOptionProps, option) => {
                 return (
                     <Option


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1509

## Changes

### 1509

- Tried showing it just like it is in the options but that ends up causing the input too tall.
- Tried showing the `prefix` in the actual input.
- Ended up showing the prefix before the icon as that _somewhat_ makes the most sense as it keeps the stuff grouped as `tenant` | `provider` `provider`. If we show the `prefix` in the input then the data goes - `provider` `tenant` `provider`. 
    

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/aa242a6c-5d4f-440a-b478-503f04dc4d10)
![image](https://github.com/user-attachments/assets/804efa92-a611-4783-9435-c6ed6587292d)

