### PR TITLE
Updating so we use the proper header for stats

### DIFF
--- a/src/components/tables/cells/stats/Header.tsx
+++ b/src/components/tables/cells/stats/Header.tsx
@@ -57,7 +57,11 @@ const StatsHeader = ({
             ),
             intl.formatMessage(
                 {
-                    id: secondHeaderSuffix ? secondHeaderSuffix : 'data.read',
+                    id: secondHeaderSuffix
+                        ? secondHeaderSuffix
+                        : firstHeaderSuffix
+                          ? firstHeaderSuffix
+                          : 'data.read',
                 },
                 {
                     type: intl.formatMessage({

--- a/src/components/tables/cells/stats/types.ts
+++ b/src/components/tables/cells/stats/types.ts
@@ -15,6 +15,6 @@ export interface StatsHeaderProps {
     selectableTableStoreName: SelectTableStoreNames;
     header?: string;
     hideFilter?: boolean;
-    firstHeaderSuffix?: 'data.written' | 'data.read' | 'data.in' | 'data.out';
-    secondHeaderSuffix?: 'data.written' | 'data.read' | 'data.in' | 'data.out';
+    firstHeaderSuffix?: 'data.written' | 'data.read' | 'data.in';
+    secondHeaderSuffix?: 'data.written' | 'data.out';
 }


### PR DESCRIPTION
Updating typing to what we actually pass

## Issues

https://github.com/estuary/ui/issues/1563

## Changes

### 1563

- Used the first column key if there before defaulting

## Tests

### Manually tested

- Looked at all the table headers

### Automated tests

- N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/734482ff-468e-49b3-9217-061d542c8987)

