### PR TITLE
Only worry about `isDefault` during create

### DIFF
--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 
 import { getDataPlaneOptions } from 'src/api/dataPlanes';
+import { useEntityWorkflow_Editing } from 'src/context/Workflow';
 import { logRocketEvent } from 'src/services/shared';
 import { CustomEvents } from 'src/services/types';
 import { useDetailsFormStore } from 'src/stores/DetailsForm/Store';
@@ -12,6 +13,8 @@ import {
 } from 'src/utils/dataPlane-utils';
 
 export const useEvaluateDataPlaneOptions = () => {
+    const isEdit = useEntityWorkflow_Editing();
+
     const storageMappings = useEntitiesStore((state) => state.storageMappings);
 
     const setDataPlaneOptions = useDetailsFormStore(
@@ -56,7 +59,7 @@ export const useEvaluateDataPlaneOptions = () => {
                               gcp_service_account_email: null,
                               aws_iam_user_arn: null,
                           },
-                          existingDataPlane.name ?? ''
+                          isEdit ? undefined : (existingDataPlane.name ?? '')
                       )
                     : null;
 
@@ -69,7 +72,10 @@ export const useEvaluateDataPlaneOptions = () => {
 
             const options = dataPlanes
                 ? dataPlanes.map((dataPlane) =>
-                      generateDataPlaneOption(dataPlane, dataPlaneNames[0])
+                      generateDataPlaneOption(
+                          dataPlane,
+                          isEdit ? undefined : dataPlaneNames[0]
+                      )
                   )
                 : [];
 
@@ -78,6 +84,6 @@ export const useEvaluateDataPlaneOptions = () => {
 
             return options;
         },
-        [storageMappings, setDataPlaneOptions, setStorageMappingPrefix]
+        [storageMappings, setDataPlaneOptions, setStorageMappingPrefix, isEdit]
     );
 };


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1690

## Changes

### 1690

- Only pass the name when in create as during edit we do not really need to worry about `isDefault` right now.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Create
![image](https://github.com/user-attachments/assets/2fc58dd3-89d4-45c2-9f7f-f43f7f7d5934)


### Edit
![image](https://github.com/user-attachments/assets/0ec55cad-37be-4811-99b6-1fdeb5908910)

