### PR TITLE
Minor projection code quality improvements

### DIFF
--- a/src/hooks/projections/useUpdateDraftedProjection.ts
+++ b/src/hooks/projections/useUpdateDraftedProjection.ts
@@ -3,8 +3,6 @@ import type { Projections } from 'src/types/schemaModels';
 
 import { useCallback } from 'react';
 
-import { omit } from 'lodash';
-
 import { modifyDraftSpec } from 'src/api/draftSpecs';
 import { useBindingsEditorStore_collectionData } from 'src/components/editor/Bindings/Store/hooks';
 import { useEditorStore_persistedDraftId } from 'src/components/editor/Store/hooks';
@@ -49,7 +47,7 @@ export const useUpdateDraftedProjection = () => {
             const spec: Schema = collectionData.spec;
 
             if (spec?.projections) {
-                spec.projections = omit(spec.projections, field);
+                delete spec.projections[field];
             }
 
             const updateResponse = await modifyDraftSpec(spec, {

--- a/src/hooks/projections/useUpdateDraftedProjection.ts
+++ b/src/hooks/projections/useUpdateDraftedProjection.ts
@@ -1,36 +1,11 @@
 import type { Schema } from 'src/types';
-import type { Projections } from 'src/types/schemaModels';
 
 import { useCallback } from 'react';
 
 import { modifyDraftSpec } from 'src/api/draftSpecs';
 import { useBindingsEditorStore_collectionData } from 'src/components/editor/Bindings/Store/hooks';
 import { useEditorStore_persistedDraftId } from 'src/components/editor/Store/hooks';
-
-const getExistingPartition = (
-    spec: Schema,
-    location: string,
-    field: string
-) => {
-    const existingProjection = spec?.projections
-        ? Object.entries(spec.projections as Projections).find(
-              ([projectedField, projectedMetadata]) => {
-                  const locationMatched =
-                      typeof projectedMetadata === 'string'
-                          ? projectedMetadata === location
-                          : projectedMetadata.location === location;
-
-                  return locationMatched && projectedField === field;
-              }
-          )
-        : undefined;
-
-    if (!existingProjection || typeof existingProjection[1] === 'string') {
-        return undefined;
-    }
-
-    return existingProjection[1].partition;
-};
+import { getExistingPartition } from 'src/utils/entity-utils';
 
 export const useUpdateDraftedProjection = () => {
     const draftId = useEditorStore_persistedDraftId();

--- a/src/utils/__tests__/entity-utils.test.ts
+++ b/src/utils/__tests__/entity-utils.test.ts
@@ -1,6 +1,9 @@
-import type { SourceCaptureDef } from 'src/types';
+import type { Schema, SourceCaptureDef } from 'src/types';
 
-import { readSourceCaptureDefinitionFromSpec } from 'src/utils/entity-utils';
+import {
+    getExistingPartition,
+    readSourceCaptureDefinitionFromSpec,
+} from 'src/utils/entity-utils';
 
 describe('readSourceCaptureDefinitionFromSpec', () => {
     const oldKey = 'sourceCapture';
@@ -86,5 +89,78 @@ describe('readSourceCaptureDefinitionFromSpec', () => {
                 })
             ).toStrictEqual(randomObject);
         });
+    });
+});
+
+describe('getExistingPartition', () => {
+    let spec: Schema = {};
+
+    beforeEach(() => {
+        spec = {
+            schema: {
+                $schema: 'https://json-schema.org/draft/2020-12/schema',
+                properties: {
+                    ts: {
+                        type: 'string',
+                        format: 'date-time',
+                        title: 'Timestamp',
+                        description:
+                            'The time at which this message was generated',
+                    },
+                    message: {
+                        type: 'string',
+                        title: 'Message',
+                        description: 'A human-readable message',
+                    },
+                },
+                type: 'object',
+                required: ['ts', 'message'],
+                title: 'Example Output Record',
+            },
+            key: ['/ts'],
+            projections: {
+                message_fr: {
+                    location: '/message',
+                    partition: false,
+                },
+                ts_utc: {
+                    location: '/ts',
+                    partition: true,
+                },
+                ts_est: '/ts',
+            },
+        };
+    });
+
+    describe(`returns undefined`, () => {
+        test(`when no projections are defined`, () => {
+            delete spec.projections;
+
+            expect(
+                getExistingPartition(spec, '/message', 'message_en')
+            ).toBeUndefined();
+        });
+
+        test(`when an existing projection for that field and/or location is not defined`, () => {
+            expect(
+                getExistingPartition(spec, '/message', 'message_en')
+            ).toBeUndefined();
+
+            expect(
+                getExistingPartition(spec, '/fake_location', 'fake_location')
+            ).toBeUndefined();
+        });
+
+        test(`when an existing projection is defined as a string`, () => {
+            expect(getExistingPartition(spec, '/ts', 'ts_est')).toBeUndefined();
+        });
+    });
+
+    test(`returns a boolean when an existing projection is defined as an object`, () => {
+        expect(getExistingPartition(spec, '/ts', 'ts_utc')).toBe(true);
+
+        expect(getExistingPartition(spec, '/message', 'message_fr')).toBe(
+            false
+        );
     });
 });

--- a/src/utils/entity-utils.ts
+++ b/src/utils/entity-utils.ts
@@ -1,4 +1,5 @@
 import type { Schema, SourceCaptureDef } from 'src/types';
+import type { Projections } from 'src/types/schemaModels';
 
 import produce from 'immer';
 
@@ -109,4 +110,29 @@ export const addOrRemoveOnIncompatibleSchemaChange = (
     }
 
     return schema;
+};
+
+export const getExistingPartition = (
+    spec: Schema,
+    location: string,
+    field: string
+) => {
+    const existingProjection = spec?.projections
+        ? Object.entries(spec.projections as Projections).find(
+              ([projectedField, projectedMetadata]) => {
+                  const locationMatched =
+                      typeof projectedMetadata === 'string'
+                          ? projectedMetadata === location
+                          : projectedMetadata.location === location;
+
+                  return locationMatched && projectedField === field;
+              }
+          )
+        : undefined;
+
+    if (!existingProjection || typeof existingProjection[1] === 'string') {
+        return undefined;
+    }
+
+    return existingProjection[1].partition;
 };


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1638

## Changes

### 1638

The following features are included in this PR:

* Use the `delete` method to remove a property from the `projections` object instead of the soon-to-be depreciated `omit` in `useUpdateDraftedProjections`.

* Move `getExistingPartition` into a utility file and add unit test coverage.

## Tests

### Manually tested

Approaches to testing are as follows:

* Validate that the projects UX remains unchanged.

### Automated tests

Test coverage added for the following utils:

* `getExistingPartition`

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_
