### PR TITLE
Hiding the `_meta` field

### DIFF
--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -185,6 +185,9 @@ const getNullableType = (schema: JsonSchema): null | string => {
 const isOAuthConfig = (schema: JsonSchema): boolean =>
     Object.hasOwn(schema, Annotations.oAuthProvider);
 
+const isHiddenField = (schema: JsonSchema): boolean =>
+    Object.hasOwn(schema, Annotations.hiddenField);
+
 // TODO (reset section) might want to know if there are multiple children in future
 // const getChildObjectCount = (schema: JsonSchema) => {
 //     if (!schema.properties) {
@@ -469,20 +472,30 @@ const generateUISchema = (
     const isRequired = isRequiredField(schemaName, rootSchema);
 
     if (isPlainObject(jsonSchema)) {
-        // We never want to show this part of the spec
-        if (schemaName === '_meta') {
-            const group: GroupLayout = {
-                type: 'Group',
-                elements: [],
-                rule: {
-                    effect: RuleEffect.HIDE,
-                    condition: {
-                        type: 'fake-to-hopefully-always-return-true',
-                    },
+        // We know we never want to show the meta on ResourceConfigs or
+        //  any field marked as hidden
+        if (schemaName === '_meta' || isHiddenField(jsonSchema)) {
+            // This is kind of overkill - but making sure they stay as a control or a group
+            //  is the more proper thing to do. Even though they'll be hidden.
+            const groupOrControl: GroupLayout | ControlElement = isCombinator(
+                jsonSchema
+            )
+                ? {
+                      type: 'Group',
+                      elements: [],
+                  }
+                : createControlElement(currentRef);
+
+            // Add in the rule to always hide. JSONForms currently (Q2 2025) always returns true if the
+            //  `type` is one they are not expecting.
+            groupOrControl.rule = {
+                effect: RuleEffect.HIDE,
+                condition: {
+                    type: 'fake-to-hopefully-always-return-true',
                 },
             };
 
-            return group;
+            return groupOrControl;
         } else if (isCombinator(jsonSchema) && isAdvancedConfig(jsonSchema)) {
             // Always create a Group for "advanced" configuration objects, so that we can collapse it and
             // see the label.

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -39,6 +39,7 @@ import {
     isGroup,
     isLayout,
     resolveSchema,
+    RuleEffect,
     toDataPath,
     toDataPathSegments,
 } from '@jsonforms/core';
@@ -468,7 +469,19 @@ const generateUISchema = (
     const isRequired = isRequiredField(schemaName, rootSchema);
 
     if (isPlainObject(jsonSchema)) {
-        if (isCombinator(jsonSchema) && isAdvancedConfig(jsonSchema)) {
+        // We never want to show this part of the spec
+        if (schemaName === '_meta') {
+            const controlObject = createControlElement(currentRef);
+
+            controlObject.rule = {
+                effect: RuleEffect.HIDE,
+                condition: {
+                    type: 'true',
+                },
+            };
+
+            return controlObject;
+        } else if (isCombinator(jsonSchema) && isAdvancedConfig(jsonSchema)) {
             // Always create a Group for "advanced" configuration objects, so that we can collapse it and
             // see the label.
 

--- a/src/services/jsonforms/index.ts
+++ b/src/services/jsonforms/index.ts
@@ -471,16 +471,18 @@ const generateUISchema = (
     if (isPlainObject(jsonSchema)) {
         // We never want to show this part of the spec
         if (schemaName === '_meta') {
-            const controlObject = createControlElement(currentRef);
-
-            controlObject.rule = {
-                effect: RuleEffect.HIDE,
-                condition: {
-                    type: 'true',
+            const group: GroupLayout = {
+                type: 'Group',
+                elements: [],
+                rule: {
+                    effect: RuleEffect.HIDE,
+                    condition: {
+                        type: 'fake-to-hopefully-always-return-true',
+                    },
                 },
             };
 
-            return controlObject;
+            return group;
         } else if (isCombinator(jsonSchema) && isAdvancedConfig(jsonSchema)) {
             // Always create a Group for "advanced" configuration objects, so that we can collapse it and
             // see the label.

--- a/src/types/jsonforms.ts
+++ b/src/types/jsonforms.ts
@@ -38,6 +38,7 @@ export enum Annotations {
     secret = 'secret', // render as a password
     secretAirbyte = 'airbyte_secret', // render as a password
     defaultResourceConfigName = 'x-collection-name', // Used to default name in resource configs
+    hiddenField = 'x-hidden-field', // The field or control will be marked as hidden using JSONForms `Rules`
     inferSchema = 'x-infer-schema', // Indicates that schema inference should be enabled in the UI
     deltaUpdates = 'x-delta-updates', // SourceCapture - Shows 'deltaUpdates' optional setting
     targetSchema = 'x-schema-name', // SourceCapture - Shows 'targetSchema' optional setting


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1615

## Changes

### 1615

- Check for the `_meta` field and hide it
- Add a new annotation to allow hiding a field

## Tests

### Manually tested

- Used the test page to create custom schemas to see how they work
- capture create/edit
- materialization create/edit

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/aefca161-b315-46e3-8fc2-1633366b8fd4)

