### PR TITLE
Use fallback, public data-plane as default for support

### DIFF
--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -92,10 +92,10 @@ export const useEvaluateDataPlaneOptions = () => {
                     const defaultDataPlaneName =
                         existingDataPlane?.data_plane_name
                             ? existingDataPlane.data_plane_name
-                            : matchedDataPlaneNames.length > 0
-                              ? matchedDataPlaneNames[0]
-                              : hasSupportRole
-                                ? `${DATA_PLANE_SETTINGS.public.prefix}${defaultDataPlaneSuffix}`
+                            : hasSupportRole
+                              ? `${DATA_PLANE_SETTINGS.public.prefix}${defaultDataPlaneSuffix}`
+                              : matchedDataPlaneNames.length > 0
+                                ? matchedDataPlaneNames[0]
                                 : dataPlaneNames.at(0);
 
                     return generateDataPlaneOption(

--- a/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
+++ b/src/hooks/dataPlanes/useEvaluateDataPlaneOptions.ts
@@ -3,8 +3,10 @@ import { useCallback } from 'react';
 import { uniq } from 'lodash';
 
 import { getDataPlaneOptions } from 'src/api/dataPlanes';
+import { useUserInfoSummaryStore } from 'src/context/UserInfoSummary/useUserInfoSummaryStore';
 import { logRocketEvent } from 'src/services/shared';
 import { CustomEvents } from 'src/services/types';
+import { DATA_PLANE_SETTINGS } from 'src/settings/dataPlanes';
 import { useDetailsFormStore } from 'src/stores/DetailsForm/Store';
 import { useEntitiesStore } from 'src/stores/Entities/Store';
 import { useWorkflowStore } from 'src/stores/Workflow/Store';
@@ -12,6 +14,7 @@ import {
     generateDataPlaneOption,
     getDataPlaneInfo,
 } from 'src/utils/dataPlane-utils';
+import { defaultDataPlaneSuffix } from 'src/utils/env-utils';
 
 export const useEvaluateDataPlaneOptions = () => {
     const setDataPlaneOptions = useDetailsFormStore(
@@ -22,6 +25,10 @@ export const useEvaluateDataPlaneOptions = () => {
     );
 
     const storageMappings = useEntitiesStore((state) => state.storageMappings);
+
+    const hasSupportRole = useUserInfoSummaryStore(
+        (state) => state.hasSupportAccess
+    );
 
     const setStorageMappingPrefix = useWorkflowStore(
         (state) => state.setStorageMappingPrefix
@@ -87,7 +94,9 @@ export const useEvaluateDataPlaneOptions = () => {
                             ? existingDataPlane.data_plane_name
                             : matchedDataPlaneNames.length > 0
                               ? matchedDataPlaneNames[0]
-                              : dataPlaneNames.at(0);
+                              : hasSupportRole
+                                ? `${DATA_PLANE_SETTINGS.public.prefix}${defaultDataPlaneSuffix}`
+                                : dataPlaneNames.at(0);
 
                     return generateDataPlaneOption(
                         existingDataPlane ?? {
@@ -147,6 +156,7 @@ export const useEvaluateDataPlaneOptions = () => {
             return evaluatedDataPlaneOptions;
         },
         [
+            hasSupportRole,
             setDataPlaneOptions,
             setExistingDataPlaneOption,
             setStorageMappingPrefix,

--- a/src/hooks/dataPlanes/useGetDataPlane.ts
+++ b/src/hooks/dataPlanes/useGetDataPlane.ts
@@ -2,6 +2,7 @@ import type { DataPlaneOption, Details } from 'src/stores/DetailsForm/types';
 
 import { useCallback } from 'react';
 
+import { useUserInfoSummaryStore } from 'src/context/UserInfoSummary/useUserInfoSummaryStore';
 import { logRocketEvent } from 'src/services/shared';
 import { CustomEvents } from 'src/services/types';
 import { DATA_PLANE_SETTINGS } from 'src/settings/dataPlanes';
@@ -10,6 +11,10 @@ import { defaultDataPlaneSuffix } from 'src/utils/env-utils';
 function useGetDataPlane() {
     // TODO (data planes) - don't want the options being passed in. Need to store those off
     // const [dataPlaneOptions] = useEntitiesStore((state) => [state.dataPlanes]);
+
+    const hasSupportRole = useUserInfoSummaryStore(
+        (state) => state.hasSupportAccess
+    );
 
     return useCallback(
         (
@@ -25,8 +30,11 @@ function useGetDataPlane() {
             }
 
             // Use the default data-plane specified by the storage mapping.
-            const defaultDataPlaneOption = dataPlaneOptions.find(
-                (option) => option.isDefault
+            const defaultDataPlaneOption = dataPlaneOptions.find((option) =>
+                hasSupportRole
+                    ? option.dataPlaneName.whole ===
+                      `${DATA_PLANE_SETTINGS.public.prefix}${defaultDataPlaneSuffix}`
+                    : option.isDefault
             );
 
             if (
@@ -69,7 +77,7 @@ function useGetDataPlane() {
 
             return defaultOption ?? null;
         },
-        []
+        [hasSupportRole]
     );
 }
 


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1697

## Changes

### 1697

The following features are included in this PR:

* Default the data-plane selector in create workflows to the fallback, public data-plane (i.e., `ops/dp/public/gcp-us-central1-c2`) for users with the **support-role**.

## Tests

### Manually tested

Approaches to testing are as follows:
-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_Screenshot(s) intentionally omitted to protect sensitive information._
