### PR TITLE
Allow for specific options to be provided just to make more flexible

### DIFF
--- a/src/components/graphs/DataByHourGraph/index.tsx
+++ b/src/components/graphs/DataByHourGraph/index.tsx
@@ -1,4 +1,5 @@
 import type { EChartsOption } from 'echarts';
+import type { Options } from 'pretty-bytes';
 import type { DataByHourStatType } from 'src/components/graphs/types';
 import type { CatalogStats_Details } from 'src/types';
 
@@ -52,11 +53,8 @@ const itemStyle = {
     borderRadius: [4, 4, 0, 0],
 };
 
-const defaultDataFormat = (value: any, fractionDigits: number = 0) => {
-    return prettyBytes(value, {
-        minimumFractionDigits: fractionDigits,
-        maximumFractionDigits: fractionDigits,
-    });
+const defaultDataFormat = (value: any, options: Options) => {
+    return prettyBytes(value, options);
 };
 
 // TODO (data graph) - need to rename this as it can handle multiple grains
@@ -193,7 +191,10 @@ function DataByHourGraph({ id, stats = [] }: Props) {
             if (dimension.includes('docs')) {
                 return `${readable(value, 2, false)}`;
             }
-            return `${defaultDataFormat(value, precision)}`;
+            return `${defaultDataFormat(value, {
+                minimumFractionDigits: precision,
+                maximumFractionDigits: precision,
+            })}`;
         },
         [intl]
     );
@@ -415,7 +416,10 @@ function DataByHourGraph({ id, stats = [] }: Props) {
                         fontSize: 14,
                         formatter: (value: any) => {
                             return renderingBytes
-                                ? defaultDataFormat(value)
+                                ? defaultDataFormat(value, {
+                                      minimumFractionDigits: 1,
+                                      maximumFractionDigits: 1,
+                                  })
                                 : readable(value, 1, true);
                         },
                     },


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1636

## Changes

### 1636

- Add `precision` to the formatting
- Refactored to allow the options to be passed manually. That way if we want to not _always_ show the decimal then we can

## Tests

### Manually tested

- Viewed the graph

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/d431d1c7-40c7-4814-9230-7bc75e992c04)

