### PR TITLE
Adding support to default private data plane if there is only one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,8 +126,8 @@
                 "vitest-mock-extended": "^1.3.1"
             },
             "engines": {
-                "node": "20.10.0",
-                "npm": "10.2.3"
+                "node": ">=20",
+                "npm": "^10"
             }
         },
         "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "private": true,
     "engines": {
-        "node": "^20",
+        "node": ">=20",
         "npm": "^10"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "main": "index.js",
     "private": true,
     "engines": {
-        "node": "20.10.0",
-        "npm": "10.2.3"
+        "node": "^20",
+        "npm": "^10"
     },
     "scripts": {
         "build": "vite build",

--- a/src/api/dataPlanes.ts
+++ b/src/api/dataPlanes.ts
@@ -35,7 +35,7 @@ const COLUMNS = [
     'cidr_blocks',
     'gcp_service_account_email',
     'aws_iam_user_arn',
-    // 'aws_link_endpoints', uncomment after https://github.com/estuary/flow/pull/1816 is done
+    // 'aws_link_endpoints', TODO uncomment after https://github.com/estuary/flow/pull/1816 is done
 ];
 
 const QUERY = COLUMNS.join(',');

--- a/src/components/editor/MonacoEditor/index.tsx
+++ b/src/components/editor/MonacoEditor/index.tsx
@@ -169,11 +169,6 @@ function MonacoEditor({
 
                 // Make sure we have all the props needed to update the value
                 if (validValue && catalogName && catalogType) {
-                    logRocketConsole('editor:update:saving', {
-                        processedVal,
-                        catalogName,
-                        catalogType,
-                    });
                     setStatus(EditorStatus.SAVING, evaluatedPath);
 
                     // Check if there is a scope to update (ex: Schema editing for bindings editor)

--- a/src/stores/DetailsForm/Store.ts
+++ b/src/stores/DetailsForm/Store.ts
@@ -4,7 +4,7 @@ import { getLiveSpecs_detailsForm } from 'api/liveSpecsExt';
 import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
 import produce from 'immer';
 import { isEmpty } from 'lodash';
-import { logRocketConsole, logRocketEvent } from 'services/shared';
+import { logRocketEvent } from 'services/shared';
 import { CustomEvents } from 'services/types';
 import { DATA_PLANE_SETTINGS } from 'settings/dataPlanes';
 import {
@@ -39,9 +39,6 @@ const getConnectorImage = async (
     connectorId: string,
     existingImageTag?: ConnectorVersionEvaluationOptions['existingImageTag']
 ): Promise<Details['data']['connectorImage'] | null> => {
-    logRocketConsole('DetailsFormHydrator>getConnectorImage', {
-        connectorId,
-    });
     const { data, error } = await getConnectors_detailsForm(connectorId);
 
     if (!error && data && data.length > 0) {
@@ -212,9 +209,6 @@ export const getInitialState = (
         set(
             produce((state: DetailsFormState) => {
                 if (connectorImage.id === '') {
-                    logRocketConsole(
-                        'DetailsFormHydrator>setDetails_connector>resetting'
-                    );
                     state.details.data.connectorImage =
                         getInitialStateData().details.data.connectorImage;
                 } else {
@@ -317,15 +311,6 @@ export const getInitialState = (
         const createWorkflow =
             workflow === 'capture_create' ||
             workflow === 'materialization_create';
-
-        logRocketConsole('DetailsFormHydrator>hydrateState', {
-            connectorId,
-            createWorkflow,
-            dataPlaneId,
-            liveSpecId,
-            searchParams: searchParams.toString(),
-            workflow,
-        });
 
         if (connectorId) {
             let dataPlaneOptions: DataPlaneOption[] = [];

--- a/src/stores/EndpointConfig/Hydrator.tsx
+++ b/src/stores/EndpointConfig/Hydrator.tsx
@@ -29,13 +29,6 @@ export const EndpointConfigHydrator = ({ children }: BaseComponentProps) => {
     const hydrateState = useEndpointConfig_hydrateState();
     const setActive = useEndpointConfig_setActive();
 
-    logRocketConsole('EndpointConfigHydrator', {
-        runHydration: Boolean(runHydration.current),
-        hydrated,
-        connectorTagId,
-        entityType,
-    });
-
     useEffect(() => {
         if (
             runHydration.current &&

--- a/src/stores/EndpointConfig/Store.ts
+++ b/src/stores/EndpointConfig/Store.ts
@@ -4,7 +4,6 @@ import { GlobalSearchParams } from 'hooks/searchParams/useGlobalSearchParams';
 import produce from 'immer';
 import { isEmpty } from 'lodash';
 import { createJSONFormDefaults } from 'services/ajv';
-import { logRocketConsole } from 'services/shared';
 import {
     CustomError,
     fetchErrors,
@@ -217,35 +216,14 @@ const getInitialState = (
             get().setServerUpdateRequired(true);
         }
 
-        logRocketConsole('EndpointConfigHydrator>hydrateState', {
-            active: get().active,
-        });
-
         if (get().active && connectorTagId && connectorTagId.length > 0) {
-            logRocketConsole(
-                'EndpointConfigHydrator>hydrateState>fetch>getSchema_Endpoint',
-                {
-                    active: get().active,
-                }
-            );
-
             const { data, error } = await getSchema_Endpoint(connectorTagId);
 
             if (error) {
-                logRocketConsole(
-                    'EndpointConfigHydrator>hydrateState>fetch>setHydrationErrorsExist',
-                    {
-                        active: get().active,
-                    }
-                );
                 get().setHydrationErrorsExist(true);
             }
 
             if (get().active && data) {
-                logRocketConsole(
-                    'EndpointConfigHydrator>hydrateState>fetch>setEndpointSchema'
-                );
-
                 await get().setEndpointSchema(
                     data.endpoint_spec_schema as unknown as Schema
                 );


### PR DESCRIPTION
Marking todos

## Issues

https://github.com/estuary/ui/issues/1524

## Changes

### 1524

- Check if we have a single private plane and use that one
- Clean up debug logging

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/79b4c974-5087-4db6-a3f7-0ab88e53352c)


![image](https://github.com/user-attachments/assets/c925c08d-71d8-49d3-883f-8c530c687298)

