### PR TITLE
Use the existing data-plane as the default in edit workflows

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ VITE_ENTITY_STATUS_BASE_URL=https://agent-api-1084703453822.us-central1.run.app/
 
 VITE_MARKETPLACE_VERIFY_URL=https://gcp-marketplace-verify-mo7rswd2xq-uc.a.run.app
 
-VITE_DEFAULT_DATA_PLANE_SUFFIX=gcp-us-central1-c1
+VITE_DEFAULT_DATA_PLANE_SUFFIX=gcp-us-central1-c2
 
 # These settings require an application restart to enable right now
 VITE_SHOW_EMAIL_LOGIN=false

--- a/src/components/shared/Entity/DetailsForm/useDataPlaneOptions.ts
+++ b/src/components/shared/Entity/DetailsForm/useDataPlaneOptions.ts
@@ -10,9 +10,6 @@ export const useDataPlaneOptions = () => {
         (state) => state.details.data.entityName
     );
     const options = useDetailsFormStore((state) => state.dataPlaneOptions);
-    const existingDataPlaneOption = useDetailsFormStore(
-        (state) => state.existingDataPlaneOption
-    );
     const storageMappings = useEntitiesStore((state) => state.storageMappings);
 
     const hasSupportRole = useUserInfoSummaryStore(
@@ -26,31 +23,11 @@ export const useDataPlaneOptions = () => {
                 catalogName
             );
 
-            // Add the existing data-plane name to the array of data-plane names of the
-            // matched storage mapping in the event it is not there. This data-plane should
-            // be treated as the default in edit workflows so it must be the first element
-            // in the array of data-plane names.
-            const evaluatedDataPlaneNames =
-                existingDataPlaneOption &&
-                !dataPlaneNames.includes(
-                    existingDataPlaneOption.dataPlaneName.whole
-                )
-                    ? [existingDataPlaneOption.dataPlaneName.whole].concat(
-                          dataPlaneNames
-                      )
-                    : dataPlaneNames;
-
             return options.filter(({ dataPlaneName }) =>
-                evaluatedDataPlaneNames.includes(dataPlaneName.whole)
+                dataPlaneNames.includes(dataPlaneName.whole)
             );
         }
 
         return options;
-    }, [
-        catalogName,
-        existingDataPlaneOption,
-        hasSupportRole,
-        options,
-        storageMappings,
-    ]);
+    }, [catalogName, hasSupportRole, options, storageMappings]);
 };

--- a/src/components/shared/Entity/DetailsForm/useDataPlaneOptions.ts
+++ b/src/components/shared/Entity/DetailsForm/useDataPlaneOptions.ts
@@ -3,7 +3,10 @@ import { useMemo } from 'react';
 import { useUserInfoSummaryStore } from 'src/context/UserInfoSummary/useUserInfoSummaryStore';
 import { useDetailsFormStore } from 'src/stores/DetailsForm/Store';
 import { useEntitiesStore } from 'src/stores/Entities/Store';
-import { getDataPlaneInfo } from 'src/utils/dataPlane-utils';
+import {
+    generateDataPlaneOption,
+    getDataPlaneInfo,
+} from 'src/utils/dataPlane-utils';
 
 export const useDataPlaneOptions = () => {
     const catalogName = useDetailsFormStore(
@@ -23,9 +26,26 @@ export const useDataPlaneOptions = () => {
                 catalogName
             );
 
-            return options.filter(({ dataPlaneName }) =>
-                dataPlaneNames.includes(dataPlaneName.whole)
-            );
+            return dataPlaneNames.map((dataPlaneName) => {
+                const existingOption = options.find(
+                    (option) => option.dataPlaneName.whole === dataPlaneName
+                );
+
+                return (
+                    existingOption ??
+                    generateDataPlaneOption(
+                        {
+                            data_plane_name: dataPlaneName,
+                            id: dataPlaneName,
+                            reactor_address: '',
+                            cidr_blocks: null,
+                            gcp_service_account_email: null,
+                            aws_iam_user_arn: null,
+                        },
+                        dataPlaneNames.at(0)
+                    )
+                );
+            });
         }
 
         return options;

--- a/src/components/shared/Entity/DetailsForm/useDataPlaneOptions.ts
+++ b/src/components/shared/Entity/DetailsForm/useDataPlaneOptions.ts
@@ -21,7 +21,7 @@ export const useDataPlaneOptions = () => {
 
     return useMemo(() => {
         if (!hasSupportRole && catalogName) {
-            const { dataPlaneNames, storageMappingPrefix } = getDataPlaneInfo(
+            const { dataPlaneNames } = getDataPlaneInfo(
                 storageMappings,
                 catalogName
             );
@@ -31,16 +31,13 @@ export const useDataPlaneOptions = () => {
             // be treated as the default in edit workflows so it must be the first element
             // in the array of data-plane names.
             const evaluatedDataPlaneNames =
-                storageMappingPrefix &&
-                existingDataPlaneOption?.[storageMappingPrefix] &&
+                existingDataPlaneOption &&
                 !dataPlaneNames.includes(
-                    existingDataPlaneOption[storageMappingPrefix].dataPlaneName
-                        .whole
+                    existingDataPlaneOption.dataPlaneName.whole
                 )
-                    ? [
-                          existingDataPlaneOption[storageMappingPrefix]
-                              .dataPlaneName.whole,
-                      ].concat(dataPlaneNames)
+                    ? [existingDataPlaneOption.dataPlaneName.whole].concat(
+                          dataPlaneNames
+                      )
                     : dataPlaneNames;
 
             return options.filter(({ dataPlaneName }) =>

--- a/src/components/shared/Entity/DetailsForm/useDataPlaneOptions.ts
+++ b/src/components/shared/Entity/DetailsForm/useDataPlaneOptions.ts
@@ -32,7 +32,11 @@ export const useDataPlaneOptions = () => {
             // in the array of data-plane names.
             const evaluatedDataPlaneNames =
                 storageMappingPrefix &&
-                existingDataPlaneOption?.[storageMappingPrefix]
+                existingDataPlaneOption?.[storageMappingPrefix] &&
+                !dataPlaneNames.includes(
+                    existingDataPlaneOption[storageMappingPrefix].dataPlaneName
+                        .whole
+                )
                     ? [
                           existingDataPlaneOption[storageMappingPrefix]
                               .dataPlaneName.whole,

--- a/src/components/shared/Entity/DetailsForm/useEvaluateStorageMapping.ts
+++ b/src/components/shared/Entity/DetailsForm/useEvaluateStorageMapping.ts
@@ -10,6 +10,9 @@ import { getDataPlaneInfo } from 'src/utils/dataPlane-utils';
 
 export const useEvaluateStorageMapping = () => {
     const options = useDetailsFormStore((state) => state.dataPlaneOptions);
+    const existingDataPlaneOption = useDetailsFormStore(
+        (state) => state.existingDataPlaneOption
+    );
 
     const storageMappings = useEntitiesStore((state) => state.storageMappings);
 
@@ -67,6 +70,19 @@ export const useEvaluateStorageMapping = () => {
                 catalogName
             );
 
+            // Add the existing data-plane name to the array of data-plane names of the
+            // matched storage mapping in the event it is not there. This data-plane should
+            // be treated as the default in edit workflows so it must be the first element
+            // in the array of data-plane names.
+            const evaluatedDataPlaneNames =
+                storageMappingPrefix &&
+                existingDataPlaneOption?.[storageMappingPrefix]
+                    ? [
+                          existingDataPlaneOption[storageMappingPrefix]
+                              .dataPlaneName.whole,
+                      ].concat(dataPlaneNames)
+                    : dataPlaneNames;
+
             let targetDataPlaneId: string | undefined = selectedDataPlane?.id;
 
             if (
@@ -81,7 +97,7 @@ export const useEvaluateStorageMapping = () => {
                 // selector is defaulted during hydration in create workflows.
                 targetDataPlaneId =
                     selectedDataPlane &&
-                    dataPlaneNames.includes(
+                    evaluatedDataPlaneNames.includes(
                         selectedDataPlane.dataPlaneName.whole
                     ) &&
                     !previousNameEmpty
@@ -92,12 +108,13 @@ export const useEvaluateStorageMapping = () => {
             return getDataPlaneOption(
                 targetDataPlaneId,
                 catalogName,
-                dataPlaneNames,
+                evaluatedDataPlaneNames,
                 hasSupportRole
             );
         },
         [
             currentStorageMappingPrefix,
+            existingDataPlaneOption,
             getDataPlaneOption,
             hasSupportRole,
             previousNameEmpty,

--- a/src/components/shared/Entity/DetailsForm/useEvaluateStorageMapping.ts
+++ b/src/components/shared/Entity/DetailsForm/useEvaluateStorageMapping.ts
@@ -35,7 +35,8 @@ export const useEvaluateStorageMapping = () => {
             dataPlaneId: string | undefined,
             catalogName: string | undefined,
             dataPlaneNames: string[],
-            supportUser: boolean
+            supportUser: boolean,
+            existingOption: DataPlaneOption | undefined
         ) => {
             let selectedOption = options.find(
                 (option) => option.id === (dataPlaneId ?? '')
@@ -51,10 +52,10 @@ export const useEvaluateStorageMapping = () => {
                           (option) =>
                               option.dataPlaneName.whole === dataPlaneNames[0]
                       )
-                    : undefined;
+                    : existingOption;
             }
 
-            return undefined;
+            return existingOption;
         },
         [options]
     );
@@ -75,16 +76,13 @@ export const useEvaluateStorageMapping = () => {
             // be treated as the default in edit workflows so it must be the first element
             // in the array of data-plane names.
             const evaluatedDataPlaneNames =
-                storageMappingPrefix &&
-                existingDataPlaneOption?.[storageMappingPrefix] &&
+                existingDataPlaneOption &&
                 !dataPlaneNames.includes(
-                    existingDataPlaneOption[storageMappingPrefix].dataPlaneName
-                        .whole
+                    existingDataPlaneOption.dataPlaneName.whole
                 )
-                    ? [
-                          existingDataPlaneOption[storageMappingPrefix]
-                              .dataPlaneName.whole,
-                      ].concat(dataPlaneNames)
+                    ? [existingDataPlaneOption.dataPlaneName.whole].concat(
+                          dataPlaneNames
+                      )
                     : dataPlaneNames;
 
             let targetDataPlaneId: string | undefined = selectedDataPlane?.id;
@@ -113,7 +111,8 @@ export const useEvaluateStorageMapping = () => {
                 targetDataPlaneId,
                 catalogName,
                 evaluatedDataPlaneNames,
-                hasSupportRole
+                hasSupportRole,
+                existingDataPlaneOption
             );
         },
         [

--- a/src/components/shared/Entity/DetailsForm/useEvaluateStorageMapping.ts
+++ b/src/components/shared/Entity/DetailsForm/useEvaluateStorageMapping.ts
@@ -76,7 +76,11 @@ export const useEvaluateStorageMapping = () => {
             // in the array of data-plane names.
             const evaluatedDataPlaneNames =
                 storageMappingPrefix &&
-                existingDataPlaneOption?.[storageMappingPrefix]
+                existingDataPlaneOption?.[storageMappingPrefix] &&
+                !dataPlaneNames.includes(
+                    existingDataPlaneOption[storageMappingPrefix].dataPlaneName
+                        .whole
+                )
                     ? [
                           existingDataPlaneOption[storageMappingPrefix]
                               .dataPlaneName.whole,

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 
 import { getDataPlaneOptions } from 'src/api/dataPlanes';
-import { useEntityWorkflow_Editing } from 'src/context/Workflow';
 import { logRocketEvent } from 'src/services/shared';
 import { CustomEvents } from 'src/services/types';
 import { useDetailsFormStore } from 'src/stores/DetailsForm/Store';
@@ -13,13 +12,11 @@ import {
 } from 'src/utils/dataPlane-utils';
 
 export const useEvaluateDataPlaneOptions = () => {
-    const isEdit = useEntityWorkflow_Editing();
-
-    const storageMappings = useEntitiesStore((state) => state.storageMappings);
-
     const setDataPlaneOptions = useDetailsFormStore(
         (state) => state.setDataPlaneOptions
     );
+
+    const storageMappings = useEntitiesStore((state) => state.storageMappings);
 
     const setStorageMappingPrefix = useWorkflowStore(
         (state) => state.setStorageMappingPrefix
@@ -34,13 +31,23 @@ export const useEvaluateDataPlaneOptions = () => {
                 reactorAddress: string | null;
             }
         ) => {
+            // Get required data-plane information from the matched storage mapping.
             const { dataPlaneNames, storageMappingPrefix } = getDataPlaneInfo(
                 storageMappings,
                 catalogName
             );
 
-            const { data: dataPlanes, error } =
-                await getDataPlaneOptions(dataPlaneNames);
+            // Add the existing data-plane name to the array of data-plane names of the
+            // matched storage mapping in the event it is not there. This data-plane should
+            // be treated as the default in edit workflows so it must be the first element
+            // in the array of data-plane names.
+            const evaluatedDataPlaneNames = existingDataPlane?.name
+                ? [existingDataPlane.name].concat(dataPlaneNames)
+                : dataPlaneNames;
+
+            const { data: dataPlanes, error } = await getDataPlaneOptions(
+                evaluatedDataPlaneNames
+            );
 
             if (!dataPlanes || dataPlanes.length === 0 || error) {
                 logRocketEvent(CustomEvents.DATA_PLANE_SELECTOR, {
@@ -59,7 +66,7 @@ export const useEvaluateDataPlaneOptions = () => {
                               gcp_service_account_email: null,
                               aws_iam_user_arn: null,
                           },
-                          isEdit ? undefined : (existingDataPlane.name ?? '')
+                          existingDataPlane.name ?? ''
                       )
                     : null;
 
@@ -70,11 +77,40 @@ export const useEvaluateDataPlaneOptions = () => {
                 return fallbackOptions;
             }
 
+            // If the array of data-planes does not contain an element with the same name
+            // as the existing data-plane, stub the BaseDataPlaneQuery response corresponding
+            // to the existing data-plane so it can appear as a data-plane option. This is
+            // particularly important for edit workflows.
+            const evaluatedDataPlanes = dataPlanes;
+            const existingDataPlaneFetched = Boolean(
+                existingDataPlane?.name &&
+                    dataPlanes.some(
+                        ({ data_plane_name }) =>
+                            data_plane_name === existingDataPlane.name
+                    )
+            );
+
+            if (existingDataPlane && !existingDataPlaneFetched) {
+                logRocketEvent(CustomEvents.DATA_PLANE_SELECTOR, {
+                    noOptionsFound: false,
+                    fallbackExists: Boolean(existingDataPlane),
+                });
+
+                evaluatedDataPlanes.concat({
+                    data_plane_name: existingDataPlane.name ?? '',
+                    id: existingDataPlane.id,
+                    reactor_address: existingDataPlane.reactorAddress ?? '',
+                    cidr_blocks: null,
+                    gcp_service_account_email: null,
+                    aws_iam_user_arn: null,
+                });
+            }
+
             const options = dataPlanes
                 ? dataPlanes.map((dataPlane) =>
                       generateDataPlaneOption(
                           dataPlane,
-                          isEdit ? undefined : dataPlaneNames[0]
+                          evaluatedDataPlaneNames[0]
                       )
                   )
                 : [];
@@ -84,6 +120,6 @@ export const useEvaluateDataPlaneOptions = () => {
 
             return options;
         },
-        [storageMappings, setDataPlaneOptions, setStorageMappingPrefix, isEdit]
+        [storageMappings, setDataPlaneOptions, setStorageMappingPrefix]
     );
 };

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -35,10 +35,14 @@ export const useEvaluateDataPlaneOptions = () => {
             }
         ) => {
             // Get required data-plane information from the matched storage mapping.
-            const { dataPlaneNames, storageMappingPrefix } = getDataPlaneInfo(
-                storageMappings,
-                catalogName
+            const dataPlaneNames = Object.values(storageMappings).flatMap(
+                ({ data_planes }) => data_planes
             );
+
+            const {
+                dataPlaneNames: matchedDataPlaneNames,
+                storageMappingPrefix,
+            } = getDataPlaneInfo(storageMappings, catalogName);
 
             // Add the existing data-plane name to the array of data-plane names of the
             // matched storage mapping in the event it is not there. This data-plane should
@@ -76,6 +80,13 @@ export const useEvaluateDataPlaneOptions = () => {
                           )
                         : undefined;
 
+                    const defaultDataPlaneName =
+                        existingDataPlane?.data_plane_name
+                            ? existingDataPlane.data_plane_name
+                            : matchedDataPlaneNames.length > 0
+                              ? matchedDataPlaneNames[0]
+                              : dataPlaneNames.at(0);
+
                     return generateDataPlaneOption(
                         existingDataPlane ?? {
                             data_plane_name: dataPlaneName,
@@ -85,7 +96,7 @@ export const useEvaluateDataPlaneOptions = () => {
                             gcp_service_account_email: null,
                             aws_iam_user_arn: null,
                         },
-                        dataPlaneNames.at(0)
+                        defaultDataPlaneName
                     );
                 }
             );

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -15,6 +15,9 @@ export const useEvaluateDataPlaneOptions = () => {
     const setDataPlaneOptions = useDetailsFormStore(
         (state) => state.setDataPlaneOptions
     );
+    const setExistingDataPlaneOption = useDetailsFormStore(
+        (state) => state.setExistingDataPlaneOption
+    );
 
     const storageMappings = useEntitiesStore((state) => state.storageMappings);
 
@@ -116,10 +119,22 @@ export const useEvaluateDataPlaneOptions = () => {
                 : [];
 
             setDataPlaneOptions(options);
+            setExistingDataPlaneOption(
+                storageMappingPrefix,
+                options.find(
+                    (option) =>
+                        option.dataPlaneName.whole === existingDataPlane?.name
+                )
+            );
             setStorageMappingPrefix(storageMappingPrefix ?? '');
 
             return options;
         },
-        [storageMappings, setDataPlaneOptions, setStorageMappingPrefix]
+        [
+            setDataPlaneOptions,
+            setExistingDataPlaneOption,
+            setStorageMappingPrefix,
+            storageMappings,
+        ]
     );
 };

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -44,21 +44,30 @@ export const useEvaluateDataPlaneOptions = () => {
             // matched storage mapping in the event it is not there. This data-plane should
             // be treated as the default in edit workflows so it must be the first element
             // in the array of data-plane names.
-            const evaluatedDataPlaneNames =
+            let evaluatedDataPlaneNames =
                 existingDataPlane?.name &&
                 !dataPlaneNames.includes(existingDataPlane.name)
                     ? [existingDataPlane.name].concat(dataPlaneNames)
                     : dataPlaneNames;
 
-            const { data: dataPlanes, error } = await getDataPlaneOptions(
-                evaluatedDataPlaneNames
-            );
+            const { data: dataPlanes, error } = await getDataPlaneOptions();
 
             // If the array of data-planes does not contain an element with the same name
             // as the existing data-plane, stub the BaseDataPlaneQuery response corresponding
             // to the existing data-plane so it can appear as a data-plane option. This is
             // particularly important for edit workflows.
-            let evaluatedDataPlaneOptions = dataPlaneNames.map(
+            if (dataPlanes) {
+                const queriedDataPlaneNames = dataPlanes
+                    ?.map(({ data_plane_name }) => data_plane_name)
+                    .filter((name) => !evaluatedDataPlaneNames.includes(name));
+
+                evaluatedDataPlaneNames = [
+                    ...evaluatedDataPlaneNames,
+                    ...queriedDataPlaneNames,
+                ];
+            }
+
+            let evaluatedDataPlaneOptions = evaluatedDataPlaneNames.map(
                 (dataPlaneName) => {
                     const existingDataPlane = dataPlanes
                         ? dataPlanes.find(

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -86,7 +86,7 @@ export const useEvaluateDataPlaneOptions = () => {
             // as the existing data-plane, stub the BaseDataPlaneQuery response corresponding
             // to the existing data-plane so it can appear as a data-plane option. This is
             // particularly important for edit workflows.
-            const evaluatedDataPlanes = dataPlanes;
+            let evaluatedDataPlanes = dataPlanes;
             const existingDataPlaneFetched = Boolean(
                 existingDataPlane?.name &&
                     dataPlanes.some(
@@ -101,7 +101,7 @@ export const useEvaluateDataPlaneOptions = () => {
                     fallbackExists: Boolean(existingDataPlane),
                 });
 
-                evaluatedDataPlanes.concat({
+                evaluatedDataPlanes = evaluatedDataPlanes.concat({
                     data_plane_name: existingDataPlane.name ?? '',
                     id: existingDataPlane.id,
                     reactor_address: existingDataPlane.reactorAddress ?? '',

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -44,9 +44,11 @@ export const useEvaluateDataPlaneOptions = () => {
             // matched storage mapping in the event it is not there. This data-plane should
             // be treated as the default in edit workflows so it must be the first element
             // in the array of data-plane names.
-            const evaluatedDataPlaneNames = existingDataPlane?.name
-                ? [existingDataPlane.name].concat(dataPlaneNames)
-                : dataPlaneNames;
+            const evaluatedDataPlaneNames =
+                existingDataPlane?.name &&
+                !dataPlaneNames.includes(existingDataPlane.name)
+                    ? [existingDataPlane.name].concat(dataPlaneNames)
+                    : dataPlaneNames;
 
             const { data: dataPlanes, error } = await getDataPlaneOptions(
                 evaluatedDataPlaneNames

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -122,7 +122,6 @@ export const useEvaluateDataPlaneOptions = () => {
 
             setDataPlaneOptions(options);
             setExistingDataPlaneOption(
-                storageMappingPrefix,
                 options.find(
                     (option) =>
                         option.dataPlaneName.whole === existingDataPlane?.name

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -111,8 +111,8 @@ export const useEvaluateDataPlaneOptions = () => {
                 });
             }
 
-            const options = dataPlanes
-                ? dataPlanes.map((dataPlane) =>
+            const options = evaluatedDataPlanes
+                ? evaluatedDataPlanes.map((dataPlane) =>
                       generateDataPlaneOption(
                           dataPlane,
                           evaluatedDataPlaneNames[0]

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { uniq } from 'lodash';
+
 import { getDataPlaneOptions } from 'src/api/dataPlanes';
 import { logRocketEvent } from 'src/services/shared';
 import { CustomEvents } from 'src/services/types';
@@ -71,7 +73,7 @@ export const useEvaluateDataPlaneOptions = () => {
                 ];
             }
 
-            let evaluatedDataPlaneOptions = evaluatedDataPlaneNames.map(
+            let evaluatedDataPlaneOptions = uniq(evaluatedDataPlaneNames).map(
                 (dataPlaneName) => {
                     const existingDataPlane = dataPlanes
                         ? dataPlanes.find(

--- a/src/stores/DetailsForm/Store.ts
+++ b/src/stores/DetailsForm/Store.ts
@@ -111,6 +111,7 @@ const getInitialStateData = (): Pick<
     | 'dataPlaneOptions'
     | 'details'
     | 'errorsExist'
+    | 'existingDataPlaneOption'
     | 'draftedEntityName'
     | 'entityNameChanged'
     | 'previousDetails'
@@ -119,6 +120,7 @@ const getInitialStateData = (): Pick<
     connectors: [],
 
     dataPlaneOptions: [],
+    existingDataPlaneOption: {},
 
     details: initialDetails,
     errorsExist: true,
@@ -281,6 +283,18 @@ export const getInitialState = (
             }),
             false,
             'Entity Name Change Flag Set'
+        );
+    },
+
+    setExistingDataPlaneOption: (prefix, value) => {
+        set(
+            produce((state: DetailsFormState) => {
+                if (prefix && value) {
+                    state.existingDataPlaneOption[prefix] = value;
+                }
+            }),
+            false,
+            'Existing Data Plane Option Set'
         );
     },
 

--- a/src/stores/DetailsForm/Store.ts
+++ b/src/stores/DetailsForm/Store.ts
@@ -120,7 +120,7 @@ const getInitialStateData = (): Pick<
     connectors: [],
 
     dataPlaneOptions: [],
-    existingDataPlaneOption: {},
+    existingDataPlaneOption: undefined,
 
     details: initialDetails,
     errorsExist: true,
@@ -286,12 +286,10 @@ export const getInitialState = (
         );
     },
 
-    setExistingDataPlaneOption: (prefix, value) => {
+    setExistingDataPlaneOption: (value) => {
         set(
             produce((state: DetailsFormState) => {
-                if (prefix && value) {
-                    state.existingDataPlaneOption[prefix] = value;
-                }
+                state.existingDataPlaneOption = value;
             }),
             false,
             'Existing Data Plane Option Set'

--- a/src/stores/DetailsForm/types.ts
+++ b/src/stores/DetailsForm/types.ts
@@ -67,6 +67,11 @@ export interface DetailsFormState
 
     dataPlaneOptions: DataPlaneOption[];
     setDataPlaneOptions: (value: DetailsFormState['dataPlaneOptions']) => void;
+    existingDataPlaneOption: { [prefix: string]: DataPlaneOption };
+    setExistingDataPlaneOption: (
+        prefix: string | undefined,
+        value: DataPlaneOption | undefined
+    ) => void;
 
     errorsExist: boolean;
 

--- a/src/stores/DetailsForm/types.ts
+++ b/src/stores/DetailsForm/types.ts
@@ -67,11 +67,8 @@ export interface DetailsFormState
 
     dataPlaneOptions: DataPlaneOption[];
     setDataPlaneOptions: (value: DetailsFormState['dataPlaneOptions']) => void;
-    existingDataPlaneOption: { [prefix: string]: DataPlaneOption };
-    setExistingDataPlaneOption: (
-        prefix: string | undefined,
-        value: DataPlaneOption | undefined
-    ) => void;
+    existingDataPlaneOption: DataPlaneOption | undefined;
+    setExistingDataPlaneOption: (value: DataPlaneOption | undefined) => void;
 
     errorsExist: boolean;
 

--- a/src/stores/Workflow/useWorkflowHydrator.ts
+++ b/src/stores/Workflow/useWorkflowHydrator.ts
@@ -1,23 +1,15 @@
-import type { DataPlaneOption } from 'src/stores/DetailsForm/types';
-
 import { useCallback } from 'react';
 
 import { getSingleConnectorWithTag } from 'src/api/connectors';
-import { getDataPlaneOptions } from 'src/api/dataPlanes';
 import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'src/hooks/searchParams/useGlobalSearchParams';
 import { logRocketConsole, logRocketEvent } from 'src/services/shared';
 import { CustomEvents } from 'src/services/types';
-import { useDetailsFormStore } from 'src/stores/DetailsForm/Store';
 import { useDetailsFormHydrator } from 'src/stores/DetailsForm/useDetailsFormHydrator';
 import { useEndpointConfigHydrator } from 'src/stores/EndpointConfig/useEndpointConfigHydrator';
 import { useEntitiesStore } from 'src/stores/Entities/Store';
 import { useWorkflowStore } from 'src/stores/Workflow/Store';
-import {
-    generateDataPlaneOption,
-    getDataPlaneInfo,
-} from 'src/utils/dataPlane-utils';
 import { hasLength } from 'src/utils/misc-utils';
 
 export const useWorkflowHydrator = (expressWorkflow: boolean | undefined) => {
@@ -25,8 +17,6 @@ export const useWorkflowHydrator = (expressWorkflow: boolean | undefined) => {
 
     const { hydrateDetailsForm } = useDetailsFormHydrator();
     const { hydrateEndpointConfig } = useEndpointConfigHydrator();
-
-    const storageMappings = useEntitiesStore((state) => state.storageMappings);
 
     const baseCatalogPrefix = useEntitiesStore((state) => {
         const storageMappingPrefixes = Object.keys(state.storageMappings);
@@ -47,11 +37,6 @@ export const useWorkflowHydrator = (expressWorkflow: boolean | undefined) => {
     const setHydrationErrorsExist = useWorkflowStore(
         (state) => state.setHydrationErrorsExist
     );
-
-    const [setDataPlaneOptions, setHydrationError_details] =
-        useDetailsFormStore((state) => {
-            return [state.setDataPlaneOptions, state.setHydrationError];
-        });
 
     const hydrateWorkflow = useCallback(async () => {
         const { data: connectorMetadata, error: connectorError } =
@@ -87,66 +72,6 @@ export const useWorkflowHydrator = (expressWorkflow: boolean | undefined) => {
                 connectorTagId,
                 connectorMetadata[0].connector_tags
             );
-
-            const { dataPlaneNames } = getDataPlaneInfo(
-                storageMappings,
-                baseEntityName
-            );
-            const defaultDataPlaneName = dataPlaneNames.at(0);
-
-            // GO fetch all the data plane options the user can see
-            const dataPlaneResponse = await getDataPlaneOptions();
-
-            let dataPlaneOptions: DataPlaneOption[] = [];
-            if (
-                !dataPlaneResponse.error &&
-                dataPlaneResponse.data &&
-                dataPlaneResponse.data.length > 0
-            ) {
-                // If we got a response then go ahead and map those options
-                dataPlaneOptions = dataPlaneResponse.data.map((dataPlane) =>
-                    generateDataPlaneOption(dataPlane, defaultDataPlaneName)
-                );
-            } else {
-                setHydrationError_details(
-                    dataPlaneResponse.error?.message ??
-                        'An error was encountered initializing the details form. If the issue persists, please contact support.'
-                );
-                return Promise.reject(dataPlaneResponse.error);
-            }
-
-            // Now step through all the storage mappings so we can hack in data planes the user might be missing
-            Object.values(storageMappings).forEach((storageMapping) => {
-                if (!storageMapping.data_planes) {
-                    return;
-                }
-
-                storageMapping.data_planes.forEach((dataPlaneName) => {
-                    if (
-                        dataPlaneOptions.findIndex(
-                            (datum) =>
-                                datum.dataPlaneName.whole === dataPlaneName
-                        ) === -1
-                    ) {
-                        // We are missing a data plane so generate a fake one
-                        dataPlaneOptions.push(
-                            generateDataPlaneOption(
-                                {
-                                    data_plane_name: dataPlaneName,
-                                    id: dataPlaneName,
-                                    reactor_address: '',
-                                    cidr_blocks: null,
-                                    gcp_service_account_email: null,
-                                    aws_iam_user_arn: null,
-                                },
-                                dataPlaneName
-                            )
-                        );
-                    }
-                });
-            });
-
-            setDataPlaneOptions(dataPlaneOptions);
         } catch (error: unknown) {
             return Promise.reject(error);
         }
@@ -160,9 +85,6 @@ export const useWorkflowHydrator = (expressWorkflow: boolean | undefined) => {
         hydrateDetailsForm,
         hydrateEndpointConfig,
         setConnectorMetadata,
-        setDataPlaneOptions,
-        setHydrationError_details,
-        storageMappings,
     ]);
 
     return {


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1690

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1689

## Changes

### 1689

The following features are included in this PR:

* Use `ops/dp/public/gcp-us-central1-c2` as the fallback, public data-plane.

### 1690

The following features are included in this PR:

* changes...

* changes...

## Tests

### Manually tested

Approaches to testing are as follows:
-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_
