### PR TITLE
Make the `shard disable` toggle on edit render on load correctly

### DIFF
--- a/src/components/editor/Shards/Disable/Form.tsx
+++ b/src/components/editor/Shards/Disable/Form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useSnackbar } from 'notistack';
 import { useIntl } from 'react-intl';
@@ -24,15 +24,32 @@ function ShardsDisableForm() {
     const formActive = useFormStateStore_isActive();
     const setFormState = useFormStateStore_setFormState();
 
+    // Mainly here for initial loading of page since it takes a little bit
+    //  of time to populate `shardDisabled`
+    useEffect(() => {
+        setLocalState((prevVal) => {
+            if (prevVal === shardDisabled) {
+                return prevVal;
+            }
+
+            return shardDisabled;
+        });
+    }, [shardDisabled]);
+
     const update = useCallback(
         (newVal: boolean) => {
             setFormState({ status: FormStatus.UPDATING, error: null });
 
+            // Set local state right away so the button feels fast
             setLocalState(newVal);
+
+            // Update the actual spec
             updateDisable(newVal)
                 .then(() => {})
                 .catch(() => {
+                    // If there was any kind of error put the opposite back in
                     setLocalState(!newVal);
+
                     enqueueSnackbar(
                         intl.formatMessage(
                             {

--- a/src/components/editor/Shards/Disable/Form.tsx
+++ b/src/components/editor/Shards/Disable/Form.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { useSnackbar } from 'notistack';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import useShards from 'src/components/editor/Shards/Disable/useShards';
 import BooleanToggleButton from 'src/components/shared/buttons/BooleanToggleButton';
@@ -62,11 +62,9 @@ function ShardsDisableForm() {
                 update(checked === 'true');
             }}
         >
-            {!localState ? (
-                <FormattedMessage id="common.enabled" />
-            ) : (
-                <FormattedMessage id="common.disabled" />
-            )}
+            {intl.formatMessage({
+                id: !localState ? 'common.enabled' : 'common.disabled',
+            })}
         </BooleanToggleButton>
     );
 }

--- a/src/components/editor/Shards/Disable/index.tsx
+++ b/src/components/editor/Shards/Disable/index.tsx
@@ -1,6 +1,6 @@
 import { Stack, Typography } from '@mui/material';
 
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import ShardsDisableForm from 'src/components/editor/Shards/Disable/Form';
 import ShardsDisableWarning from 'src/components/editor/Shards/Disable/Warning';
@@ -8,6 +8,8 @@ import { useEditorStore_persistedDraftId } from 'src/components/editor/Store/hoo
 import { useEntityType } from 'src/context/EntityContext';
 
 function ShardsDisable() {
+    const intl = useIntl();
+
     const entityType = useEntityType();
 
     const draftId = useEditorStore_persistedDraftId();
@@ -22,17 +24,21 @@ function ShardsDisable() {
 
             <Stack spacing={1} sx={{ mb: 2 }}>
                 <Typography style={{ fontWeight: 500 }}>
-                    <FormattedMessage
-                        id="workflows.disable.title"
-                        values={{ entityType }}
-                    />
+                    {intl.formatMessage(
+                        { id: 'workflows.disable.title' },
+                        {
+                            entityType,
+                        }
+                    )}
                 </Typography>
 
                 <Typography component="div">
-                    <FormattedMessage
-                        id="workflows.disable.message"
-                        values={{ entityType }}
-                    />
+                    {intl.formatMessage(
+                        { id: 'workflows.disable.message' },
+                        {
+                            entityType,
+                        }
+                    )}
                 </Typography>
             </Stack>
 

--- a/src/components/editor/Shards/index.tsx
+++ b/src/components/editor/Shards/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from '@mui/material';
 
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import ShardsDisable from 'src/components/editor/Shards/Disable';
 import { useEditorStore_persistedDraftId } from 'src/components/editor/Store/hooks';
@@ -14,6 +14,8 @@ interface Props {
 }
 
 function ShardsEditor({ renderOpen }: Props) {
+    const intl = useIntl();
+
     const forcedToEnable = useGlobalSearchParams(
         GlobalSearchParams.FORCED_SHARD_ENABLE
     );
@@ -30,7 +32,9 @@ function ShardsEditor({ renderOpen }: Props) {
                 forceOpen={Boolean(forcedToEnable || renderOpen)}
                 header={
                     <Typography>
-                        <FormattedMessage id="workflows.advancedSettings.title" />
+                        {intl.formatMessage({
+                            id: 'workflows.advancedSettings.title',
+                        })}
                     </Typography>
                 }
             >


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1575

## Changes

### 1575

- Needed to add a hook to make sure the local state is kept in sync

### Misc

- While digging down to the form switched out some translations

## Tests

### Manually tested

- Edited capture - enabled and disabled
- Edited materialization - enabled and disabled

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
