### PR TITLE
Display connector status message on overview tab of details page

### DIFF
--- a/src/components/shared/Entity/Details/Logs/Status/index.tsx
+++ b/src/components/shared/Entity/Details/Logs/Status/index.tsx
@@ -9,14 +9,8 @@ import SectionViews from 'src/components/shared/Entity/Details/Logs/Status/Secti
 import ServerError from 'src/components/shared/Entity/Details/Logs/Status/ServerError';
 import UnderDev from 'src/components/shared/UnderDev';
 import { useUserInfoSummaryStore } from 'src/context/UserInfoSummary/useUserInfoSummaryStore';
-import useGlobalSearchParams, {
-    GlobalSearchParams,
-} from 'src/hooks/searchParams/useGlobalSearchParams';
-import EntityStatusHydrator from 'src/stores/EntityStatus/Hydrator';
 
 export default function Status() {
-    const catalogName = useGlobalSearchParams(GlobalSearchParams.CATALOG_NAME);
-
     const intl = useIntl();
 
     const hasSupportRole = useUserInfoSummaryStore(
@@ -28,43 +22,38 @@ export default function Status() {
     }
 
     return (
-        <EntityStatusHydrator catalogName={catalogName}>
-            <Stack spacing={2} style={{ marginTop: 40 }}>
-                <UnderDev />
+        <Stack spacing={2} style={{ marginTop: 40 }}>
+            <UnderDev />
 
-                <Stack
-                    direction="row"
-                    spacing={4}
-                    style={{ justifyContent: 'space-between' }}
-                >
-                    <Box>
-                        <Stack
-                            direction="row"
-                            spacing={2}
-                            style={{ alignItems: 'center', marginBottom: 2 }}
-                        >
-                            <Typography
-                                variant="h6"
-                                style={{ marginBottom: 4 }}
-                            >
-                                {intl.formatMessage({
-                                    id: 'details.ops.status.header',
-                                })}
-                            </Typography>
+            <Stack
+                direction="row"
+                spacing={4}
+                style={{ justifyContent: 'space-between' }}
+            >
+                <Box>
+                    <Stack
+                        direction="row"
+                        spacing={2}
+                        style={{ alignItems: 'center', marginBottom: 2 }}
+                    >
+                        <Typography variant="h6" style={{ marginBottom: 4 }}>
+                            {intl.formatMessage({
+                                id: 'details.ops.status.header',
+                            })}
+                        </Typography>
 
-                            <RefreshButton />
-                        </Stack>
+                        <RefreshButton />
+                    </Stack>
 
-                        <SectionUpdated />
-                    </Box>
+                    <SectionUpdated />
+                </Box>
 
-                    <SectionFormatter />
-                </Stack>
-
-                <ServerError />
-
-                <SectionViews />
+                <SectionFormatter />
             </Stack>
-        </EntityStatusHydrator>
+
+            <ServerError />
+
+            <SectionViews />
+        </Stack>
     );
 }

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/index.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/index.tsx
@@ -13,6 +13,7 @@ import { TIME_SETTINGS } from 'src/components/shared/Entity/Details/Overview/Det
 import RelatedCollections from 'src/components/shared/Entity/RelatedCollections';
 import ExternalLink from 'src/components/shared/ExternalLink';
 import KeyValueList from 'src/components/shared/KeyValueList';
+import { useEntityType } from 'src/context/EntityContext';
 import { useEntityStatusStore_singleResponse } from 'src/stores/EntityStatus/hooks';
 import {
     formatDataPlaneName,
@@ -23,6 +24,8 @@ import { hasLength } from 'src/utils/misc-utils';
 
 function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
     const intl = useIntl();
+
+    const entityType = useEntityType();
 
     const latestConnectorStatus =
         useEntityStatusStore_singleResponse(entityName)?.connector_status
@@ -126,16 +129,18 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
             });
         }
 
-        response.push({
-            title: intl.formatMessage({
-                id: 'data.connectorStatus',
-            }),
-            val: (
-                <Typography component="div">
-                    {latestConnectorStatus ?? '--'}
-                </Typography>
-            ),
-        });
+        if (entityType !== 'collection') {
+            response.push({
+                title: intl.formatMessage({
+                    id: 'data.connectorStatus',
+                }),
+                val: (
+                    <Typography component="div">
+                        {latestConnectorStatus ?? '--'}
+                    </Typography>
+                ),
+            });
+        }
 
         if (hasLength(latestLiveSpec.writes_to)) {
             response.push({
@@ -164,7 +169,7 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
         }
 
         return response;
-    }, [intl, latestConnectorStatus, latestLiveSpec]);
+    }, [entityType, intl, latestConnectorStatus, latestLiveSpec]);
 
     return (
         <CardWrapper

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/shared.ts
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/shared.ts
@@ -1,0 +1,11 @@
+import type { FormatDateOptions } from 'react-intl';
+
+export const TIME_SETTINGS: FormatDateOptions = {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short',
+};

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/types.ts
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/types.ts
@@ -1,0 +1,7 @@
+import type { LiveSpecsQuery_details } from 'src/hooks/useLiveSpecs';
+
+export interface DetailsSectionProps {
+    entityName: string;
+    latestLiveSpec: LiveSpecsQuery_details | null;
+    loading: boolean;
+}

--- a/src/components/shared/Entity/Details/index.tsx
+++ b/src/components/shared/Entity/Details/index.tsx
@@ -17,6 +17,7 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'src/hooks/searchParams/useGlobalSearchParams';
 import useBrowserTitle from 'src/hooks/useBrowserTitle';
+import EntityStatusHydrator from 'src/stores/EntityStatus/Hydrator';
 import { useEntityStatusStore } from 'src/stores/EntityStatus/Store';
 import { EditorStoreNames } from 'src/stores/names';
 
@@ -46,37 +47,39 @@ function EntityDetails() {
         <LocalZustandProvider createStore={localStore}>
             <LiveSpecsHydrator catalogName={catalogName} localZustandScope>
                 <ShardHydrator catalogName={catalogName}>
-                    <Stack spacing={2} sx={{ m: 1 }}>
-                        <Stack
-                            direction="row"
-                            sx={{ justifyContent: 'space-between' }}
-                        >
-                            <Typography
-                                component="span"
-                                variant="h6"
-                                sx={{
-                                    ...truncateTextSx,
-                                    alignItems: 'center',
-                                }}
+                    <EntityStatusHydrator catalogName={catalogName}>
+                        <Stack spacing={2} sx={{ m: 1 }}>
+                            <Stack
+                                direction="row"
+                                sx={{ justifyContent: 'space-between' }}
                             >
-                                {catalogName}
-                            </Typography>
+                                <Typography
+                                    component="span"
+                                    variant="h6"
+                                    sx={{
+                                        ...truncateTextSx,
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    {catalogName}
+                                </Typography>
 
-                            <Stack direction="row">
-                                <EditButton buttonVariant="outlined" />
+                                <Stack direction="row">
+                                    <EditButton buttonVariant="outlined" />
 
-                                <MaterializeButton />
+                                    <MaterializeButton />
+                                </Stack>
                             </Stack>
+
+                            <Divider />
+
+                            <DetailTabs />
                         </Stack>
 
-                        <Divider />
-
-                        <DetailTabs />
-                    </Stack>
-
-                    <Box sx={{ m: 1 }}>
-                        <RenderTab />
-                    </Box>
+                        <Box sx={{ m: 1 }}>
+                            <RenderTab />
+                        </Box>
+                    </EntityStatusHydrator>
                 </ShardHydrator>
             </LiveSpecsHydrator>
         </LocalZustandProvider>

--- a/src/components/shared/KeyValueList/index.tsx
+++ b/src/components/shared/KeyValueList/index.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react';
 
 import { List, ListItem, ListItemText, Typography } from '@mui/material';
 
+import { diminishedTextColor } from 'src/context/Theme';
+
 export type KeyValue = {
     title: string | ReactNode;
     val?: string | ReactNode;
@@ -20,17 +22,26 @@ function KeyValueList({ data, disableTypography, sectionTitle }: Props) {
                 {sectionTitle ? (
                     <Typography variant="subtitle1">{sectionTitle}</Typography>
                 ) : null}
-                <List dense sx={{ ml: 1, pt: 0, overflowY: 'auto' }}>
+
+                <List dense sx={{ pt: 0, overflowY: 'auto' }}>
                     {data.map(({ title, val }, index) => (
-                        <ListItem key={`${title}-keyValueList-${index}`}>
+                        <ListItem
+                            key={`${title}-keyValueList-${index}`}
+                            style={{ paddingLeft: 0, paddingRight: 0 }}
+                        >
                             <ListItemText
                                 disableTypography={disableTypography}
                                 primary={title}
                                 secondary={val}
                                 primaryTypographyProps={{
+                                    color: (theme) =>
+                                        diminishedTextColor[theme.palette.mode],
                                     component: 'div',
+                                    marginBottom: '2px',
                                 }}
                                 secondaryTypographyProps={{
+                                    color: (theme) =>
+                                        theme.palette.text.primary,
                                     component: 'div',
                                 }}
                             />

--- a/src/components/shared/KeyValueList/index.tsx
+++ b/src/components/shared/KeyValueList/index.tsx
@@ -27,7 +27,11 @@ function KeyValueList({ data, disableTypography, sectionTitle }: Props) {
                     {data.map(({ title, val }, index) => (
                         <ListItem
                             key={`${title}-keyValueList-${index}`}
-                            style={{ paddingLeft: 0, paddingRight: 0 }}
+                            style={
+                                val
+                                    ? { paddingLeft: 0, paddingRight: 0 }
+                                    : undefined
+                            }
                         >
                             <ListItemText
                                 disableTypography={disableTypography}
@@ -35,7 +39,11 @@ function KeyValueList({ data, disableTypography, sectionTitle }: Props) {
                                 secondary={val}
                                 primaryTypographyProps={{
                                     color: (theme) =>
-                                        diminishedTextColor[theme.palette.mode],
+                                        val
+                                            ? diminishedTextColor[
+                                                  theme.palette.mode
+                                              ]
+                                            : theme.palette.text.primary,
                                     component: 'div',
                                     marginBottom: '2px',
                                 }}

--- a/src/components/shared/KeyValueList/index.tsx
+++ b/src/components/shared/KeyValueList/index.tsx
@@ -45,7 +45,7 @@ function KeyValueList({ data, disableTypography, sectionTitle }: Props) {
                                               ]
                                             : theme.palette.text.primary,
                                     component: 'div',
-                                    marginBottom: '2px',
+                                    marginBottom: val ? '2px' : undefined,
                                 }}
                                 secondaryTypographyProps={{
                                     color: (theme) =>

--- a/src/lang/en-US/Data.ts
+++ b/src/lang/en-US/Data.ts
@@ -36,4 +36,5 @@ export const Data: Record<string, string> = {
     'data.completed': `Completed`,
     'data.ipv4': `IPv4`,
     'data.ipv6': `IPv6`,
+    'data.connectorStatus': `Connector Status`,
 };


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1550

## Changes

The following features are included in this PR:

### 1550

* Hydrate entity status store state when landing on an entity details page.

* Display the connector status message in the _Details_ section of the _Overview_ tab on an entity details page.

### Misc.

* Update the list item styling in the `KeyValueList` component, which is responsible for rendering the contents of the _Details_ section on the _Overview_ tab on an entity details page.

**NOTE:** It should be noted that the `/status` endpoint is only called when the page is initially loaded. As mentioned in the issue, the display of connector status on the _Overview_ tab of an entity details page is an expedited feature.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that an unformatted connector status message is displayed in the _Details_ section of the _Overview_ tab when the control-plane `/status` endpoint returns a `connector_status` object.

* Validate that dashes are displayed in the _Details_ section of the _Overview_ tab when the control-plane `/status` endpoint returns a **null** `connector_status`.

* Validate that dashes are displayed in the _Details_ section of the _Overview_ tab when the control-plane `/status` endpoint fails and that the call failure is silent.

* Validate that the connector status **never** displays in the _Details_ section of the _Overview_ tab on the details page of a collection.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**No `connector_status` returned by control-plane `/status` endpoint**

<img width="175" alt="pr_screenshot-1551-connector_status_detail-no_response" src="https://github.com/user-attachments/assets/c75f413c-1a7e-47df-84e4-61e3b2fdb1e2" />

<br />
<br />

**A `connector_status` is returned by control-plane `/status` endpoint**

<img width="175" alt="pr_screenshot-1551-connector_status_detail-response" src="https://github.com/user-attachments/assets/46e3e6e8-d020-4b06-8e0c-f6c9ba31d632" />

<br />
<br />

**Workflow form error alert**

<img width="542" alt="pr_screenshot-1551-workflow_form_error_alert" src="https://github.com/user-attachments/assets/94123ffc-b1ec-4ed2-9ad0-88c41b17dc66" />
