### PR TITLE
prod: correct table queries on admin settings tab

### DIFF
--- a/src/api/alerts.ts
+++ b/src/api/alerts.ts
@@ -155,7 +155,7 @@ const getNotificationSubscriptionsForTable = (
         supabaseClient
             .from(TABLES.ALERT_SUBSCRIPTIONS)
             .select(`id, updated_at, catalog_prefix, email`)
-            .like('catalog_prefix', `${catalogPrefix}*`),
+            .like('catalog_prefix', `${catalogPrefix}%`),
         ['catalog_prefix', 'email'],
         searchQuery,
         sorting,

--- a/src/api/storageMappings.ts
+++ b/src/api/storageMappings.ts
@@ -31,7 +31,7 @@ const getStorageMappings = (
             updated_at
         `
             )
-            .like('catalog_prefix', `${catalogPrefix}*`),
+            .like('catalog_prefix', `${catalogPrefix}%`),
         [],
         searchQuery,
         sorting,


### PR DESCRIPTION
## Changes

* Replace the `*` character with the `%` character in the `like` pattern for the _Organization Notifications_ and _Cloud Storage_ table queries.

**NOTE:** This change should not result in any new behavior; it is purely syntactical. It was alleged to be a source of Postgres statement timeouts for the support role but, in practice, that is not the case.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_N/A_
