### PR TITLE
Add new `source`|`sourceCapture` options and default to new prefix setting

### DIFF
--- a/src/components/materialization/source/targetSchema/Form.tsx
+++ b/src/components/materialization/source/targetSchema/Form.tsx
@@ -1,8 +1,11 @@
 import type { AutoCompleteOptionForTargetSchema } from 'src/components/materialization/source/targetSchema/types';
 import type { BaseFormProps } from 'src/components/shared/specPropEditor/types';
 
+import { useMount } from 'react-use';
+
 import SelectorOption from 'src/components/materialization/source/targetSchema/SelectorOption';
 import SpecPropAutoComplete from 'src/components/shared/specPropEditor/SpecPropAutoComplete';
+import { useEntityWorkflow } from 'src/context/Workflow';
 import useTargetSchemaOptions from 'src/hooks/sourceCapture/useTargetSchemaOptions';
 import { compareOptionsIncludingAliases } from 'src/stores/SourceCapture/shared';
 import { useSourceCaptureStore } from 'src/stores/SourceCapture/Store';
@@ -12,23 +15,19 @@ export default function TargetSchemaForm({
     scope,
     updateDraftedSetting,
 }: BaseFormProps) {
-    // const workflow = useEntityWorkflow();
+    const workflow = useEntityWorkflow();
 
-    const [
-        setTargetSchemaHasError,
-        // setTargetSchema
-    ] = useSourceCaptureStore((state) => [
-        state.setTargetSchemaHasError,
-        // state.setTargetSchema
-    ]);
+    const [setTargetSchemaHasError, setTargetSchema] = useSourceCaptureStore(
+        (state) => [state.setTargetSchemaHasError, state.setTargetSchema]
+    );
 
     const options = useTargetSchemaOptions();
 
-    // useMount(() => {
-    //     if (workflow === 'materialization_create') {
-    //         setTargetSchema('prefixNonDefaultSchema');
-    //     }
-    // });
+    useMount(() => {
+        if (workflow === 'materialization_create') {
+            setTargetSchema('prefixNonDefaultSchema');
+        }
+    });
 
     return (
         <SpecPropAutoComplete

--- a/src/hooks/sourceCapture/useTargetSchemaOptions.tsx
+++ b/src/hooks/sourceCapture/useTargetSchemaOptions.tsx
@@ -1,6 +1,9 @@
+import type { ReactNode } from 'react';
 import type { AutoCompleteOptionForTargetSchema } from 'src/components/materialization/source/targetSchema/types';
 
 import { useMemo } from 'react';
+
+import { Typography } from '@mui/material';
 
 import { useIntl } from 'react-intl';
 
@@ -12,44 +15,41 @@ function useTargetSchemaOptions(): AutoCompleteOptionForTargetSchema[] {
     return useMemo(
         () =>
             filteredTargetNamingOptions.map((choice) => {
-                const description = intl.formatMessage({
-                    id: `schemaMode.options.${choice}.description`,
-                });
-                // let description: ReactNode | string;
-                // if (choice === 'prefixNonDefaultSchema') {
-                //     description = (
-                //         <>
-                //             {intl.formatMessage(
-                //                 {
-                //                     id: `schemaMode.options.prefixNonDefaultSchema.description`,
-                //                 },
-                //                 {
-                //                     defaultSchema: (
-                //                         <code>
-                //                             {intl.formatMessage({
-                //                                 id: 'schemaMode.options.prefixNonDefaultSchema.ignored',
-                //                             })}
-                //                         </code>
-                //                     ),
-                //                     highlight: (
-                //                         <Typography
-                //                             component="span"
-                //                             sx={{ fontWeight: 500 }}
-                //                         >
-                //                             {intl.formatMessage({
-                //                                 id: `schemaMode.options.prefixNonDefaultSchema.description.highlight`,
-                //                             })}
-                //                         </Typography>
-                //                     ),
-                //                 }
-                //             )}
-                //         </>
-                //     );
-                // } else {
-                //     description = intl.formatMessage({
-                //         id: `schemaMode.options.${choice}.description`,
-                //     });
-                // }
+                let description: ReactNode | string;
+                if (choice === 'prefixNonDefaultSchema') {
+                    description = (
+                        <>
+                            {intl.formatMessage(
+                                {
+                                    id: `schemaMode.options.prefixNonDefaultSchema.description`,
+                                },
+                                {
+                                    defaultSchema: (
+                                        <code>
+                                            {intl.formatMessage({
+                                                id: 'schemaMode.options.prefixNonDefaultSchema.ignored',
+                                            })}
+                                        </code>
+                                    ),
+                                    highlight: (
+                                        <Typography
+                                            component="span"
+                                            sx={{ fontWeight: 500 }}
+                                        >
+                                            {intl.formatMessage({
+                                                id: `schemaMode.options.prefixNonDefaultSchema.description.highlight`,
+                                            })}
+                                        </Typography>
+                                    ),
+                                }
+                            )}
+                        </>
+                    );
+                } else {
+                    description = intl.formatMessage({
+                        id: `schemaMode.options.${choice}.description`,
+                    });
+                }
 
                 return {
                     description,

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -328,17 +328,6 @@ export const Workflows: Record<string, string> = {
     'schemaMode.options.noSchema.example.table': `orders`,
     'schemaMode.options.noSchema.example.schema': `default`,
 
-    // Remove
-    'schemaMode.options.leaveEmpty.label': `Use Table Name Only`,
-    'schemaMode.options.leaveEmpty.description': `Only uses the last part of the collection name as the table name. Schema is left empty, default schema is used.`,
-    'schemaMode.options.leaveEmpty.example.table': `orders`,
-    'schemaMode.options.leaveEmpty.example.schema': `default`,
-
-    'schemaMode.options.fromSourceName.label': `Mirror Schemas`,
-    'schemaMode.options.fromSourceName.description': `Sets the schema name to the second-to-last part of the collection name, and uses the last part as the table name.`,
-    'schemaMode.options.fromSourceName.example.table': `orders`,
-    'schemaMode.options.fromSourceName.example.schema': `AcmeCo-prod`,
-
     // Entities Create
     'entityCreate.catalogEditor.heading': `Advanced Specification Editor`,
     'entityCreate.docs.header': `Connector Help`,

--- a/src/stores/SourceCapture/shared.ts
+++ b/src/stores/SourceCapture/shared.ts
@@ -1,40 +1,39 @@
 import type { AutoCompleteOptionForTargetSchema } from 'src/components/materialization/source/targetSchema/types';
 
-// TODO (source capture new options)
 // Need to keep in sync with - estuary/flow/crates/models/src/source_capture.rs
 // The order that these appear in here is the order they show in the dashboard
 export const targetNamingOptions = [
-    // 'prefixNonDefaultSchema',
-    // 'prefixSchema',
+    'prefixNonDefaultSchema',
+    'prefixSchema',
 
     // fromSourceName renamed to withSchema
     'fromSourceName',
-    // 'withSchema',
+    'withSchema',
 
     // leaveEmpty renamed to noSchema
     'leaveEmpty',
-    // 'noSchema',
+    'noSchema',
 ] as const;
 
 // Functions to handle the old aliases. Keeping them together so they are easier to stay in sync
-// const filterAliases = (choice: string) => {
-//     return choice !== 'leaveEmpty' && choice !== 'fromSourceName';
-// };
+const filterAliases = (choice: string) => {
+    return choice !== 'leaveEmpty' && choice !== 'fromSourceName';
+};
 
-export const filteredTargetNamingOptions = targetNamingOptions;
-// targetNamingOptions.filter(filterAliases);
+export const filteredTargetNamingOptions =
+    targetNamingOptions.filter(filterAliases);
 
 export const compareOptionsIncludingAliases = (
     option: AutoCompleteOptionForTargetSchema,
     optionVal: AutoCompleteOptionForTargetSchema
 ) => {
-    // if (optionVal.val === 'leaveEmpty') {
-    //     return option.val === 'noSchema';
-    // }
+    if (optionVal.val === 'leaveEmpty') {
+        return option.val === 'noSchema';
+    }
 
-    // if (optionVal.val === 'fromSourceName') {
-    //     return option.val === 'noSchema';
-    // }
+    if (optionVal.val === 'fromSourceName') {
+        return option.val === 'noSchema';
+    }
 
     return option.val === optionVal.val;
 };

--- a/src/utils/__tests__/entity-utils.test.ts
+++ b/src/utils/__tests__/entity-utils.test.ts
@@ -53,9 +53,7 @@ describe('readSourceCaptureDefinitionFromSpec', () => {
                 sourceCaptureDef = {
                     ...sourceCaptureDef,
                     deltaUpdates: true,
-                    // TODO (source capture new options)
-                    // targetSchema: 'prefixNonDefaultSchema',
-                    targetSchema: 'leaveEmpty',
+                    targetSchema: 'prefixNonDefaultSchema',
                 };
             });
 

--- a/src/utils/entity-utils.ts
+++ b/src/utils/entity-utils.ts
@@ -72,16 +72,11 @@ export const addOrRemoveSourceCapture = (
     sourceCapture: SourceCaptureDef | null
 ) => {
     if (sourceCapture) {
-        // TODO (source capture new options) - only add setting when there is a source capture
-        if (sourceCapture.capture) {
-            if (schema.source) {
-                schema.source = sourceCapture;
-            } else {
-                // TODO (source capture new options) - we are going to default to the old value
-                //  until the backend deploys changes and then switch to defaulting to
-                //  the new name
-                schema.sourceCapture = sourceCapture;
-            }
+        // Use the old option of that is what is there
+        if (schema.sourceCapture) {
+            schema.sourceCapture = sourceCapture;
+        } else {
+            schema.source = sourceCapture;
         }
     } else {
         delete schema.source;


### PR DESCRIPTION
## Issues

Completes https://github.com/estuary/ui/issues/1588

## Changes

### 1588

- Add back in code for new options and defaulting to the new setting `source`
     - This code was previously tested with https://github.com/estuary/ui/pull/1613 and then commented out while we wait for `flow` to release their changes.

## Tests

### Manually tested

- Materialization create
- Materialization edit

### Automated tests

- Updated the related test

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/1cce3c71-537a-4f5d-a3bf-1dc91d9e4cd3)

