### PR TITLE
Enable virtual scrolling for safari in binding editor

### DIFF
--- a/src/components/collection/Selector/List/CollectionSelectorBody.tsx
+++ b/src/components/collection/Selector/List/CollectionSelectorBody.tsx
@@ -57,9 +57,16 @@ function CollectionSelectorBody({
         }
     };
 
-    // TODO (FireFox Height Hack) - hardcoded height to make life easier
     return (
-        <TableBody component="div" sx={{ height: parentHeight }}>
+        <TableBody
+            component="div"
+            sx={{
+                // TODO (Safari Height Hack) - Safari ignores the height when the display is `table-row-group`
+                display: 'table-cell',
+                // TODO (FireFox Height Hack) - hardcoded height to make life easier
+                height: parentHeight,
+            }}
+        >
             <AutoSizer>
                 {({ height, width }: AutoSizer['state']) => {
                     return (


### PR DESCRIPTION
 browsers

## Issues

https://github.com/estuary/ui/issues/1580

## Changes

### 1580

- Safari seems to not be happy with the `table-row-group` but will set the height properly for the `table-cell` display style. So using that. Since we are hardcoding all the heights again to fix FireFox we should be safe.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Chrome
![image](https://github.com/user-attachments/assets/bf2f9a7e-cdb9-4ffa-9ac0-614deebf6efb)

### FireFox
![image](https://github.com/user-attachments/assets/d4486c62-519c-4ba9-8a22-6181b5f5c453)

### Safari (Tested by changing the `display` value in prod on my MacBook)
<img width="432" alt="image" src="https://github.com/user-attachments/assets/9a5ccf64-2355-437f-84f6-9d233e6f894e" />

