### PR TITLE
Collection Reset - do not update unless backfilled

### DIFF
--- a/src/components/editor/Bindings/Backfill/useUpdateBackfillCounter.ts
+++ b/src/components/editor/Bindings/Backfill/useUpdateBackfillCounter.ts
@@ -4,6 +4,7 @@ import type { BindingMetadata, Schema } from 'src/types';
 
 import { useCallback } from 'react';
 
+import { cloneDeep } from 'lodash';
 import { useIntl } from 'react-intl';
 
 import { modifyDraftSpec } from 'src/api/draftSpecs';
@@ -96,7 +97,7 @@ function useUpdateBackfillCounter() {
                     ? 'counterIncremented'
                     : 'counterDecremented';
 
-            const spec: Schema = draftSpec.spec;
+            const spec: Schema = cloneDeep(draftSpec.spec);
 
             if (bindingMetadataExists) {
                 bindingMetadata.forEach(({ bindingIndex, collection }) => {

--- a/src/components/shared/Entity/Actions/useSave.ts
+++ b/src/components/shared/Entity/Actions/useSave.ts
@@ -290,7 +290,8 @@ function useSave(
                         return;
                     }
 
-                    // If it is not being backfill we do not need to update
+                    // If it is not being backfill we do not need to update. This is important for when
+                    //  a user has run a re-discover and they have a bunch of collections on their draft
                     if (
                         !collectionsBeingBackfilled.includes(
                             draftSpec.catalog_name

--- a/src/components/shared/Entity/Actions/useSave.ts
+++ b/src/components/shared/Entity/Actions/useSave.ts
@@ -281,6 +281,7 @@ function useSave(
             const collectionsToUpdate: any[] = [];
             if (collectionsOnDraft) {
                 collectionsOnDraft.forEach((draftSpec) => {
+                    // If we are removing it we do not need to update
                     if (
                         collectionsBeingRemovedFromDraft.includes(
                             draftSpec.catalog_name
@@ -289,6 +290,16 @@ function useSave(
                         return;
                     }
 
+                    // If it is not being backfill we do not need to update
+                    if (
+                        !collectionsBeingBackfilled.includes(
+                            draftSpec.catalog_name
+                        )
+                    ) {
+                        return;
+                    }
+
+                    // If the spec is not already marked for reset go ahead and do it now
                     if (draftSpec.spec.reset !== true) {
                         collectionsToUpdate.push({
                             catalog_name: draftSpec.catalog_name,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1708

## Changes

### 1708

- Add a check that the collection should be backfilled
- Add a `cloneDeep` to make backfill changes show in editor

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
