### PR TITLE
Fixing issue installing `flow wasm` with only `read` access

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,8 @@
 name: UI Build
 
-# permissions:
-#     contents: read
+permissions:
+    contents: read
+    packages: read
 
 on:
     push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: UI Build
 
-permissions:
-    contents: read
+# permissions:
+#     contents: read
 
 on:
     push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: UI Build
 
 permissions:
     contents: read
-    packages: read
+    packages: read # needed for `npm install` of `@estuary/flow-web
 
 on:
     push:


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1602

## Changes

### 1602

- Added `packages: read` to allow for the `npm install`

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/074bf677-3abe-4fa3-a6e7-2b78b8b7008f)

