### PR TITLE
[PROD] - add some extra logging and minor logic tweaks for loading create

### DIFF
--- a/src/components/shared/Entity/EndpointConfig/index.tsx
+++ b/src/components/shared/Entity/EndpointConfig/index.tsx
@@ -118,6 +118,9 @@ function EndpointConfig({
             //  connector schema changes should be backwards compatible (as of Q1 2024)
             resetConfig = false;
         } else {
+            // TODO (create load) this should not be true anymore. The user cannot change the connector
+            //  but without this the create flow will not load in.
+
             // In create if the schema changed it probably means the user selected
             //  a different connector in the dropdown. So we need to clear out data
             //  and update the schema

--- a/src/stores/DetailsForm/Hydrator.tsx
+++ b/src/stores/DetailsForm/Hydrator.tsx
@@ -38,6 +38,11 @@ export const DetailsFormHydrator = ({ children }: BaseComponentProps) => {
         }
     });
 
+    // Until details is hydrated we should wait to load in the other hydrator children
+    if (!hydrated) {
+        return null;
+    }
+
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;
 };

--- a/src/stores/EndpointConfig/Hydrator.tsx
+++ b/src/stores/EndpointConfig/Hydrator.tsx
@@ -1,6 +1,7 @@
 import { useEntityType } from 'context/EntityContext';
 import { useEntityWorkflow } from 'context/Workflow';
-import { useEffect, useState } from 'react';
+
+import { useEffect, useRef } from 'react';
 import { logRocketConsole } from 'services/shared';
 import { useDetailsFormStore } from 'stores/DetailsForm/Store';
 import {
@@ -16,7 +17,7 @@ export const EndpointConfigHydrator = ({ children }: BaseComponentProps) => {
     const entityType = useEntityType();
     const workflow = useEntityWorkflow();
 
-    const [runHydration, setRunHydration] = useState(true);
+    const runHydration = useRef(true);
 
     const connectorTagId = useDetailsFormStore(
         (state) => state.details.data.connectorImage.id
@@ -28,14 +29,21 @@ export const EndpointConfigHydrator = ({ children }: BaseComponentProps) => {
     const hydrateState = useEndpointConfig_hydrateState();
     const setActive = useEndpointConfig_setActive();
 
+    logRocketConsole('EndpointConfigHydrator', {
+        runHydration: Boolean(runHydration.current),
+        hydrated,
+        connectorTagId,
+        entityType,
+    });
+
     useEffect(() => {
         if (
-            runHydration &&
+            runHydration.current &&
             !hydrated &&
             connectorTagId.length > 0 &&
             (entityType === 'capture' || entityType === 'materialization')
         ) {
-            setRunHydration(false);
+            runHydration.current = false;
             setActive(true);
             hydrateState(entityType, workflow, connectorTagId).then(
                 () => {
@@ -57,7 +65,6 @@ export const EndpointConfigHydrator = ({ children }: BaseComponentProps) => {
         entityType,
         hydrateState,
         hydrated,
-        runHydration,
         setActive,
         setHydrated,
         setHydrationErrorsExist,

--- a/src/stores/EndpointConfig/Store.ts
+++ b/src/stores/EndpointConfig/Store.ts
@@ -221,8 +221,7 @@ const getInitialState = (
             active: get().active,
         });
 
-        // get().active &&
-        if (connectorTagId && connectorTagId.length > 0) {
+        if (get().active && connectorTagId && connectorTagId.length > 0) {
             logRocketConsole(
                 'EndpointConfigHydrator>hydrateState>fetch>getSchema_Endpoint',
                 {

--- a/src/stores/EndpointConfig/Store.ts
+++ b/src/stores/EndpointConfig/Store.ts
@@ -4,6 +4,7 @@ import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
 import produce from 'immer';
 import { isEmpty } from 'lodash';
 import { createJSONFormDefaults } from 'services/ajv';
+import { logRocketConsole } from 'services/shared';
 import {
     CustomError,
     fetchErrors,
@@ -216,14 +217,36 @@ const getInitialState = (
             get().setServerUpdateRequired(true);
         }
 
-        if (get().active && connectorTagId && connectorTagId.length > 0) {
+        logRocketConsole('EndpointConfigHydrator>hydrateState', {
+            active: get().active,
+        });
+
+        // get().active &&
+        if (connectorTagId && connectorTagId.length > 0) {
+            logRocketConsole(
+                'EndpointConfigHydrator>hydrateState>fetch>getSchema_Endpoint',
+                {
+                    active: get().active,
+                }
+            );
+
             const { data, error } = await getSchema_Endpoint(connectorTagId);
 
             if (error) {
+                logRocketConsole(
+                    'EndpointConfigHydrator>hydrateState>fetch>setHydrationErrorsExist',
+                    {
+                        active: get().active,
+                    }
+                );
                 get().setHydrationErrorsExist(true);
             }
 
             if (get().active && data) {
+                logRocketConsole(
+                    'EndpointConfigHydrator>hydrateState>fetch>setEndpointSchema'
+                );
+
                 await get().setEndpointSchema(
                     data.endpoint_spec_schema as unknown as Schema
                 );


### PR DESCRIPTION
Do not load past details hydrator until it is done Using a ref in hopes it reduces the chance of renders

## Issues

https://github.com/estuary/ui/issues/1520

## Changes

### 1520

-  Adding some LR logging to see if that can help
- No longer loading endpoint until details is fully hydrated. Hoping this will reduce the chance of something odd happening during loading. Also, all the other hydrators are dependent on that one so waiting is not a huge deal.
- 

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
