### PR TITLE
Update backfill-related client state when binding removed

### DIFF
--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -581,10 +581,16 @@ const getInitialState = (
                     }
 
                     // Update backfill-related state.
-                    state.backfilledBindings =
-                        mappedUUIDsAndResourceConfigs.map(
-                            ([bindingUUID, _resourceConfig]) => bindingUUID
-                        );
+                    const evaluatedBackfilledBindings =
+                        mappedUUIDsAndResourceConfigs
+                            .map(
+                                ([bindingUUID, _resourceConfig]) => bindingUUID
+                            )
+                            .filter((bindingUUID) =>
+                                state.backfilledBindings.includes(bindingUUID)
+                            );
+
+                    state.backfilledBindings = evaluatedBackfilledBindings;
 
                     state.backfillAllBindings =
                         state.backfilledBindings.length > 0 &&
@@ -650,10 +656,16 @@ const getInitialState = (
                         collection: resourceConfig.meta.collectionName,
                     };
 
-                    state.backfilledBindings =
-                        mappedUUIDsAndResourceConfigs.map(
-                            ([bindingUUID, _resourceConfig]) => bindingUUID
-                        );
+                    const evaluatedBackfilledBindings =
+                        mappedUUIDsAndResourceConfigs
+                            .map(
+                                ([bindingUUID, _resourceConfig]) => bindingUUID
+                            )
+                            .filter((bindingUUID) =>
+                                state.backfilledBindings.includes(bindingUUID)
+                            );
+
+                    state.backfilledBindings = evaluatedBackfilledBindings;
 
                     state.backfillAllBindings =
                         state.backfilledBindings.length > 0 &&

--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -50,6 +50,7 @@ import {
     resetCollectionMetadata,
     sortResourceConfigs,
     STORE_KEY,
+    updateBackfilledBindingState,
     whatChanged,
 } from './shared';
 import {
@@ -581,21 +582,10 @@ const getInitialState = (
                     }
 
                     // Update backfill-related state.
-                    const evaluatedBackfilledBindings =
+                    updateBackfilledBindingState(
+                        state,
                         mappedUUIDsAndResourceConfigs
-                            .map(
-                                ([bindingUUID, _resourceConfig]) => bindingUUID
-                            )
-                            .filter((bindingUUID) =>
-                                state.backfilledBindings.includes(bindingUUID)
-                            );
-
-                    state.backfilledBindings = evaluatedBackfilledBindings;
-
-                    state.backfillAllBindings =
-                        state.backfilledBindings.length > 0 &&
-                        state.backfilledBindings.length ===
-                            Object.keys(state.resourceConfigs).length;
+                    );
 
                     // Remove the binding from the bindings dictionary.
                     const evaluatedBindings = state.bindings;
@@ -656,21 +646,10 @@ const getInitialState = (
                         collection: resourceConfig.meta.collectionName,
                     };
 
-                    const evaluatedBackfilledBindings =
+                    updateBackfilledBindingState(
+                        state,
                         mappedUUIDsAndResourceConfigs
-                            .map(
-                                ([bindingUUID, _resourceConfig]) => bindingUUID
-                            )
-                            .filter((bindingUUID) =>
-                                state.backfilledBindings.includes(bindingUUID)
-                            );
-
-                    state.backfilledBindings = evaluatedBackfilledBindings;
-
-                    state.backfillAllBindings =
-                        state.backfilledBindings.length > 0 &&
-                        state.backfilledBindings.length ===
-                            Object.keys(state.resourceConfigs).length;
+                    );
                 } else {
                     state.bindings = {};
                     state.currentBinding = null;

--- a/src/stores/Binding/shared.ts
+++ b/src/stores/Binding/shared.ts
@@ -252,6 +252,25 @@ export const initializeAndGenerateUUID = (
     };
 };
 
+export const updateBackfilledBindingState = (
+    state: BindingState,
+    mappedUUIDsAndResourceConfigs: [string, ResourceConfig][]
+) => {
+    if (state.backfilledBindings.length > 0) {
+        const evaluatedBackfilledBindings = mappedUUIDsAndResourceConfigs
+            .map(([bindingUUID, _resourceConfig]) => bindingUUID)
+            .filter((bindingUUID) =>
+                state.backfilledBindings.includes(bindingUUID)
+            );
+
+        state.backfilledBindings = evaluatedBackfilledBindings;
+
+        state.backfillAllBindings =
+            state.backfilledBindings.length ===
+            Object.keys(state.resourceConfigs).length;
+    }
+};
+
 export const STORE_KEY = 'Bindings';
 
 export const hydrateConnectorTagDependentState = async (


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1530

## Changes

### 1530

The following features are included in this PR:

* Correct the logic that updates binding store state property, `backfilledBindings`, in the following binding store actions: `removeBinding` and `removeBindings`.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that `backfilledBindings` accurately reflects the bindings that are backfilled when one or more bindings are removed.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_
