### PR TITLE
Updating default `target naming` settings

### DIFF
--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -295,7 +295,7 @@ export const Workflows: Record<string, string> = {
     'deltaUpdates.input.label': `Default setting for the "Delta Updates" field of newly adding bindings.`,
 
     // Schema Mode
-    'schemaMode.message': `Default naming convention for how collections map to destination tables and schemas. If blank, only the table name will be set to the last part of the collection name.`,
+    'schemaMode.message': `Default naming convention for how collections map to destination tables and schemas. If blank, prefixes the table name with the second-to-last part of the collection name.`,
     'schemaMode.input.label': `Target Resource Naming Convention`,
 
     'specPropUpdater.error.message': `The current setting "{currentSetting}" does not match a known option. Please update or remove.`,

--- a/src/services/ajv.ts
+++ b/src/services/ajv.ts
@@ -144,8 +144,10 @@ export const prepareSourceCaptureForServer = (arg: SourceCaptureDef) => {
         response.deltaUpdates = false;
     }
 
+    // This matches the default provided by flow on the backend
+    //  flow/crates/models/src/source_capture.rs
     if (!response.targetNaming) {
-        response.targetNaming = 'noSchema';
+        response.targetNaming = 'prefixNonDefaultSchema';
     }
 
     return response;


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1680

## Changes

### 1680

- Change the default value
- Update messages to users so they understand the default setting

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

No setting and the name is now prefaced.
![image](https://github.com/user-attachments/assets/4adf7055-f9b8-4bc4-a588-66006907ad23)

No preface when `public` is the second to last
![image](https://github.com/user-attachments/assets/585ff531-b05e-4ada-a314-fe13f6ca7948)

Update the content for the change in default option
![image](https://github.com/user-attachments/assets/eb4f00d7-04fd-4b90-af9a-38a026322ed5)

