### PR TITLE
Travjenkins/feature/update reset default for dekaf

### DIFF
--- a/src/components/editor/Bindings/Backfill/BackfillButton.tsx
+++ b/src/components/editor/Bindings/Backfill/BackfillButton.tsx
@@ -29,11 +29,13 @@ import {
     useBinding_setBackfilledBindings,
 } from 'src/stores/Binding/hooks';
 import { useBindingStore } from 'src/stores/Binding/Store';
+import { useDetailsFormStore } from 'src/stores/DetailsForm/Store';
 import {
     useFormStateStore_isActive,
     useFormStateStore_setFormState,
 } from 'src/stores/FormState/hooks';
 import { FormStatus } from 'src/stores/FormState/types';
+import { isDekafConnector } from 'src/utils/connector-utils';
 import { hasLength } from 'src/utils/misc-utils';
 
 function BackfillButton({
@@ -60,6 +62,10 @@ function BackfillButton({
     const backfilledBindings = useBinding_backfilledBindings();
     const setBackfilledBindings = useBinding_setBackfilledBindings();
     const backfillSupported = useBinding_backfillSupported();
+
+    const editingDekaf = useDetailsFormStore((state) =>
+        isDekafConnector(state.details?.data?.connectorImage)
+    );
 
     const setCollectionMetadata = useBindingStore(
         (state) => state.setCollectionMetadata
@@ -164,7 +170,13 @@ function BackfillButton({
                             ? currentBindingUUID
                             : undefined;
 
-                        setBackfilledBindings(increment, targetBindingUUID);
+                        setBackfilledBindings(
+                            // Dekaf has issues with collection reset and RARELY will users actually
+                            //  want to do it
+                            editingDekaf ? 'incremental' : 'reset',
+                            increment,
+                            targetBindingUUID
+                        );
 
                         if (workflow === 'materialization_edit') {
                             evaluateTrialCollections(
@@ -203,6 +215,7 @@ function BackfillButton({
             currentBindingUUID,
             currentCollection,
             draftSpec,
+            editingDekaf,
             evaluateServerDifferences,
             evaluateTrialCollections,
             setBackfilledBindings,

--- a/src/hooks/useServerUpdateRequiredMonitor.ts
+++ b/src/hooks/useServerUpdateRequiredMonitor.ts
@@ -31,7 +31,7 @@ const useServerUpdateRequiredMonitor = (draftSpecs: DraftSpecQuery[]) => {
                     ([collection, bindingUUIDs]) => {
                         return bindingUUIDs.some((bindingUUID) => {
                             const expectedBindingIndex =
-                                resourceConfigs[bindingUUID].meta.bindingIndex;
+                                resourceConfigs[bindingUUID]?.meta.bindingIndex;
 
                             if (expectedBindingIndex > -1) {
                                 const binding =

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -371,10 +371,20 @@ export const useBinding_backfillSupported = () =>
 export const useBinding_collectionsBeingBackfilled = () =>
     useBindingStore(
         useShallow((state) => {
-            return state.backfilledBindings.map((backfilledBinding) => {
-                return state.resourceConfigs[backfilledBinding].meta
-                    .collectionName;
-            });
+            return (
+                state.backfilledBindings
+                    // There is a chance that during rehydration that the resourceConfigs will be
+                    //  empty for a little bit. This happens during materialization when a user marks
+                    //  things for backfill, edits the endpoint config, and generates a new catalog.Z
+                    .filter((datum) =>
+                        Boolean(state.resourceConfigs?.[datum]?.meta)
+                    )
+                    .map(
+                        (backfilledBinding) =>
+                            state.resourceConfigs[backfilledBinding].meta
+                                .collectionName
+                    )
+            );
         })
     );
 

--- a/src/stores/Binding/slices/Backfill.ts
+++ b/src/stores/Binding/slices/Backfill.ts
@@ -22,6 +22,7 @@ export interface StoreWithBackfill {
     backfilledBindings: string[];
     backfillAllBindings: boolean;
     setBackfilledBindings: (
+        defaultBackfillValue: BackfillMode,
         increment: BooleanString,
         targetBindingUUID?: string
     ) => void;
@@ -81,7 +82,11 @@ export const getStoreWithBackfillSettings = (
         );
     },
 
-    setBackfilledBindings: (increment, targetBindingUUID) => {
+    setBackfilledBindings: (
+        defaultBackfillMode,
+        increment,
+        targetBindingUUID
+    ) => {
         set(
             produce((state: BindingState) => {
                 const existingBindingUUIDs = Object.keys(state.resourceConfigs);
@@ -109,7 +114,7 @@ export const getStoreWithBackfillSettings = (
                     increment === 'true' &&
                     state.backfillMode === null
                 ) {
-                    state.backfillMode = 'reset';
+                    state.backfillMode = defaultBackfillMode;
                 }
             }),
             false,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1715

## Changes

### 1715

- Prevent the app failing when editing a materialization, marking backfill, editing config, and then clicking `Next`

## Tests

### Manually tested

- Edit materializations
- Edit captures

### Automated tests

- N/A

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
