### PR TITLE
Ensure the absence of data-plane options in workflows is non-blocking

### DIFF
--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -214,6 +214,7 @@ export interface LiveSpecsExtQuery_DetailsForm {
     spec_type: Entity;
     spec: any;
     data_plane_id: string;
+    data_plane_name: string;
     connector_tag_id: string;
     connector_image_name: string;
     connector_image_tag: string;
@@ -226,6 +227,7 @@ const DETAILS_FORM_QUERY = `
     spec_type,
     spec,
     data_plane_id,
+    data_plane_name,
     connector_tag_id,
     connector_image_name,
     connector_image_tag,

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -215,6 +215,7 @@ export interface LiveSpecsExtQuery_DetailsForm {
     spec: any;
     data_plane_id: string;
     data_plane_name: string | null;
+    reactor_address: string | null;
     connector_tag_id: string;
     connector_image_name: string;
     connector_image_tag: string;
@@ -228,6 +229,7 @@ const DETAILS_FORM_QUERY = `
     spec,
     data_plane_id,
     data_plane_name,
+    reactor_address,
     connector_tag_id,
     connector_image_name,
     connector_image_tag,

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -214,7 +214,7 @@ export interface LiveSpecsExtQuery_DetailsForm {
     spec_type: Entity;
     spec: any;
     data_plane_id: string;
-    data_plane_name: string;
+    data_plane_name: string | null;
     connector_tag_id: string;
     connector_image_name: string;
     connector_image_tag: string;

--- a/src/components/shared/Entity/DetailsForm/useDataPlaneField.ts
+++ b/src/components/shared/Entity/DetailsForm/useDataPlaneField.ts
@@ -50,6 +50,26 @@ export default function useDataPlaneField(
 
                 dataPlanesOneOf.push({ const: option, title });
             });
+        } else {
+            // The details form store hydrator does not fail loudly when no data-plane options are found
+            // and the create workflow does not have a fallback data-plane option to use in that scenario.
+            dataPlanesOneOf.push({
+                const: {
+                    dataPlaneName: {
+                        cluster: '',
+                        prefix: '',
+                        provider: '',
+                        region: '',
+                        whole: '',
+                    },
+                    id: '',
+                    reactorAddress: '',
+                    scope: 'public',
+                },
+                title: intl.formatMessage({
+                    id: 'workflows.dataPlane.label.noOptionsFound',
+                }),
+            });
         }
 
         return {

--- a/src/components/shared/Entity/DetailsForm/useDataPlaneField.ts
+++ b/src/components/shared/Entity/DetailsForm/useDataPlaneField.ts
@@ -11,7 +11,10 @@ import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'src/hooks/searchParams/useGlobalSearchParams';
 import { useDetailsFormStore } from 'src/stores/DetailsForm/Store';
-import { formatDataPlaneName } from 'src/utils/dataPlane-utils';
+import {
+    DATA_PLANE_OPTION_TEMPLATE,
+    formatDataPlaneName,
+} from 'src/utils/dataPlane-utils';
 import { hasLength } from 'src/utils/misc-utils';
 
 interface OneOfElement {
@@ -54,18 +57,7 @@ export default function useDataPlaneField(
             // The details form store hydrator does not fail loudly when no data-plane options are found
             // and the create workflow does not have a fallback data-plane option to use in that scenario.
             dataPlanesOneOf.push({
-                const: {
-                    dataPlaneName: {
-                        cluster: '',
-                        prefix: '',
-                        provider: '',
-                        region: '',
-                        whole: '',
-                    },
-                    id: '',
-                    reactorAddress: '',
-                    scope: 'public',
-                },
+                const: DATA_PLANE_OPTION_TEMPLATE,
                 title: intl.formatMessage({
                     id: 'workflows.dataPlane.label.noOptionsFound',
                 }),

--- a/src/forms/renderers/DataPlaneSelector/AutoComplete.tsx
+++ b/src/forms/renderers/DataPlaneSelector/AutoComplete.tsx
@@ -42,6 +42,7 @@ import DataPlaneIcon from 'src/components/shared/Entity/DataPlaneIcon';
 import { defaultOutline_hovered } from 'src/context/Theme';
 import AutoCompleteInputWithStartAdornment from 'src/forms/renderers/AutoCompleteInputWithStartAdornment';
 import Option from 'src/forms/renderers/DataPlaneSelector/Option';
+import { DATA_PLANE_OPTION_TEMPLATE } from 'src/utils/dataPlane-utils';
 
 export interface WithOptionLabel {
     getOptionLabel?(option: EnumOption): string;
@@ -57,7 +58,12 @@ export interface WithOptionLabel {
 }
 
 const areOptionsEqual = (option?: any, value?: any) => {
-    return typeof value?.id === 'string' && option.id === value.id;
+    return (
+        (typeof value?.id === 'string' && option.id === value.id) ||
+        (value === undefined &&
+            option.dataPlaneName.whole ===
+                DATA_PLANE_OPTION_TEMPLATE.dataPlaneName.whole)
+    );
 };
 
 export const DataPlaneAutoComplete = ({

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -215,6 +215,7 @@ export const Workflows: Record<string, string> = {
 
     'workflows.dataPlane.description': `Choose the data plane you would like to use.`,
     'workflows.dataPlane.label': `Data Plane`,
+    'workflows.dataPlane.label.noOptionsFound': `No options found`,
 
     'workflows.alert.endpointConfigEmpty': `This endpoint requires configuration of the external system only.`,
 

--- a/src/stores/DetailsForm/useDetailsFormHydrator.ts
+++ b/src/stores/DetailsForm/useDetailsFormHydrator.ts
@@ -85,7 +85,7 @@ const getDataPlane = (
 const evaluateDataPlaneOptions = async (
     setDataPlaneOptions: DetailsFormState['setDataPlaneOptions'],
     setHydrationError: DetailsFormState['setHydrationError'],
-    existingDataPlane?: { name: string; id: string }
+    existingDataPlane?: { name: string | null; id: string }
 ): Promise<DataPlaneOption[]> => {
     const dataPlaneResponse = await getDataPlaneOptions();
 
@@ -104,7 +104,7 @@ const evaluateDataPlaneOptions = async (
 
         const stubOption = existingDataPlane
             ? generateDataPlaneOption({
-                  data_plane_name: existingDataPlane.name,
+                  data_plane_name: existingDataPlane.name ?? '',
                   id: existingDataPlane.id,
                   reactor_address: '',
                   cidr_blocks: null,

--- a/src/stores/DetailsForm/useDetailsFormHydrator.ts
+++ b/src/stores/DetailsForm/useDetailsFormHydrator.ts
@@ -85,7 +85,11 @@ const getDataPlane = (
 const evaluateDataPlaneOptions = async (
     setDataPlaneOptions: DetailsFormState['setDataPlaneOptions'],
     setHydrationError: DetailsFormState['setHydrationError'],
-    existingDataPlane?: { name: string | null; id: string }
+    existingDataPlane?: {
+        name: string | null;
+        id: string;
+        reactorAddress: string | null;
+    }
 ): Promise<DataPlaneOption[]> => {
     const dataPlaneResponse = await getDataPlaneOptions();
 
@@ -106,7 +110,7 @@ const evaluateDataPlaneOptions = async (
             ? generateDataPlaneOption({
                   data_plane_name: existingDataPlane.name ?? '',
                   id: existingDataPlane.id,
-                  reactor_address: '',
+                  reactor_address: existingDataPlane.reactorAddress ?? '',
                   cidr_blocks: null,
                   gcp_service_account_email: null,
                   aws_iam_user_arn: null,
@@ -224,6 +228,7 @@ export const useDetailsFormHydrator = () => {
                     connector_tag_id,
                     data_plane_id,
                     data_plane_name,
+                    reactor_address,
                 } = data[0];
 
                 const connectorImage = await getConnectorImage(
@@ -235,7 +240,11 @@ export const useDetailsFormHydrator = () => {
                 const dataPlaneOptions = await evaluateDataPlaneOptions(
                     setDataPlaneOptions,
                     setHydrationError,
-                    { name: data_plane_name, id: data_plane_id }
+                    {
+                        name: data_plane_name,
+                        id: data_plane_id,
+                        reactorAddress: reactor_address,
+                    }
                 );
                 const dataPlane = getDataPlane(dataPlaneOptions, data_plane_id);
 

--- a/src/stores/DetailsForm/useDetailsFormHydrator.ts
+++ b/src/stores/DetailsForm/useDetailsFormHydrator.ts
@@ -87,12 +87,12 @@ const evaluateDataPlaneOptions = async (
     setHydrationError: DetailsFormState['setHydrationError'],
     existingDataPlane?: { name: string; id: string }
 ): Promise<DataPlaneOption[]> => {
-    let dataPlaneResponse = await getDataPlaneOptions();
+    const dataPlaneResponse = await getDataPlaneOptions();
 
     if (dataPlaneResponse.error) {
         setHydrationError(
             dataPlaneResponse.error?.message ??
-                'An error was encountered initializing the data-plane selector in details form. If the issue persists, please contact support.'
+                'An error was encountered initializing the data-plane selector in the details form. If the issue persists, please contact support.'
         );
     }
 

--- a/src/utils/dataPlane-utils.ts
+++ b/src/utils/dataPlane-utils.ts
@@ -47,7 +47,7 @@ export const DATA_PLANE_OPTION_TEMPLATE: DataPlaneOption = {
         prefix: '',
         provider: '',
         region: '',
-        whole: '',
+        whole: 'template',
     },
     id: '',
     reactorAddress: '',

--- a/src/utils/dataPlane-utils.ts
+++ b/src/utils/dataPlane-utils.ts
@@ -41,6 +41,19 @@ export enum ErrorFlags {
     TOKEN_NOT_FOUND = 'Unauthenticated',
 }
 
+export const DATA_PLANE_OPTION_TEMPLATE: DataPlaneOption = {
+    dataPlaneName: {
+        cluster: '',
+        prefix: '',
+        provider: '',
+        region: '',
+        whole: '',
+    },
+    id: '',
+    reactorAddress: '',
+    scope: 'public',
+};
+
 export const shouldRefreshToken = (errorMessage?: string | null) => {
     return (
         errorMessage &&


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1605

## Changes

### 1605

The following features are included in this PR:

* Include the `data_plane_name` in the `live-specs-ext` call used to prefill the details form store state in edit workflows. This is required because the `publications` table references data-planes by name and not ID. In the event no data-plane options are returned, `data_plane_name` and `data_plane_id` are used to create a fallback data-plane option (i.e., an element in the `dataPlaneOptions` array, a details form store state property) and prefill the selected data-plane (i.e., the details form store state property, `details.data.dataPlane`).

* Create a fallback option for the data-plane selector `oneOf` whose value is a dummy `DataPlaneOption` object and label is `No options found`. This primarily safeguards create workflows; in the event no data-plane options are returned, the data-plane selector can still be rendered but the task will be effectively forced into the default, public data-plane.

* Track instances where data-plane options are not returned with a LogRocket event.

**NOTE:** The client will continue to display an error in the place of the form if the call to fetch the series of data-plane options **fails**.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the form is initialized in the event no data-plane options were returned in all workflows.

**NOTE:** Testing this scenario locally is difficult given there is only one functional data-plane available and knowledge of how to create a functional, local data-plane is held by a very small subset of the engineering team.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
