### PR TITLE
Making the check work for toggle all call

### DIFF
--- a/src/hooks/bindings/useDisableUpdater.ts
+++ b/src/hooks/bindings/useDisableUpdater.ts
@@ -5,7 +5,10 @@ import { useCallback, useMemo } from 'react';
 import { useSnackbar } from 'notistack';
 import { useIntl } from 'react-intl';
 
-import { useEditorStore_queryResponse_draftSpecs } from 'src/components/editor/Store/hooks';
+import {
+    useEditorStore_id,
+    useEditorStore_queryResponse_draftSpecs,
+} from 'src/components/editor/Store/hooks';
 import { useEntityType } from 'src/context/EntityContext';
 import useDraftUpdater from 'src/hooks/useDraftUpdater';
 import { useBindingStore } from 'src/stores/Binding/Store';
@@ -20,6 +23,7 @@ function useDisableUpdater(bindingUUID?: string) {
 
     const entityType = useEntityType();
 
+    const draftId = useEditorStore_id();
     const draftSpecs = useEditorStore_queryResponse_draftSpecs();
 
     const { enqueueSnackbar } = useSnackbar();
@@ -147,19 +151,21 @@ function useDisableUpdater(bindingUUID?: string) {
 
     const currentSetting: boolean | null | undefined = useMemo(() => {
         if (bindingIndex !== null) {
-            if (
-                draftSpecs?.[0]?.spec?.bindings &&
-                draftSpecs?.[0]?.spec?.bindings.length > 0 &&
-                draftSpecs[0].spec.bindings[bindingIndex]
-            ) {
-                return (
-                    draftSpecs[0].spec.bindings[bindingIndex].disable ??
-                    storeSetting
-                );
+            // If there is a draft id then we are not going to run another generation
+            //  so only use the setting from the draft
+            if (draftId) {
+                if (
+                    draftSpecs?.[0]?.spec?.bindings &&
+                    draftSpecs?.[0]?.spec?.bindings.length > 0 &&
+                    draftSpecs[0].spec.bindings[bindingIndex]
+                ) {
+                    return draftSpecs[0].spec.bindings[bindingIndex].disable;
+                }
             } else {
-                // Usually means the user has entered edit, adding some bindings, and has flipped
-                //  the disable/enable toggle on the new bindings but did NOT click the next button
-                //  yet.
+                // No draft ID means we will be using the store settings on the next call to
+                //  generate the spec. This is common for create and _sometimes_ edit. Like when the user
+                //  starts editing, adding some bindings, and has flipped the disable/enable toggle on the
+                //  new bindings but did NOT click the next button yet.
                 return storeSetting;
             }
         } else {
@@ -167,7 +173,7 @@ function useDisableUpdater(bindingUUID?: string) {
         }
 
         return null;
-    }, [bindingIndex, draftSpecs, storeSetting]);
+    }, [bindingIndex, draftId, draftSpecs, storeSetting]);
 
     return {
         currentSetting,

--- a/src/hooks/bindings/useDisableUpdater.ts
+++ b/src/hooks/bindings/useDisableUpdater.ts
@@ -152,7 +152,10 @@ function useDisableUpdater(bindingUUID?: string) {
                 draftSpecs?.[0]?.spec?.bindings.length > 0 &&
                 draftSpecs[0].spec.bindings[bindingIndex]
             ) {
-                return draftSpecs[0].spec.bindings[bindingIndex].disable;
+                return (
+                    draftSpecs[0].spec.bindings[bindingIndex].disable ??
+                    storeSetting
+                );
             } else {
                 // Usually means the user has entered edit, adding some bindings, and has flipped
                 //  the disable/enable toggle on the new bindings but did NOT click the next button


### PR DESCRIPTION
Putting current setting into memo

## Issues

https://github.com/estuary/ui/issues/1675

## Changes

### 1675

- Need to ignore collection name checking when there is no name to compare to
- Only use the draft settings when there is a draft id. This is because if we have a draft id we are NOT going to show the `next` button and have the spec be generated again. So whatever is in the draft will be used in publication.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

![image](https://github.com/user-attachments/assets/b744c599-3877-40be-92a3-f954e81e277b)

