### PR TITLE
Need to clone these objects before updating them so re-renders happen

### DIFF
--- a/src/components/capture/useAutoDiscovery.ts
+++ b/src/components/capture/useAutoDiscovery.ts
@@ -2,7 +2,7 @@ import type { Schema } from 'src/types';
 
 import { useCallback, useEffect, useRef } from 'react';
 
-import { debounce } from 'lodash';
+import { cloneDeep, debounce } from 'lodash';
 import { useUnmount } from 'react-use';
 
 import { modifyDraftSpec } from 'src/api/draftSpecs';
@@ -62,7 +62,7 @@ function useAutoDiscovery() {
         if (!mutateDraftSpecs || !draftId || draftSpecs.length === 0) {
             return Promise.reject();
         } else {
-            const spec: Schema = draftSpecs[0].spec;
+            const spec: Schema = cloneDeep(draftSpecs[0].spec);
 
             spec.autoDiscover = autoDiscover
                 ? {

--- a/src/hooks/captureInterval/useCaptureInterval.ts
+++ b/src/hooks/captureInterval/useCaptureInterval.ts
@@ -2,7 +2,7 @@ import type { Schema } from 'src/types';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { debounce, omit } from 'lodash';
+import { cloneDeep, debounce, omit } from 'lodash';
 import { useUnmount } from 'react-use';
 
 import { modifyDraftSpec } from 'src/api/draftSpecs';
@@ -21,6 +21,9 @@ import { formatCaptureInterval } from 'src/utils/time-utils';
 import { DEFAULT_DEBOUNCE_WAIT } from 'src/utils/workflow-utils';
 import { CAPTURE_INTERVAL_RE } from 'src/validation';
 
+// TODO (capture interval) - this feature does not support two way data binding
+//  with the editor. Needs to be added when we convert this over to the new
+//  draftUpdater approach.
 export default function useCaptureInterval() {
     // Binding Store
     const captureInterval = useBindingStore((state) => state.captureInterval);
@@ -59,7 +62,7 @@ export default function useCaptureInterval() {
                 return Promise.resolve();
             }
 
-            let spec: Schema = draftSpec.spec;
+            let spec: Schema = cloneDeep(draftSpec.spec);
             const originalInterval = draftSpec.spec?.interval;
 
             if (!hasLength(interval)) {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1701

## Changes

### 1701

- closing the spec before updating on captureInterval and autoDiscovery

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
