### PR TITLE
No longer use sticky columns for field selection table

### DIFF
--- a/src/components/tables/EntityTable/TableHeader.tsx
+++ b/src/components/tables/EntityTable/TableHeader.tsx
@@ -6,7 +6,11 @@ import { ArrowDown } from 'iconoir-react';
 import { FormattedMessage } from 'react-intl';
 
 import { TABLE_HEADER_CELL_CLASS_PREFIX } from 'src/components/tables/EntityTable/shared';
-import { getStickyTableCell, zIndexIncrement } from 'src/context/Theme';
+import {
+    getStickyTableCell,
+    wrappingTableBodyHeader,
+    zIndexIncrement,
+} from 'src/context/Theme';
 import { getTableComponents } from 'src/utils/table-utils';
 
 function EntityTableHeader({
@@ -57,6 +61,12 @@ function EntityTableHeader({
                     if (column.sticky) {
                         tableCellSX = {
                             ...getStickyTableCell(true),
+                        };
+                    }
+
+                    if (column.columnWraps) {
+                        tableCellSX = {
+                            ...wrappingTableBodyHeader,
                         };
                     }
 

--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -17,7 +17,7 @@ import {
 } from 'src/components/tables/FieldSelection/shared';
 import {
     doubleElevationHoverBackground,
-    getStickyTableCell,
+    wrappingTableBodyCell,
 } from 'src/context/Theme';
 import { useBinding_currentBindingUUID } from 'src/stores/Binding/hooks';
 import { basicSort_string } from 'src/utils/misc-utils';
@@ -45,7 +45,7 @@ function Row({ columns, row }: RowProps) {
                 },
             }}
         >
-            <TableCell sx={getStickyTableCell()}>
+            <TableCell sx={wrappingTableBodyCell}>
                 <Typography>{row.field}</Typography>
             </TableCell>
 

--- a/src/components/tables/FieldSelection/Rows.tsx
+++ b/src/components/tables/FieldSelection/Rows.tsx
@@ -50,7 +50,7 @@ function Row({ columns, row }: RowProps) {
             </TableCell>
 
             {pointerColumnVisible ? (
-                <TableCell>
+                <TableCell sx={wrappingTableBodyCell}>
                     <Typography>{row.ptr}</Typography>
                 </TableCell>
             ) : null}

--- a/src/components/tables/FieldSelection/shared.ts
+++ b/src/components/tables/FieldSelection/shared.ts
@@ -14,12 +14,17 @@ export const tableColumns: TableColumns[] = [
     {
         field: 'field',
         headerIntlKey: 'data.field',
-        sticky: true,
+        columnWraps: true,
     },
-    { field: 'ptr', headerIntlKey: optionalColumnIntlKeys.pointer },
+    {
+        field: 'ptr',
+        headerIntlKey: optionalColumnIntlKeys.pointer,
+        collapseHeader: true,
+    },
     {
         field: null,
         headerIntlKey: 'data.type',
+        collapseHeader: true,
     },
     {
         field: 'constraint.type',

--- a/src/components/tables/FieldSelection/shared.ts
+++ b/src/components/tables/FieldSelection/shared.ts
@@ -19,7 +19,7 @@ export const tableColumns: TableColumns[] = [
     {
         field: 'ptr',
         headerIntlKey: optionalColumnIntlKeys.pointer,
-        collapseHeader: true,
+        columnWraps: true,
     },
     {
         field: null,

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -758,6 +758,25 @@ export const getStickyTableCell = (headerParent?: boolean): SxProps<Theme> => {
     };
 };
 
+export const wrappingTableCell = {
+    wordWrap: 'break-word',
+    // WARNING - the min width work as you might expect. The max width does NOT
+    //  It looks and feels good but the cell will for sure grow larger than just 300px
+    //  even though that is what the styling says.
+    minWidth: 10,
+    maxWidth: 400,
+};
+
+export const wrappingTableBodyCell: SxProps<Theme> = {
+    ...wrappingTableCell,
+    background: (theme) => tableCellBackground[theme.palette.mode],
+};
+
+export const wrappingTableBodyHeader: SxProps<Theme> = {
+    ...wrappingTableCell,
+    background: (theme) => theme.palette.background.default,
+};
+
 // RGB translation of #CA3B55.
 export const errorOutlinedButtonBackground = {
     light: `rgba(202, 59, 85, 0.12)`,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -355,6 +355,7 @@ export interface TableColumns {
     cols?: number;
     display?: string;
     flexGrow?: boolean;
+    columnWraps?: boolean;
     headerIntlKey?: string | null;
     minWidth?: number | string;
     sticky?: boolean;


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1720

## Changes

### 1720

- Remove the sticky column styling as it causes issues on super long field names

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### wide view and short content
<img width="1778" height="585" alt="image" src="https://github.com/user-attachments/assets/f09aeeac-e20a-4c78-9fdc-479b33057adb" />

### narrow view and short content
<img width="678" height="562" alt="image" src="https://github.com/user-attachments/assets/ee7e3fcd-3b00-4f28-bf4e-f8e7941eb4c3" />
<img width="759" height="619" alt="image" src="https://github.com/user-attachments/assets/4e3e9c2f-2725-4f2c-ae4f-b0e6c77c1fce" />

### Longer field names will now wrap
<img width="1626" height="650" alt="image" src="https://github.com/user-attachments/assets/3bb81c6f-646a-423d-b918-0ad0be0cc72d" />
