### PR TITLE
Need to use the custom matcher function when it is provided

### DIFF
--- a/src/components/shared/specPropEditor/SpecPropAutoComplete.tsx
+++ b/src/components/shared/specPropEditor/SpecPropAutoComplete.tsx
@@ -35,8 +35,15 @@ export default function SpecPropAutoComplete({
             return null;
         }
 
-        return options.find((option) => option.val === currentSetting) ?? null;
-    }, [currentSetting, options]);
+        // Use the custom matcher if it was provided - otherwise just do a simple compare
+        return (
+            options.find((option) =>
+                isOptionEqualToValue
+                    ? isOptionEqualToValue(option.val, currentSetting)
+                    : option.val === currentSetting
+            ) ?? null
+        );
+    }, [currentSetting, isOptionEqualToValue, options]);
 
     useEffect(() => {
         // No setting at all so we're good


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1649

## Changes

### 1649

- using the custom matcher function if one is provided

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/b3b9ce20-0610-43e7-b4d2-38cc18730976)
![image](https://github.com/user-attachments/assets/754fde17-19db-4314-8494-e9ef2a1b7760)

