### PR TITLE
Prevent field selection mass action from selecting optional fields

### DIFF
--- a/src/components/editor/Bindings/FieldSelection/FieldActions/SaveButton.tsx
+++ b/src/components/editor/Bindings/FieldSelection/FieldActions/SaveButton.tsx
@@ -37,9 +37,7 @@ export default function SaveButton({
             onClick={() => {
                 if (projections && selectedAlgorithm) {
                     const selectedValue =
-                        selectedAlgorithm === 'excludeAll'
-                            ? 'exclude'
-                            : 'default';
+                        selectedAlgorithm === 'excludeAll' ? 'exclude' : null;
 
                     const updatedFields = evaluateUpdatedFields(
                         projections,

--- a/src/components/editor/Bindings/FieldSelection/FieldActions/shared.ts
+++ b/src/components/editor/Bindings/FieldSelection/FieldActions/shared.ts
@@ -4,12 +4,15 @@ import type {
 } from 'src/components/editor/Bindings/FieldSelection/types';
 import type { FieldSelectionDictionary } from 'src/stores/Binding/slices/FieldSelection';
 
-import { isRequireOnlyField } from 'src/utils/workflow-utils';
+import {
+    isRecommendedField,
+    isRequireOnlyField,
+} from 'src/utils/workflow-utils';
 
 export const evaluateUpdatedFields = (
     projections: CompositeProjection[],
-    recommended: boolean,
-    selectedValue: FieldSelectionType
+    recommendedFlag: boolean,
+    selectedValue: FieldSelectionType | null
 ) => {
     const updatedFields: FieldSelectionDictionary = {};
 
@@ -18,11 +21,15 @@ export const evaluateUpdatedFields = (
             ? isRequireOnlyField(constraint.type)
             : false;
 
+        const recommended = constraint
+            ? isRecommendedField(constraint.type)
+            : false;
+
         let selectionType = required ? 'require' : selectedValue;
 
-        if (recommended) {
+        if (recommendedFlag) {
             selectionType =
-                selectedValue === 'exclude' && required
+                (selectedValue === 'exclude' && required) || recommended
                     ? 'default'
                     : selectedValue;
         }


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1553

## Changes

### 1553

The following features are included in this PR:

* Prevent the _Select scalars_ field selection mode from temporarily marking fields with constraint type `FIELD_OPTIONAL` as _selected_.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the _Select_ field selection row action button never enters a selected state for optional fields.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_