### PR TITLE
Adding `reddit` and `linkedin` to options for where user heard about us

### DIFF
--- a/src/directives/Onboard/Survey/index.tsx
+++ b/src/directives/Onboard/Survey/index.tsx
@@ -21,11 +21,13 @@ function OnboardingSurvey() {
 
     const originOptions: string[] = useConstant(() => [
         intl.formatMessage({ id: 'tenant.origin.radio.browserSearch.label' }),
-        intl.formatMessage({ id: 'tenant.origin.radio.socialMedia.label' }),
         intl.formatMessage({ id: 'tenant.origin.radio.paidAdvertising.label' }),
         intl.formatMessage({ id: 'tenant.origin.radio.content.label' }),
         intl.formatMessage({ id: 'tenant.origin.radio.referral.label' }),
         intl.formatMessage({ id: 'tenant.origin.radio.webinar.label' }),
+        intl.formatMessage({ id: 'tenant.origin.radio.reddit.label' }),
+        intl.formatMessage({ id: 'tenant.origin.radio.linkedIn.label' }),
+        intl.formatMessage({ id: 'tenant.origin.radio.socialMedia.label' }),
         surveyOptionOther,
     ]);
 

--- a/src/lang/en-US/Authentication.ts
+++ b/src/lang/en-US/Authentication.ts
@@ -97,6 +97,8 @@ export const Authentication: Record<string, string> = {
     'tenant.origin.radio.content.label': `Blog`,
     'tenant.origin.radio.referral.label': `Word of Mouth`,
     'tenant.origin.radio.webinar.label': `Webinar`,
+    'tenant.origin.radio.reddit.label': `Reddit`,
+    'tenant.origin.radio.linkedIn.label': `LinkedIn`,
     'tenant.origin.radio.other.label': `Other`,
 
     'tenant.grantDirective.header': `Tenant shared with you`,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1527

## Changes

### 1527

-  adding options
- moved all the "social medias" together

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/410b7034-223e-491c-a630-ba4d296081c5)

