### PR TITLE
Set form status quickly and do not await function in click handlers

### DIFF
--- a/src/components/capture/GenerateButton.tsx
+++ b/src/components/capture/GenerateButton.tsx
@@ -77,15 +77,13 @@ function CaptureGenerateButton({
         selectedConnectorId,
     ]);
 
-    const processFormData = async (event: React.MouseEvent<HTMLElement>) => {
-        event.preventDefault();
-
-        await generateCatalog(event);
-    };
-
     return (
         <Button
-            onClick={processFormData}
+            onClick={(event) => {
+                event.preventDefault();
+
+                void generateCatalog();
+            }}
             disabled={disabled || isSaving || formActive}
             sx={entityHeaderButtonSx}
         >

--- a/src/components/capture/RediscoverButton.tsx
+++ b/src/components/capture/RediscoverButton.tsx
@@ -34,7 +34,7 @@ function RediscoverButton({ entityType, disabled }: Props) {
             <Box>
                 <IconButton
                     disabled={disable}
-                    onClick={generateCatalog}
+                    onClick={() => void generateCatalog()}
                     sx={{ borderRadius: 0 }}
                     aria-label={intl.formatMessage({
                         id: 'workflows.collectionSelector.cta.rediscover',

--- a/src/components/materialization/GenerateButton.tsx
+++ b/src/components/materialization/GenerateButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mui/material';
 
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import { useEditorStore_isSaving } from 'src/components/editor/Store/hooks';
 import useGenerateCatalog from 'src/components/materialization/useGenerateCatalog';
@@ -13,6 +13,7 @@ interface Props {
 }
 
 function MaterializeGenerateButton({ disabled }: Props) {
+    const intl = useIntl();
     const generateCatalog = useGenerateCatalog();
     const isSaving = useEditorStore_isSaving();
     const formActive = useFormStateStore_isActive();
@@ -20,13 +21,13 @@ function MaterializeGenerateButton({ disabled }: Props) {
 
     return (
         <Button
-            onClick={async () => {
-                await generateCatalog(mutateDraftSpecs);
+            onClick={() => {
+                void generateCatalog(mutateDraftSpecs);
             }}
             disabled={disabled || isSaving || formActive}
             sx={entityHeaderButtonSx}
         >
-            <FormattedMessage id="cta.generateCatalog.materialization" />
+            {intl.formatMessage({ id: 'cta.generateCatalog.materialization' })}
         </Button>
     );
 }

--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -33,8 +33,8 @@ function EntityCreateSave({
         <Button
             disabled={disabled || isSaving || formActive}
             sx={entityHeaderButtonSx}
-            onClick={async () => {
-                await save(draftId);
+            onClick={() => {
+                void save(draftId);
             }}
         >
             {intl.formatMessage({

--- a/src/components/shared/Entity/Actions/useSave.ts
+++ b/src/components/shared/Entity/Actions/useSave.ts
@@ -436,6 +436,10 @@ function useSave(
 
     return useCallback(
         async (draftId: string | null, hideLogs?: boolean) => {
+            setFormState({
+                status: FormStatus.PROCESSING,
+            });
+
             // FullSource updates the draft directly and does not require a new generation so
             //  need to check for errors. We might want to add all the errors here just to be safe or
             //  in the future when we directly update drafts

--- a/src/stores/FormState/Store.ts
+++ b/src/stores/FormState/Store.ts
@@ -27,7 +27,10 @@ const formActive = (status: FormStatus) => {
         status === FormStatus.SAVED ||
         // This is like 'saved' but a bit different. With PreSavePrompt we need a way to make sure the user
         //  never is able to get back out of that ever
-        status === FormStatus.LOCKED
+        status === FormStatus.LOCKED ||
+        // Used while the form is processing stuff. Right now only used in useSave for the time between the
+        //  button click and the actual test/save starts. If you set to testing or saving the logs show
+        status === FormStatus.PROCESSING
     );
 };
 

--- a/src/stores/FormState/types.ts
+++ b/src/stores/FormState/types.ts
@@ -42,6 +42,9 @@ export enum FormStatus {
 
     // USE WITH CAUTION - only for prompts right now (Q3 2024)
     LOCKED = 'LOCKED',
+
+    // Used when clicking test/save but the actual test/save has not started yet
+    PROCESSING = 'PROCESSING',
 }
 
 export interface EntityFormState {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1733

## Changes

### 1733

- Stop using `await` in the onclick handler as this means the click handler will not let anything else run until it is done :facepalm: 
- Set the status from within the click handler to allow it to update as fast as possible

## Tests

### Manually tested

- Clicking Next, Test, Save, and Rediscover on Captures
- Clicking Next, Test, Save, and Refresh Field Select on Materializations

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
