### PR TITLE
DEPS: add license exception for img/sharp-libvips-darwin-arm64

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -43,7 +43,8 @@
 
         "// LGPL - only used for image processing and easy to remove": "0.0.0",
         "@img/sharp-libvips-linux-x64": "1.1.0",
-        "@img/sharp-libvips-linuxmusl-x64": "1.1.0"
+        "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
+        "@img/sharp-libvips-darwin-arm64": "1.1.0"
     },
     "ignore": [{ "prefix": "@estuary" }]
 }


### PR DESCRIPTION
There was already an exception for the linux version, and this was preventing the UI from running on Mac.

Previously, `tilt up` would report the following error, which goes away after this patch:

```
Running cmd: BROWSER=none npm start

> estuary-ui@1.0.0 start
> npm run licenses && vite


> estuary-ui@1.0.0 licenses
> licensee --errors-only

@img/sharp-libvips-darwin-arm64@1.1.0
  NOT APPROVED
  Terms: LGPL-3.0-or-later
  Repository: git+https://github.com/lovell/sharp-libvips.git
  Homepage: https://sharp.pixelplumbing.com
  Author: Lovell Fuller <npm@lovell.info>
  Contributors: None listed
```