### PR TITLE
Reorder metadata displayed on the overview tab of an entity details page

### DIFF
--- a/src/components/shared/Entity/Details/Overview/DetailsSection/index.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/index.tsx
@@ -53,46 +53,6 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
             return response;
         }
 
-        // Add last updated - without user as Estuary folks
-        //  sometimes update stuff and that might look odd
-        response.push({
-            title: intl.formatMessage({
-                id: 'entityTable.data.lastUpdated',
-            }),
-            val: `${intl.formatDate(latestLiveSpec.updated_at, TIME_SETTINGS)}`,
-        });
-
-        // At when it was created
-        response.push({
-            title: intl.formatMessage({
-                id: 'data.created_at',
-            }),
-            val: intl.formatDate(latestLiveSpec.created_at, TIME_SETTINGS),
-        });
-
-        if (hasLength(latestLiveSpec.data_plane_name)) {
-            const dataPlaneScope = getDataPlaneScope(
-                latestLiveSpec.data_plane_name
-            );
-
-            const dataPlaneName = parseDataPlaneName(
-                latestLiveSpec.data_plane_name,
-                dataPlaneScope
-            );
-
-            response.push({
-                title: intl.formatMessage({ id: 'data.dataPlane' }),
-                val: (
-                    <DataPlane
-                        dataPlaneName={dataPlaneName}
-                        formattedSuffix={formatDataPlaneName(dataPlaneName)}
-                        logoSize={20}
-                        scope={dataPlaneScope}
-                    />
-                ),
-            });
-        }
-
         if (latestLiveSpec.connectorName) {
             response.push({
                 title: intl.formatMessage({
@@ -141,6 +101,46 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
                 ),
             });
         }
+
+        if (hasLength(latestLiveSpec.data_plane_name)) {
+            const dataPlaneScope = getDataPlaneScope(
+                latestLiveSpec.data_plane_name
+            );
+
+            const dataPlaneName = parseDataPlaneName(
+                latestLiveSpec.data_plane_name,
+                dataPlaneScope
+            );
+
+            response.push({
+                title: intl.formatMessage({ id: 'data.dataPlane' }),
+                val: (
+                    <DataPlane
+                        dataPlaneName={dataPlaneName}
+                        formattedSuffix={formatDataPlaneName(dataPlaneName)}
+                        logoSize={20}
+                        scope={dataPlaneScope}
+                    />
+                ),
+            });
+        }
+
+        // Add last updated - without user as Estuary folks
+        //  sometimes update stuff and that might look odd
+        response.push({
+            title: intl.formatMessage({
+                id: 'entityTable.data.lastUpdated',
+            }),
+            val: `${intl.formatDate(latestLiveSpec.updated_at, TIME_SETTINGS)}`,
+        });
+
+        // At when it was created
+        response.push({
+            title: intl.formatMessage({
+                id: 'data.created_at',
+            }),
+            val: intl.formatDate(latestLiveSpec.created_at, TIME_SETTINGS),
+        });
 
         if (hasLength(latestLiveSpec.writes_to)) {
             response.push({


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1555

## Changes

### 1555

The following features are included in this PR:

* Reorder the information in the _Details_ section of the _Overview_ tab on the entity details page as follows (from top to bottom): connector, connector status, data plane, last updated, created, writes to and/or reads from.

## Tests

### Manually tested

Approaches to testing are as follows:

-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**_Details_ section of the _Overview_ tab of a capture details page**

<img width="158" alt="pr_screenshot-1555-connector_status_detail-response" src="https://github.com/user-attachments/assets/b4ecf5c4-6e9f-45d8-9316-c7d9f4782a5b" />

<br />
<br />

**_Details_ section of the _Overview_ tab of a collection details page**

<img width="158" alt="pr_screenshot-1555-connector_status_detail-response-collection" src="https://github.com/user-attachments/assets/cbdec6ab-b8f4-470d-bb3e-413fbad4a8bd" />

<br />
<br />

**_Details_ section of the _Overview_ tab of a materialization details page**

<img width="157" alt="pr_screenshot-1555-connector_status_detail-response-mat" src="https://github.com/user-attachments/assets/6bd7da33-4b55-46fb-9f18-f3682c0b913e" />

<br />
<br />