### PR TITLE
Use `targetNaming` while setting the source capture

### DIFF
--- a/src/components/editor/Bindings/index.tsx
+++ b/src/components/editor/Bindings/index.tsx
@@ -100,12 +100,6 @@ function BindingsMultiEditor({
 
     return (
         <LocalZustandProvider createStore={localStore}>
-            <Typography sx={{ mb: 2 }}>
-                <FormattedMessage
-                    id={`${messagePrefix}.collectionSelector.instructions`}
-                />
-            </Typography>
-
             <Stack spacing={5} sx={{ mb: 5 }}>
                 {entityType === 'capture' ? <AutoDiscoverySettings /> : null}
 
@@ -117,6 +111,12 @@ function BindingsMultiEditor({
 
                 <AdvancedOptions />
             </Stack>
+
+            <Typography sx={{ mb: 2 }}>
+                <FormattedMessage
+                    id={`${messagePrefix}.collectionSelector.instructions`}
+                />
+            </Typography>
 
             <ListAndDetails
                 list={

--- a/src/components/materialization/source/Capture/AddSourceCaptureToSpecButton.tsx
+++ b/src/components/materialization/source/Capture/AddSourceCaptureToSpecButton.tsx
@@ -78,7 +78,7 @@ function AddSourceCaptureToSpecButton({ toggle }: AddCollectionDialogCTAProps) {
                 updatedSourceCapture.deltaUpdates = deltaUpdates;
             }
             if (sourceCaptureTargetSchemaSupported) {
-                updatedSourceCapture.targetSchema = targetSchema;
+                updatedSourceCapture.targetNaming = targetSchema;
             }
 
             // Check the name since the optional settings may

--- a/src/components/materialization/source/Capture/index.tsx
+++ b/src/components/materialization/source/Capture/index.tsx
@@ -10,6 +10,8 @@ function SourceCapture() {
     const intl = useIntl();
     return (
         <Stack spacing={1}>
+            <SourceConfiguration />
+
             <Typography variant="formSectionHeader">
                 {intl.formatMessage({ id: 'workflows.sourceCapture.header' })}
             </Typography>
@@ -30,8 +32,6 @@ function SourceCapture() {
                 <SourceCaptureChip />
                 <SelectCapture />
             </Stack>
-
-            <SourceConfiguration />
         </Stack>
     );
 }

--- a/src/components/materialization/source/SourceConfiguration.tsx
+++ b/src/components/materialization/source/SourceConfiguration.tsx
@@ -22,7 +22,7 @@ function SourceConfiguration() {
     }
 
     return (
-        <Stack spacing={1} sx={{ pt: 2, maxWidth: '50%' }}>
+        <Stack spacing={1} sx={{ pb: 2, maxWidth: '50%' }}>
             <Typography variant="formSectionHeader">
                 {intl.formatMessage({
                     id: 'workflows.sourceCapture.optionalSettings.header',


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1653

## Changes

### 1653

- Need to replace `targetSchema` with `targetNaming` here otherwise when we prepare to call the WASM function we will end up adding BOTH values to the source capture

### Misc

- Changing the order of `Collection Settings` and `Link Capture` as the order was confusing users and they would set the settings AFTER adding a link capture
- Moving the general message closer to the list as it makes more sense being close to the `Add` cta

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/74a236d8-4d1c-48de-8b47-5d23b9018894)

