### PR TITLE
Moving all GitPod settings into a JSON object

### DIFF
--- a/src/components/transformation/create/GitPodButton.tsx
+++ b/src/components/transformation/create/GitPodButton.tsx
@@ -181,8 +181,6 @@ function GitPodButton({
                 return generateGitPodURL(
                     evaluatedDraftId,
                     token.data,
-                    language,
-                    sourceCollectionSet ?? sourceCollectionArray,
                     catalogName
                 );
             } catch (e: unknown) {
@@ -197,15 +195,7 @@ function GitPodButton({
                 setUrlLoading(false);
             }
         },
-        [
-            catalogName,
-            displayError,
-            generateDraftWithSpecs,
-            intl,
-            language,
-            sourceCollectionArray,
-            sourceCollectionSet,
-        ]
+        [catalogName, displayError, generateDraftWithSpecs, intl]
     );
 
     return (

--- a/src/services/gitpod.ts
+++ b/src/services/gitpod.ts
@@ -4,8 +4,7 @@ import type { RefreshTokenData } from 'src/types';
 import { isArray } from 'lodash';
 
 const GIT_POD_URL = `https://gitpod.io/#`;
-const GIT_REPO =
-    'https://github.com/estuary/flow-gitpod-base/tree/travjenkins/bug/read-from-json';
+const GIT_REPO = 'https://github.com/estuary/flow-gitpod-base';
 const GIT_REPO_PATH = `/${GIT_REPO}`; // Must start with a slash to separate it from the variables
 
 // WARNING GitPod can change the URL format at anytime

--- a/src/services/gitpod.ts
+++ b/src/services/gitpod.ts
@@ -3,11 +3,14 @@ import type { RefreshTokenData } from 'src/types';
 
 import { isArray } from 'lodash';
 
-const GIT_REPO = 'https://github.com/estuary/flow-gitpod-base';
+const GIT_POD_URL = `https://gitpod.io/#`;
+const GIT_REPO =
+    'https://github.com/estuary/flow-gitpod-base/tree/travjenkins/bug/read-from-json';
+const GIT_REPO_PATH = `/${GIT_REPO}`; // Must start with a slash to separate it from the variables
 
 // WARNING GitPod can change the URL format at anytime
-// https://www.gitpod.io/docs/configure/repositories/environment-variables#providing-one-time-environment-variables-via-the-context-url
-//  Last verified Q4 2024
+// https://www.gitpod.io/docs/classic/user/configure/workspaces/environment-variables#one-time-environment-variables-via-context-url
+//  Last verified Q3 2025
 export const generateGitPodURL = (
     draftId: string,
     token: RefreshTokenData,
@@ -19,18 +22,21 @@ export const generateGitPodURL = (
         ? sourceCollections.length
         : sourceCollections.size;
 
-    const gitPodURL = `https://gitpod.io/#`;
+    // https://github.com/estuary/flow-gitpod-base/blob/main/init.sh
+    // This object is consumed by GitPod init.sh and has to stay in sync
+    const settingsPart = `FLOW_SETTINGS=${encodeURIComponent(
+        Buffer.from(
+            JSON.stringify({
+                id: draftId,
+                rt: token,
 
-    const urlVariables = `FLOW_DRAFT_ID=${encodeURIComponent(
-        draftId
-    )},FLOW_REFRESH_TOKEN=${encodeURIComponent(
-        Buffer.from(JSON.stringify(token)).toString('base64')
-    )},FLOW_TEMPLATE_TYPE=${derivationLanguage},FLOW_TEMPLATE_MODE=${
-        sourceCollectionCount > 1 ? 'multi' : 'single'
-    },FLOW_COLLECTION_NAME=${encodeURIComponent(computedEntityName)}`;
+                // TODO - (GitPod) These all seem unused in the script but need to double check
+                dl: derivationLanguage,
+                tt: sourceCollectionCount > 1 ? 'multi' : 'single',
+                cn: computedEntityName,
+            })
+        ).toString('base64')
+    )}`;
 
-    // Must start with a slash to separate it from the variables
-    const gitRepoPath = `/${GIT_REPO}`;
-
-    return `${gitPodURL}${urlVariables}${gitRepoPath}`;
+    return `${GIT_POD_URL}${settingsPart}${GIT_REPO_PATH}`;
 };

--- a/src/services/gitpod.ts
+++ b/src/services/gitpod.ts
@@ -1,8 +1,6 @@
 import { Buffer } from 'buffer';
 import type { RefreshTokenData } from 'src/types';
 
-import { isArray } from 'lodash';
-
 const GIT_POD_URL = `https://gitpod.io/#`;
 const GIT_REPO = 'https://github.com/estuary/flow-gitpod-base';
 const GIT_REPO_PATH = `/${GIT_REPO}`; // Must start with a slash to separate it from the variables
@@ -13,29 +11,21 @@ const GIT_REPO_PATH = `/${GIT_REPO}`; // Must start with a slash to separate it 
 export const generateGitPodURL = (
     draftId: string,
     token: RefreshTokenData,
-    derivationLanguage: string,
-    sourceCollections: Set<string> | string[],
     computedEntityName: string
 ) => {
-    const sourceCollectionCount = isArray(sourceCollections)
-        ? sourceCollections.length
-        : sourceCollections.size;
-
     // https://github.com/estuary/flow-gitpod-base/blob/main/init.sh
     // This object is consumed by GitPod init.sh and has to stay in sync
-    const settingsPart = `FLOW_SETTINGS=${encodeURIComponent(
+    const settingsPart = `F_S=${encodeURIComponent(
         Buffer.from(
             JSON.stringify({
                 id: draftId,
                 rt: token,
-
-                // TODO - (GitPod) These all seem unused in the script but need to double check
-                dl: derivationLanguage,
-                tt: sourceCollectionCount > 1 ? 'multi' : 'single',
-                cn: computedEntityName,
             })
         ).toString('base64')
     )}`;
 
-    return `${GIT_POD_URL}${settingsPart}${GIT_REPO_PATH}`;
+    // Adding a bit of unique value here - this is not consumed by the workspace
+    const uniqueProps = `ENTITY=${encodeURIComponent(computedEntityName)}`;
+
+    return `${GIT_POD_URL}${uniqueProps},${settingsPart}${GIT_REPO_PATH}`;
 };


### PR DESCRIPTION
Merge at the same time as - https://github.com/estuary/flow-gitpod-base/pull/20

## Issues

https://github.com/estuary/ui/issues/1727

## Changes

### 1727

- moved all the data needed into a single JSON object
- cleaned up data that was not being used
- kept the collection name for some unique feeling and make the UX nicer with the URL

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

New URL with params
<img width="2098" height="683" alt="image" src="https://github.com/user-attachments/assets/e8d00da8-e2cc-4c9f-afdf-a5dc5d8f4b48" />

Able to start up
<img width="957" height="286" alt="image" src="https://github.com/user-attachments/assets/7364c4dc-d0e0-4063-b4c7-4fc0eddfd3f1" />

