### PR TITLE
Fix FireFox not rendering bindings list

### DIFF
--- a/src/components/collection/Selector/List/CollectionSelectorBody.tsx
+++ b/src/components/collection/Selector/List/CollectionSelectorBody.tsx
@@ -18,6 +18,7 @@ import { useBinding_currentBindingUUID } from 'src/stores/Binding/hooks';
 function CollectionSelectorBody({
     columns,
     filterValue,
+    height: parentHeight,
     rows,
     selectionEnabled,
     setCurrentBinding,
@@ -56,8 +57,9 @@ function CollectionSelectorBody({
         }
     };
 
+    // TODO (FireFox Height Hack) - hardcoded height to make life easier
     return (
-        <TableBody component="div">
+        <TableBody component="div" sx={{ height: parentHeight }}>
             <AutoSizer>
                 {({ height, width }: AutoSizer['state']) => {
                     return (

--- a/src/components/collection/Selector/List/CollectionSelectorBody.tsx
+++ b/src/components/collection/Selector/List/CollectionSelectorBody.tsx
@@ -88,11 +88,12 @@ function CollectionSelectorBody({
                                         key={row[COLLECTION_SELECTOR_UUID_COL]}
                                         component={Box}
                                         style={style}
-                                        selected={
-                                            row[
-                                                COLLECTION_SELECTOR_UUID_COL
-                                            ] === currentBindingUUID
-                                        }
+                                        selected={Boolean(
+                                            selectionEnabled &&
+                                                row[
+                                                    COLLECTION_SELECTOR_UUID_COL
+                                                ] === currentBindingUUID
+                                        )}
                                         hover={selectionEnabled}
                                     >
                                         {columns.map((column) => {

--- a/src/components/collection/Selector/List/CollectionSelectorFooter.tsx
+++ b/src/components/collection/Selector/List/CollectionSelectorFooter.tsx
@@ -11,24 +11,28 @@ import {
 
 import { useIntl } from 'react-intl';
 
+import { DEFAULT_ROW_HEIGHT } from 'src/components/collection/Selector/List/shared';
 import { defaultOutlineColor } from 'src/context/Theme';
 import { useBinding_enabledBindings_count } from 'src/stores/Binding/hooks';
 
 function CollectionSelectorFooter({
     columnCount,
     totalCount,
+    hideFooter,
 }: CollectionSelectorFooterProps) {
     const intl = useIntl();
 
     const enabledBindingsCount = useBinding_enabledBindings_count();
 
+    // TODO (FireFox Height Hack) - hardcoded height to make life easier
     return (
-        <TableFooter component="div">
-            <TableRow component="div">
+        <TableFooter component="div" sx={{ height: DEFAULT_ROW_HEIGHT }}>
+            <TableRow component="div" sx={{ height: DEFAULT_ROW_HEIGHT }}>
                 <TableCell
                     component="div"
                     align="right"
                     sx={{
+                        alignContents: 'center',
                         borderBottom: 'none',
                         borderTop: (theme) =>
                             `1px solid ${defaultOutlineColor[theme.palette.mode]}`,
@@ -37,39 +41,45 @@ function CollectionSelectorFooter({
                         py: 0.7,
                     }}
                 >
-                    <Stack
-                        direction="row"
-                        spacing={1}
-                        sx={{ alignItems: 'center', justifyContent: 'end' }}
-                        divider={<Divider orientation="vertical" flexItem />}
-                    >
-                        <Box>
-                            {intl.formatMessage(
-                                {
-                                    id: Boolean(enabledBindingsCount)
-                                        ? enabledBindingsCount === totalCount
-                                            ? 'workflows.collectionSelector.footer.enabledCount.all'
-                                            : 'workflows.collectionSelector.footer.enabledCount'
-                                        : 'workflows.collectionSelector.footer.enabledCount.empty',
-                                },
-                                {
-                                    disabledBindingsCount: enabledBindingsCount,
-                                }
-                            )}
-                        </Box>
-                        <Box>
-                            {intl.formatMessage(
-                                {
-                                    id: Boolean(totalCount)
-                                        ? 'workflows.collectionSelector.footer.count'
-                                        : 'workflows.collectionSelector.footer.count.empty',
-                                },
-                                {
-                                    totalCount,
-                                }
-                            )}
-                        </Box>
-                    </Stack>
+                    {hideFooter ? null : (
+                        <Stack
+                            direction="row"
+                            spacing={1}
+                            sx={{ alignItems: 'center', justifyContent: 'end' }}
+                            divider={
+                                <Divider orientation="vertical" flexItem />
+                            }
+                        >
+                            <Box>
+                                {intl.formatMessage(
+                                    {
+                                        id: Boolean(enabledBindingsCount)
+                                            ? enabledBindingsCount ===
+                                              totalCount
+                                                ? 'workflows.collectionSelector.footer.enabledCount.all'
+                                                : 'workflows.collectionSelector.footer.enabledCount'
+                                            : 'workflows.collectionSelector.footer.enabledCount.empty',
+                                    },
+                                    {
+                                        disabledBindingsCount:
+                                            enabledBindingsCount,
+                                    }
+                                )}
+                            </Box>
+                            <Box>
+                                {intl.formatMessage(
+                                    {
+                                        id: Boolean(totalCount)
+                                            ? 'workflows.collectionSelector.footer.count'
+                                            : 'workflows.collectionSelector.footer.count.empty',
+                                    },
+                                    {
+                                        totalCount,
+                                    }
+                                )}
+                            </Box>
+                        </Stack>
+                    )}
                 </TableCell>
             </TableRow>
         </TableFooter>

--- a/src/components/collection/Selector/List/CollectionSelectorFooter.tsx
+++ b/src/components/collection/Selector/List/CollectionSelectorFooter.tsx
@@ -18,7 +18,6 @@ import { useBinding_enabledBindings_count } from 'src/stores/Binding/hooks';
 function CollectionSelectorFooter({
     columnCount,
     totalCount,
-    hideFooter,
 }: CollectionSelectorFooterProps) {
     const intl = useIntl();
 
@@ -41,45 +40,39 @@ function CollectionSelectorFooter({
                         py: 0.7,
                     }}
                 >
-                    {hideFooter ? null : (
-                        <Stack
-                            direction="row"
-                            spacing={1}
-                            sx={{ alignItems: 'center', justifyContent: 'end' }}
-                            divider={
-                                <Divider orientation="vertical" flexItem />
-                            }
-                        >
-                            <Box>
-                                {intl.formatMessage(
-                                    {
-                                        id: Boolean(enabledBindingsCount)
-                                            ? enabledBindingsCount ===
-                                              totalCount
-                                                ? 'workflows.collectionSelector.footer.enabledCount.all'
-                                                : 'workflows.collectionSelector.footer.enabledCount'
-                                            : 'workflows.collectionSelector.footer.enabledCount.empty',
-                                    },
-                                    {
-                                        disabledBindingsCount:
-                                            enabledBindingsCount,
-                                    }
-                                )}
-                            </Box>
-                            <Box>
-                                {intl.formatMessage(
-                                    {
-                                        id: Boolean(totalCount)
-                                            ? 'workflows.collectionSelector.footer.count'
-                                            : 'workflows.collectionSelector.footer.count.empty',
-                                    },
-                                    {
-                                        totalCount,
-                                    }
-                                )}
-                            </Box>
-                        </Stack>
-                    )}
+                    <Stack
+                        direction="row"
+                        spacing={1}
+                        sx={{ alignItems: 'center', justifyContent: 'end' }}
+                        divider={<Divider orientation="vertical" flexItem />}
+                    >
+                        <Box>
+                            {intl.formatMessage(
+                                {
+                                    id: Boolean(enabledBindingsCount)
+                                        ? enabledBindingsCount === totalCount
+                                            ? 'workflows.collectionSelector.footer.enabledCount.all'
+                                            : 'workflows.collectionSelector.footer.enabledCount'
+                                        : 'workflows.collectionSelector.footer.enabledCount.empty',
+                                },
+                                {
+                                    disabledBindingsCount: enabledBindingsCount,
+                                }
+                            )}
+                        </Box>
+                        <Box>
+                            {intl.formatMessage(
+                                {
+                                    id: Boolean(totalCount)
+                                        ? 'workflows.collectionSelector.footer.count'
+                                        : 'workflows.collectionSelector.footer.count.empty',
+                                },
+                                {
+                                    totalCount,
+                                }
+                            )}
+                        </Box>
+                    </Stack>
                 </TableCell>
             </TableRow>
         </TableFooter>

--- a/src/components/collection/Selector/List/CollectionSelectorFooter.tsx
+++ b/src/components/collection/Selector/List/CollectionSelectorFooter.tsx
@@ -12,7 +12,7 @@ import {
 import { useIntl } from 'react-intl';
 
 import { defaultOutlineColor } from 'src/context/Theme';
-import { useBinding_disabledBindings_count } from 'src/stores/Binding/hooks';
+import { useBinding_enabledBindings_count } from 'src/stores/Binding/hooks';
 
 function CollectionSelectorFooter({
     columnCount,
@@ -20,7 +20,7 @@ function CollectionSelectorFooter({
 }: CollectionSelectorFooterProps) {
     const intl = useIntl();
 
-    const disabledBindingsCount = useBinding_disabledBindings_count();
+    const enabledBindingsCount = useBinding_enabledBindings_count();
 
     return (
         <TableFooter component="div">
@@ -46,14 +46,14 @@ function CollectionSelectorFooter({
                         <Box>
                             {intl.formatMessage(
                                 {
-                                    id: Boolean(disabledBindingsCount)
-                                        ? disabledBindingsCount === totalCount
-                                            ? 'workflows.collectionSelector.footer.disabledCount.all'
-                                            : 'workflows.collectionSelector.footer.disabledCount'
-                                        : 'workflows.collectionSelector.footer.disabledCount.empty',
+                                    id: Boolean(enabledBindingsCount)
+                                        ? enabledBindingsCount === totalCount
+                                            ? 'workflows.collectionSelector.footer.enabledCount.all'
+                                            : 'workflows.collectionSelector.footer.enabledCount'
+                                        : 'workflows.collectionSelector.footer.enabledCount.empty',
                                 },
                                 {
-                                    disabledBindingsCount,
+                                    disabledBindingsCount: enabledBindingsCount,
                                 }
                             )}
                         </Box>

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -369,11 +369,12 @@ function CollectionSelectorList({
                         checkScrollbarVisibility={checkScrollbarVisibility}
                     />
 
-                    <CollectionSelectorFooter
-                        columnCount={columns.length}
-                        totalCount={mappedResourceConfigs.length}
-                        hideFooter={hideFooter}
-                    />
+                    {hideFooter ? null : (
+                        <CollectionSelectorFooter
+                            columnCount={columns.length}
+                            totalCount={mappedResourceConfigs.length}
+                        />
+                    )}
                 </CollectionSelectorTable>
             </TableContainer>
         </Box>

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -49,6 +49,7 @@ import { QUICK_DEBOUNCE_WAIT } from 'src/utils/workflow-utils';
 function CollectionSelectorList({
     disableActions,
     header,
+    height,
     hideFooter,
     setCurrentBinding,
 }: CollectionSelectorListProps) {
@@ -334,6 +335,8 @@ function CollectionSelectorList({
                 sx={{
                     height: '100%',
                     width: '100%',
+                    // TODO (FireFox Height Hack) - added overflow so the scroll bar does not show up
+                    overflow: 'hidden',
                 }}
             >
                 <CollectionSelectorTable>
@@ -352,6 +355,11 @@ function CollectionSelectorList({
 
                     <CollectionSelectorBody
                         columns={columns}
+                        // TODO (FireFox Height Hack)
+                        // Magic number - it works and I hate it.
+                        // Do not copy this anywhere.
+                        // You need the height to hit some super magic special thing that makes no sense so FireFox will render the footer at the bottom.
+                        height={height - 120}
                         filterValue={filterValue}
                         rows={filteredRows}
                         selectionEnabled={selectionEnabled}
@@ -361,12 +369,11 @@ function CollectionSelectorList({
                         checkScrollbarVisibility={checkScrollbarVisibility}
                     />
 
-                    {hideFooter ? undefined : (
-                        <CollectionSelectorFooter
-                            columnCount={columns.length}
-                            totalCount={mappedResourceConfigs.length}
-                        />
-                    )}
+                    <CollectionSelectorFooter
+                        columnCount={columns.length}
+                        totalCount={mappedResourceConfigs.length}
+                        hideFooter={hideFooter}
+                    />
                 </CollectionSelectorTable>
             </TableContainer>
         </Box>

--- a/src/components/collection/Selector/types.ts
+++ b/src/components/collection/Selector/types.ts
@@ -72,6 +72,7 @@ export interface CollectionSelectorCellSettings {
 }
 
 export interface CollectionSelectorListProps {
+    height: number; // Remove once FF can handle settings heights right https://bugzilla.mozilla.org/show_bug.cgi?id=1904559
     disableActions?: boolean;
     header?: string;
     hideFooter?: boolean;
@@ -82,6 +83,7 @@ export interface CollectionSelectorBodyProps {
     checkScrollbarVisibility: () => void;
     columns: ColumnProps[];
     filterValue: string;
+    height: number;
     rows: CollectionSelectorMappedResourceConfig[];
     scrollingElementCallback: (node?: any) => FixedSizeList | undefined;
     selectionEnabled: boolean;
@@ -92,4 +94,5 @@ export interface CollectionSelectorBodyProps {
 export interface CollectionSelectorFooterProps {
     columnCount: number;
     totalCount: number;
+    hideFooter?: boolean;
 }

--- a/src/components/collection/Selector/types.ts
+++ b/src/components/collection/Selector/types.ts
@@ -94,5 +94,4 @@ export interface CollectionSelectorBodyProps {
 export interface CollectionSelectorFooterProps {
     columnCount: number;
     totalCount: number;
-    hideFooter?: boolean;
 }

--- a/src/components/editor/Bindings/Selector.tsx
+++ b/src/components/editor/Bindings/Selector.tsx
@@ -31,10 +31,14 @@ function BindingSelector({
 
     const disableActions = formActive || readOnly;
 
+    // TODO (FireFox Height Hack) - added overflow so the scroll bar does not show up
     return (
         <Stack
             direction="column"
-            sx={{ height: legacyTransformHeightHack ?? '100%' }}
+            sx={{
+                height: legacyTransformHeightHack ?? '100%',
+                overflow: 'hidden',
+            }}
         >
             <BindingSearch
                 itemType={itemType}
@@ -44,6 +48,7 @@ function BindingSelector({
 
             <CollectionSelectorList
                 header={itemType}
+                height={legacyTransformHeightHack ?? 570}
                 hideFooter={hideFooter}
                 disableActions={disableActions}
                 setCurrentBinding={

--- a/src/components/tables/EntityTable/TableHeader.tsx
+++ b/src/components/tables/EntityTable/TableHeader.tsx
@@ -27,7 +27,7 @@ function EntityTableHeader({
         getTableComponents(enableDivRendering);
 
     return (
-        <TableHead component={theaderComponent}>
+        <TableHead component={theaderComponent} sx={{ height }}>
             <TableRow
                 component={trComponent}
                 sx={{

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -55,9 +55,9 @@ export const Workflows: Record<string, string> = {
 
     'workflows.collectionSelector.footer.count': `total: {totalCount}`,
     'workflows.collectionSelector.footer.count.empty': ` `,
-    'workflows.collectionSelector.footer.disabledCount': `disabled: {disabledBindingsCount}`,
-    'workflows.collectionSelector.footer.disabledCount.all': `all disabled`,
-    'workflows.collectionSelector.footer.disabledCount.empty': `all enabled`,
+    'workflows.collectionSelector.footer.enabledCount': `enabled: {disabledBindingsCount}`,
+    'workflows.collectionSelector.footer.enabledCount.all': `all enabled`,
+    'workflows.collectionSelector.footer.enabledCount.empty': `all disabled`,
 
     'workflows.collectionSelector.schemaEdit.cta.syncSchema': `Synchronize Schema`,
     'workflows.collectionSelector.schemaEdit.header': `CLI`,

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -177,11 +177,11 @@ export const useBinding_allBindingsDisabled = () => {
     );
 };
 
-export const useBinding_disabledBindings_count = () => {
+export const useBinding_enabledBindings_count = () => {
     return useBindingStore(
         useShallow((state) =>
             Object.values(state.resourceConfigs).reduce((count, config) => {
-                return config.meta?.disable ? count + 1 : count;
+                return config.meta?.disable ? count : count + 1;
             }, 0)
         )
     );


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1580

## Changes

### 1580

- Add back in height since FF does not allow the body to grow

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Chrome
![image](https://github.com/user-attachments/assets/8777ef80-4678-4a02-8a8b-2b3b49c78a68)
![image](https://github.com/user-attachments/assets/d230b2e8-7e61-42c0-b0db-4ed3f3be56f2)


### FireFox
![image](https://github.com/user-attachments/assets/3daf5b70-900b-4e6f-b937-2173a88ce486)
![image](https://github.com/user-attachments/assets/8e6912c1-9de7-4f18-a816-7057b262a4a6)