### PR TITLE
Enable data-plane selection when configuring storage mapping

### DIFF
--- a/src/api/dataPlanes.ts
+++ b/src/api/dataPlanes.ts
@@ -41,7 +41,10 @@ const COLUMNS = [
 
 const QUERY = COLUMNS.join(',');
 
-const getDataPlaneOptions = async (dataPlaneNames?: string[]) => {
+const getDataPlaneOptions = async (
+    dataPlaneNames?: string[],
+    prefix?: string
+) => {
     let queryBuilder = supabaseClient
         .from(TABLES.DATA_PLANES)
         .select(QUERY)
@@ -49,6 +52,12 @@ const getDataPlaneOptions = async (dataPlaneNames?: string[]) => {
 
     if (dataPlaneNames && dataPlaneNames.length > 0) {
         queryBuilder = queryBuilder.in('data_plane_name', dataPlaneNames);
+    }
+
+    if (prefix && prefix.length > 0) {
+        queryBuilder = queryBuilder.or(
+            `data_plane_name.like.%/public/%,data_plane_name.like.%/private/${prefix}%`
+        );
     }
 
     const data = await supabaseRetry(
@@ -98,4 +107,4 @@ const getDataPlanesForTable = (
 //     return data;
 // };
 
-export { getDataPlanesForTable, getDataPlaneOptions };
+export { getDataPlaneOptions, getDataPlanesForTable };

--- a/src/components/admin/Settings/StorageMappings/Dialog/Content.tsx
+++ b/src/components/admin/Settings/StorageMappings/Dialog/Content.tsx
@@ -1,7 +1,13 @@
-import { Box, DialogContent, Typography } from '@mui/material';
+import type { DataPlaneOption } from 'src/stores/DetailsForm/types';
+
+import { useEffect, useState } from 'react';
+
+import { Box, DialogContent, Skeleton, Stack, Typography } from '@mui/material';
 
 import { FormattedMessage } from 'react-intl';
 
+import { getDataPlaneOptions } from 'src/api/dataPlanes';
+import DataPlaneSelector from 'src/components/admin/Settings/StorageMappings/Dialog/DataPlaneSelector';
 import RepublicationError from 'src/components/admin/Settings/StorageMappings/Dialog/Error';
 import StorageMappingForm from 'src/components/admin/Settings/StorageMappings/Dialog/Form';
 import RepublicationLogs from 'src/components/admin/Settings/StorageMappings/Dialog/Logs';
@@ -10,7 +16,11 @@ import { REPUBLICATION_FAILURE_MESSAGE_ID } from 'src/components/admin/Settings/
 import { useStorageMappingStore } from 'src/components/admin/Settings/StorageMappings/Store/create';
 import Error from 'src/components/shared/Error';
 import ErrorBoundryWrapper from 'src/components/shared/ErrorBoundryWrapper';
+import { BASE_ERROR } from 'src/services/supabase';
+import { DATA_PLANE_SETTINGS } from 'src/settings/dataPlanes';
 import { useTenantStore } from 'src/stores/Tenant/Store';
+import { generateDataPlaneOption } from 'src/utils/dataPlane-utils';
+import { defaultDataPlaneSuffix } from 'src/utils/env-utils';
 
 function StorageMappingContent() {
     const selectedTenant = useTenantStore((state) => state.selectedTenant);
@@ -18,6 +28,63 @@ function StorageMappingContent() {
     const logToken = useStorageMappingStore((state) => state.logToken);
     const provider = useStorageMappingStore((state) => state.provider);
     const serverError = useStorageMappingStore((state) => state.serverError);
+    const setDataPlaneName = useStorageMappingStore(
+        (state) => state.setDataPlaneName
+    );
+    const setServerError = useStorageMappingStore(
+        (state) => state.setServerError
+    );
+
+    const [dataPlaneOptions, setDataPlaneOptions] = useState<
+        DataPlaneOption[] | null
+    >(null);
+
+    useEffect(() => {
+        getDataPlaneOptions(undefined, selectedTenant).then(
+            (response) => {
+                // TODO: Determine whether this is worthy of an alert.
+                if (!response.data) {
+                    setServerError({
+                        ...BASE_ERROR,
+                        message: 'data-plane options not found',
+                    });
+
+                    setDataPlaneOptions([]);
+
+                    return;
+                }
+
+                const formattedData = response.data.map((datum) =>
+                    generateDataPlaneOption(datum)
+                );
+
+                if (formattedData.length === 1) {
+                    setDataPlaneName(formattedData[0].dataPlaneName.whole);
+                } else {
+                    const defaultDataPlaneOption =
+                        formattedData.find(
+                            (option) => option.scope === 'private'
+                        ) ??
+                        formattedData.find(
+                            (option) =>
+                                option.dataPlaneName.whole ===
+                                `${DATA_PLANE_SETTINGS.public.prefix}${defaultDataPlaneSuffix}`
+                        ) ??
+                        formattedData[0];
+
+                    setDataPlaneName(
+                        defaultDataPlaneOption.dataPlaneName.whole
+                    );
+                }
+
+                setDataPlaneOptions(formattedData);
+            },
+            (error) => {
+                setDataPlaneOptions([]);
+                setServerError(error);
+            }
+        );
+    }, [selectedTenant, setDataPlaneName, setDataPlaneOptions, setServerError]);
 
     return (
         <DialogContent sx={{ mt: 1 }}>
@@ -41,8 +108,10 @@ function StorageMappingContent() {
                     errored={serverError !== null}
                     token={logToken}
                 />
-            ) : (
-                <>
+            ) : dataPlaneOptions !== null ? (
+                <Stack spacing={2}>
+                    <DataPlaneSelector options={dataPlaneOptions} />
+
                     <ProviderSelector />
 
                     {provider ? (
@@ -50,7 +119,12 @@ function StorageMappingContent() {
                             <StorageMappingForm />
                         </ErrorBoundryWrapper>
                     ) : null}
-                </>
+                </Stack>
+            ) : (
+                <Stack spacing={2}>
+                    <Skeleton height={45} />
+                    <Skeleton height={27} />
+                </Stack>
             )}
         </DialogContent>
     );

--- a/src/components/admin/Settings/StorageMappings/Dialog/DataPlaneSelector.tsx
+++ b/src/components/admin/Settings/StorageMappings/Dialog/DataPlaneSelector.tsx
@@ -1,0 +1,174 @@
+import type { DataPlaneSelectorProps } from 'src/components/admin/Settings/StorageMappings/types';
+
+import { useMemo, useState } from 'react';
+
+import {
+    Autocomplete,
+    Box,
+    FormControl,
+    InputLabel,
+    MenuList,
+    Stack,
+    Typography,
+} from '@mui/material';
+
+import { isArray } from 'lodash';
+import { useIntl } from 'react-intl';
+
+import { useStorageMappingStore } from 'src/components/admin/Settings/StorageMappings/Store/create';
+import DataPlaneIcon from 'src/components/shared/Entity/DataPlaneIcon';
+import { defaultOutline_hovered } from 'src/context/Theme';
+import AutoCompleteInputWithStartAdornment from 'src/forms/renderers/AutoCompleteInputWithStartAdornment';
+import Option from 'src/forms/renderers/DataPlaneSelector/Option';
+
+const DataPlaneSelector = ({ options }: DataPlaneSelectorProps) => {
+    const intl = useIntl();
+
+    const dataPlaneName = useStorageMappingStore(
+        (state) => state.dataPlaneName
+    );
+    const setDataPlaneName = useStorageMappingStore(
+        (state) => state.setDataPlaneName
+    );
+
+    const [inputValue, setInputValue] = useState('');
+
+    const currentOption = useMemo(
+        () =>
+            options.find(
+                (option) => option.dataPlaneName.whole === dataPlaneName
+            ),
+        [dataPlaneName, options]
+    );
+
+    return (
+        <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel>
+                {intl.formatMessage({
+                    id: 'data.dataPlane',
+                })}
+            </InputLabel>
+
+            <Autocomplete
+                autoComplete
+                clearOnBlur
+                disableClearable
+                fullWidth
+                getOptionLabel={(option) => option.dataPlaneName.whole}
+                groupBy={(option) => option.scope}
+                inputValue={inputValue}
+                onChange={(_event: any, value) => {
+                    setDataPlaneName(value.dataPlaneName.whole);
+                }}
+                onInputChange={(_event, newInputValue) => {
+                    setInputValue(newInputValue);
+                }}
+                renderGroup={({ group, children }) =>
+                    children === null ||
+                    (isArray(children) &&
+                        children.some((node) => node !== null)) ? (
+                        <li key={group}>
+                            <Typography
+                                color="primary"
+                                sx={{
+                                    backgroundColor: (theme) =>
+                                        theme.palette.background.paper,
+                                    fontWeight: 500,
+                                    pl: 1,
+                                    py: 1,
+                                    textTransform: 'capitalize',
+                                }}
+                            >
+                                {intl.formatMessage({ id: `common.${group}` })}
+                            </Typography>
+
+                            <MenuList style={{ padding: 0 }}>
+                                {children}
+                            </MenuList>
+                        </li>
+                    ) : null
+                }
+                renderInput={(textFieldProps) => {
+                    return (
+                        <AutoCompleteInputWithStartAdornment
+                            textFieldProps={textFieldProps}
+                            startAdornment={
+                                currentOption ? (
+                                    <Stack
+                                        direction="row"
+                                        spacing={1}
+                                        sx={{
+                                            alignItems: 'center',
+                                        }}
+                                    >
+                                        {currentOption.dataPlaneName.prefix ? (
+                                            <Box
+                                                sx={{
+                                                    borderRight: (theme) =>
+                                                        defaultOutline_hovered[
+                                                            theme.palette.mode
+                                                        ],
+                                                    fontsize: 9,
+                                                    pr: 1,
+                                                }}
+                                            >
+                                                {
+                                                    currentOption.dataPlaneName
+                                                        .prefix
+                                                }
+                                            </Box>
+                                        ) : null}
+
+                                        <DataPlaneIcon
+                                            provider={
+                                                currentOption.dataPlaneName
+                                                    .provider
+                                            }
+                                            scope={currentOption.scope}
+                                        />
+                                    </Stack>
+                                ) : null
+                            }
+                        />
+                    );
+                }}
+                renderOption={(renderOptionProps, option) => {
+                    return (
+                        <Option
+                            renderOptionProps={renderOptionProps}
+                            option={{
+                                label: option.dataPlaneName.whole,
+                                value: option,
+                            }}
+                            key={option.id}
+                        />
+                    );
+                }}
+                slotProps={{
+                    popper: {
+                        sx: {
+                            '& .MuiAutocomplete-listbox': {
+                                p: 0,
+                            },
+                        },
+                    },
+                }}
+                sx={{
+                    mt: 2,
+                }}
+                options={(options ?? []).sort((a, b) => {
+                    if (a.scope === b.scope) {
+                        return a.dataPlaneName.whole.localeCompare(
+                            b.dataPlaneName.whole
+                        );
+                    }
+
+                    return a.scope === 'public' ? 1 : -1;
+                })}
+                value={currentOption}
+            />
+        </FormControl>
+    );
+};
+
+export default DataPlaneSelector;

--- a/src/components/admin/Settings/StorageMappings/Dialog/ProviderSelector.tsx
+++ b/src/components/admin/Settings/StorageMappings/Dialog/ProviderSelector.tsx
@@ -1,6 +1,6 @@
 import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import { CloudProviderCodes } from 'src/components/admin/Settings/StorageMappings/Dialog/useConfigurationSchema';
 import { useStorageMappingStore } from 'src/components/admin/Settings/StorageMappings/Store/create';
@@ -22,7 +22,9 @@ function ProviderSelector() {
     return (
         <FormControl fullWidth sx={{ mb: 2 }}>
             <InputLabel id={INPUT_ID}>
-                <FormattedMessage id="storageMappings.provider.label" />
+                {intl.formatMessage({
+                    id: 'storageMappings.provider.label',
+                })}
             </InputLabel>
 
             <Select
@@ -42,9 +44,9 @@ function ProviderSelector() {
             >
                 {Object.keys(CloudProviderCodes).map((code) => (
                     <MenuItem key={code} value={code}>
-                        <FormattedMessage
-                            id={`storageMappings.dialog.generate.providerOption.${code}`}
-                        />
+                        {intl.formatMessage({
+                            id: `storageMappings.dialog.generate.providerOption.${code}`,
+                        })}
                     </MenuItem>
                 ))}
             </Select>

--- a/src/components/admin/Settings/StorageMappings/Store/create.ts
+++ b/src/components/admin/Settings/StorageMappings/Store/create.ts
@@ -12,8 +12,15 @@ import { devtoolsOptions } from 'src/utils/store-utils';
 
 const getInitialStateData = (): Pick<
     StorageMappingState,
-    'formValue' | 'logToken' | 'provider' | 'pubId' | 'saving' | 'serverError'
+    | 'dataPlaneName'
+    | 'formValue'
+    | 'logToken'
+    | 'provider'
+    | 'pubId'
+    | 'saving'
+    | 'serverError'
 > => ({
+    dataPlaneName: '',
     formValue: { data: {} },
     logToken: '',
     provider: null,
@@ -30,6 +37,36 @@ const getInitialState = (
 
     resetState: () => {
         set(getInitialStateData(), false, 'State reset');
+    },
+
+    setDataPlaneName: (value) => {
+        set(
+            produce((state: StorageMappingState) => {
+                state.dataPlaneName = value;
+            }),
+            false,
+            'Data-plane name set'
+        );
+    },
+
+    setLogToken: (value) => {
+        set(
+            produce((state: StorageMappingState) => {
+                state.logToken = value;
+            }),
+            false,
+            'Publication log token set'
+        );
+    },
+
+    setPubId: (value) => {
+        set(
+            produce((state: StorageMappingState) => {
+                state.pubId = value;
+            }),
+            false,
+            'Publication ID set'
+        );
     },
 
     setSaving: (value) => {
@@ -52,26 +89,6 @@ const getInitialState = (
             }),
             false,
             'Server error set'
-        );
-    },
-
-    setLogToken: (value) => {
-        set(
-            produce((state: StorageMappingState) => {
-                state.logToken = value;
-            }),
-            false,
-            'Publication log token set'
-        );
-    },
-
-    setPubId: (value) => {
-        set(
-            produce((state: StorageMappingState) => {
-                state.pubId = value;
-            }),
-            false,
-            'Publication ID set'
         );
     },
 

--- a/src/components/admin/Settings/StorageMappings/Store/types.ts
+++ b/src/components/admin/Settings/StorageMappings/Store/types.ts
@@ -3,23 +3,19 @@ import type { CloudProviderCodes } from 'src/components/admin/Settings/StorageMa
 import type { JsonFormsData } from 'src/types';
 
 export interface StorageMappingState {
-    provider: CloudProviderCodes | null;
-    updateProvider: (value: CloudProviderCodes) => void;
-
+    dataPlaneName: string;
     formValue: JsonFormsData;
-    updateFormValue: (value: JsonFormsData) => void;
-
-    pubId: string;
-    setPubId: (value: string) => void;
-
     logToken: string;
-    setLogToken: (value: string) => void;
-
+    provider: CloudProviderCodes | null;
+    pubId: string;
     saving: boolean;
-    setSaving: (value: boolean) => void;
-
     serverError: PostgrestError | null;
-    setServerError: (value: PostgrestError | string | null) => void;
-
     resetState: () => void;
+    setDataPlaneName: (value: StorageMappingState['dataPlaneName']) => void;
+    setLogToken: (value: string) => void;
+    setPubId: (value: string) => void;
+    setSaving: (value: boolean) => void;
+    setServerError: (value: PostgrestError | string | null) => void;
+    updateFormValue: (value: JsonFormsData) => void;
+    updateProvider: (value: CloudProviderCodes) => void;
 }

--- a/src/components/admin/Settings/StorageMappings/types.ts
+++ b/src/components/admin/Settings/StorageMappings/types.ts
@@ -1,0 +1,5 @@
+import type { DataPlaneOption } from 'src/stores/DetailsForm/types';
+
+export interface DataPlaneSelectorProps {
+    options: DataPlaneOption[];
+}

--- a/src/lang/en-US/AdminPage.ts
+++ b/src/lang/en-US/AdminPage.ts
@@ -149,7 +149,7 @@ export const AdminPage: Record<string, string> = {
     'storageMappingsTable.message2': `We couldn't find any results matching your search. Please try a different filter.`,
     'storageMappings.status.active': `Primary`,
     'storageMappings.prefix.description': `The Flow prefix you want to configure`,
-    'storageMappings.provider.label': `Provider`,
+    'storageMappings.provider.label': `Provider *`,
     'storageMappings.provider.description': `The provider (ex: S3, GCP) you are using`,
     'storageMappings.bucket.label': `Bucket`,
     'storageMappings.bucket.description': `The name of the bucket you have setup to store data in.`,


### PR DESCRIPTION
## Issues

The issues directly below are advanced by this PR:
https://github.com/estuary/ui/issues/1700

## Changes

### 1700

The following features are included in this PR:

* Display a data-plane selector in the _Configure Storage_ dialog that enables the selection of a **single** data-plane.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
