### PR TITLE
Display fixed, multi-use invite links in table

### DIFF
--- a/src/api/directives.ts
+++ b/src/api/directives.ts
@@ -183,7 +183,7 @@ const getDirectivesByType = (
                 count: 'exact',
             })
             .eq('spec->>type', directiveType)
-            .or(`uses_remaining.eq.1,uses_remaining.is.null`),
+            .or(`uses_remaining.gt.0,uses_remaining.is.null`),
         ['catalog_prefix', `spec->>capability`, `spec->>grantedPrefix`],
         searchQuery,
         sorting,


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1633

## Changes

### 1633

The following features are included in this PR:

* Display fixed, multi-use invite links in _Active Invite Links_ table.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that invite links with non-zero uses remaining are displayed in the _Active Invite Links_ table.

* Validate that invite links with zero uses remaining are **not** displayed in the _Active Invite Links_ table.

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_