### PR TITLE
Disable Select field selection table row action for optional fields

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/index.tsx
+++ b/src/components/editor/Bindings/FieldSelection/index.tsx
@@ -37,7 +37,7 @@ import {
     useFormStateStore_status,
 } from 'src/stores/FormState/hooks';
 import { FormStatus } from 'src/stores/FormState/types';
-import { getBindingIndex } from 'src/utils/workflow-utils';
+import { getBindingIndex, isRecommendedField } from 'src/utils/workflow-utils';
 
 interface Props {
     bindingUUID: string;
@@ -68,7 +68,11 @@ const mapConstraintsToProjections = (
               }
             : null;
 
-        let selectionType: FieldSelectionType | null = 'default';
+        let selectionType: FieldSelectionType | null =
+            constraint && isRecommendedField(constraint.type)
+                ? 'default'
+                : null;
+
         let selectionMetadata: Schema | undefined;
 
         if (fieldMetadata) {

--- a/src/components/tables/cells/fieldSelection/FieldActionButton.tsx
+++ b/src/components/tables/cells/fieldSelection/FieldActionButton.tsx
@@ -51,7 +51,11 @@ export default function FieldActionButton({
                         {...props}
                         disabled={disabled}
                         onClick={(_event, value) =>
-                            updateSingleSelection(value, selection)
+                            updateSingleSelection(
+                                value,
+                                selection,
+                                constraint.type
+                            )
                         }
                     >
                         {intl.formatMessage({ id: labelId })}
@@ -66,7 +70,9 @@ export default function FieldActionButton({
             {...props}
             className={TOGGLE_BUTTON_CLASS}
             disabled={disabled}
-            onClick={(_event, value) => updateSingleSelection(value, selection)}
+            onClick={(_event, value) =>
+                updateSingleSelection(value, selection, constraint.type)
+            }
         >
             {intl.formatMessage({ id: labelId })}
         </OutlinedToggleButton>

--- a/src/components/tables/cells/fieldSelection/FieldActions.tsx
+++ b/src/components/tables/cells/fieldSelection/FieldActions.tsx
@@ -54,7 +54,10 @@ function FieldActions({ bindingUUID, field, constraint }: FieldActionsProps) {
                     bindingUUID={bindingUUID}
                     color="success"
                     constraint={constraint}
-                    disabled={!recommendFields[bindingUUID]}
+                    disabled={
+                        !recommendFields[bindingUUID] ||
+                        constraint.type === ConstraintTypes.FIELD_OPTIONAL
+                    }
                     field={field}
                     labelId="fieldSelection.table.cta.selectField"
                     selection={selection}

--- a/src/hooks/fieldSelection/useOnFieldActionClick.ts
+++ b/src/hooks/fieldSelection/useOnFieldActionClick.ts
@@ -1,4 +1,7 @@
-import type { FieldSelectionType } from 'src/components/editor/Bindings/FieldSelection/types';
+import type {
+    ConstraintTypes,
+    FieldSelectionType,
+} from 'src/components/editor/Bindings/FieldSelection/types';
 import type { FieldSelection } from 'src/stores/Binding/slices/FieldSelection';
 
 import { useCallback } from 'react';
@@ -7,7 +10,10 @@ import { logRocketEvent } from 'src/services/shared';
 import { CustomEvents } from 'src/services/types';
 import { useBinding_setSingleSelection } from 'src/stores/Binding/hooks';
 import { useBindingStore } from 'src/stores/Binding/Store';
-import { isFieldSelectionType } from 'src/utils/workflow-utils';
+import {
+    isFieldSelectionType,
+    isRecommendedField,
+} from 'src/utils/workflow-utils';
 
 const evaluateSelectionType = (
     recommended: boolean,
@@ -38,7 +44,11 @@ export default function useOnFieldActionClick(
     const setSingleSelection = useBinding_setSingleSelection();
 
     return useCallback(
-        (value: any, selection: FieldSelection | null) => {
+        (
+            value: any,
+            selection: FieldSelection | null,
+            constraintType: ConstraintTypes
+        ) => {
             if (!isFieldSelectionType(value)) {
                 logRocketEvent(CustomEvents.FIELD_SELECTION, {
                     value,
@@ -50,7 +60,7 @@ export default function useOnFieldActionClick(
             const singleValue = selection?.mode !== value ? value : null;
 
             const selectionType = evaluateSelectionType(
-                recommended,
+                recommended && isRecommendedField(constraintType),
                 value,
                 selection?.mode ?? null,
                 singleValue


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1553

## Changes

### 1553

The following features are included in this PR:

* Disable the _Select_ field selection table row action for fields with constraint type `FIELD_OPTIONAL`.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the _Select_ field selection row action button is disabled for optional fields.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**_Select_ row action disabled for optional fields**

<img width="301" alt="pr_screenshot-1554-optional_fields-rec_true" src="https://github.com/user-attachments/assets/7be5f892-b5b3-4c0c-a580-dd4c13b84f7f" />


