### PR TITLE
package.json: update to @estuary/flow-web:v0.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@dnd-kit/utilities": "^3.2.1",
                 "@emotion/react": "^11.11.1",
                 "@emotion/styled": "^11.11.0",
-                "@estuary/flow-web": "^0.5.0",
+                "@estuary/flow-web": "^0.5.11",
                 "@jsonforms/core": "3.2.1",
                 "@jsonforms/material-renderers": "3.2.1",
                 "@jsonforms/react": "3.2.1",
@@ -1189,9 +1189,9 @@
             }
         },
         "node_modules/@estuary/flow-web": {
-            "version": "0.5.0",
-            "resolved": "https://npm.pkg.github.com/download/@estuary/flow-web/0.5.0/0ab22a6f123b8066923d453900c572b73be1c6c3",
-            "integrity": "sha512-8CfFsW+1gvNawTuHQP/LDA8CIp6BYkc3efVZ6ZCyokY2jXeSMsvyQzhuq1n7avsj09J5dBe2GmuzbInNHfZa0w==",
+            "version": "0.5.11",
+            "resolved": "https://npm.pkg.github.com/download/@estuary/flow-web/0.5.11/c58ccdebd1a7a20805b4acc93f51aca9d939c211",
+            "integrity": "sha512-S/dUdE/Qd6w8iXSn2SxAYKxZlNoosDIL0jnuJk7tJ+pYKvRqajSPa81+47SqACRkuoRAkkdJpqnB9GHwJq4tPw==",
             "license": "BSL"
         },
         "node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@estuary/flow-web": "^0.5.0",
+        "@estuary/flow-web": "^0.5.11",
         "@jsonforms/core": "3.2.1",
         "@jsonforms/material-renderers": "3.2.1",
         "@jsonforms/react": "3.2.1",


### PR DESCRIPTION
completes https://github.com/estuary/ui/issues/1549

This update brings support for `flow://relaxed-write-schema`.

### Manually tested

-  Verified collection details -> Spec tab on a local stack using `flow://relaxed-write-schema` now works.
