### PR TITLE
Present private data-planes first in data-plane selector

### DIFF
--- a/src/forms/renderers/DataPlaneSelector/AutoComplete.tsx
+++ b/src/forms/renderers/DataPlaneSelector/AutoComplete.tsx
@@ -210,7 +210,7 @@ export const DataPlaneAutoComplete = ({
                     );
                 }
 
-                return a.value.scope === 'private' ? 1 : -1;
+                return a.value.scope === 'public' ? 1 : -1;
             })}
             value={currentOption}
         />


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1688

## Changes

### 1688

* Present private data-planes before public data-planes in the data-plane selector.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
