### PR TITLE
Clean up data flow reset

### DIFF
--- a/src/api/draftSpecs.ts
+++ b/src/api/draftSpecs.ts
@@ -4,6 +4,8 @@ import type {
     DraftSpecData,
     DraftSpecsExtQuery_BySpecTypeReduced,
     DraftSpecUpdateMatchData,
+    MassCreateDraftSpecsData,
+    MassUpdateMatchData,
 } from 'src/api/types';
 import type { DraftSpecQuery } from 'src/hooks/useDraftSpecs';
 import type { Entity } from 'src/types';
@@ -51,7 +53,7 @@ export const createDraftSpec = (
 export const massCreateDraftSpecs = async (
     draftId: string,
     specType: Entity,
-    specs: any[]
+    specs: MassCreateDraftSpecsData[]
 ) => {
     if (specs.length > 0) {
         const limiter = pLimit(3);
@@ -95,7 +97,7 @@ export const massCreateDraftSpecs = async (
 export const massUpdateDraftSpecs = async (
     draftId: string,
     specType: Entity,
-    specs: any[]
+    specs: MassUpdateMatchData[]
 ) => {
     if (specs.length > 0) {
         const limiter = pLimit(3);
@@ -185,8 +187,7 @@ export const getDraftSpecsBySpecType = async (
 
 export const getDraftSpecsBySpecTypeReduced = async (
     draftId: string,
-    specType: Entity,
-    fetchSpec?: boolean
+    specType: Entity
 ) => {
     const responses = await pagedFetchAll<DraftSpecsExtQuery_BySpecTypeReduced>(
         DEFAULT_PAGING_SIZE,
@@ -194,9 +195,7 @@ export const getDraftSpecsBySpecTypeReduced = async (
         (start) =>
             supabaseClient
                 .from(TABLES.DRAFT_SPECS_EXT)
-                .select(
-                    `draft_id,catalog_name,spec_type${fetchSpec ? ',spec' : ''}`
-                )
+                .select(`draft_id,catalog_name,spec_type,spec`)
                 .eq('draft_id', draftId)
                 .eq('spec_type', specType)
                 .range(start, start + DEFAULT_PAGING_SIZE - 1)

--- a/src/api/liveSpecsExt.ts
+++ b/src/api/liveSpecsExt.ts
@@ -331,11 +331,18 @@ const getLiveSpecsByCatalogNames = async (
         index = index + CHUNK_SIZE;
     }
 
-    const res = await Promise.all(promises);
+    const responses = await Promise.all(promises);
 
-    const errors = res.filter((r) => r.error);
-
-    return errors[0] ?? res[0];
+    return {
+        responses: responses
+            .filter((r) => r.data)
+            .map((r) => r.data)
+            .flat(1),
+        errors: responses
+            .filter((r) => r.error)
+            .map((r) => r.error)
+            .flat(1),
+    };
 };
 
 const getLiveSpecsByConnectorId = async (

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -81,5 +81,16 @@ export interface DraftSpecsExtQuery_BySpecTypeReduced {
     draft_id: string;
     catalog_name: string;
     spec_type: string;
-    spec?: any;
+    spec: any;
+}
+
+export interface MassUpdateMatchData {
+    catalog_name: string;
+    spec: any;
+}
+
+export interface MassCreateDraftSpecsData {
+    catalog_name: string;
+    expect_pub_id: string;
+    spec: any;
 }

--- a/src/components/editor/Bindings/Backfill/ModeSelector/index.tsx
+++ b/src/components/editor/Bindings/Backfill/ModeSelector/index.tsx
@@ -7,10 +7,12 @@ import AutocompletedField from 'src/components/shared/toolbar/AutocompletedField
 import useBackfillModeOptions from 'src/hooks/bindings/useBackfillModeOptions';
 import { useBinding_backfilledBindings_count } from 'src/stores/Binding/hooks';
 import { useBindingStore } from 'src/stores/Binding/Store';
+import { useFormStateStore_isActive } from 'src/stores/FormState/hooks';
 
 function BackfillModeSelector({ disabled }: BackfillModeSelectorProps) {
     const intl = useIntl();
     const backfillCount = useBinding_backfilledBindings_count();
+    const formActive = useFormStateStore_isActive();
 
     const [setBackfillMode] = useBindingStore((state) => [
         state.setBackfillMode,
@@ -35,6 +37,7 @@ function BackfillModeSelector({ disabled }: BackfillModeSelectorProps) {
             }}
             autocompleteSx={{ flexGrow: 1 }}
             AutoCompleteOptions={{
+                disabled: formActive,
                 isOptionEqualToValue,
                 renderOption: (renderOptionProps, option: any) => {
                     return (

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -63,7 +63,7 @@ export const Workflows: Record<string, string> = {
 
     'workflows.collectionSelector.footer.backfilled': `backfilled: {calculatedCount}`,
     'workflows.collectionSelector.footer.backfilled.all': `all backfilled`,
-    'workflows.collectionSelector.footer.backfilled.empty': ` `,
+    'workflows.collectionSelector.footer.backfilled.empty': `-`,
 
     'workflows.collectionSelector.schemaEdit.cta.syncSchema': `Synchronize Schema`,
     'workflows.collectionSelector.schemaEdit.header': `CLI`,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1741

## Changes

### 1741

- Clean up hanging `reset` values if the flag is changed after the collections are added to the draft
- Make sure we return all the live specs when fetching them

## Tests

### Manually tested

- Materialization edit with ~350 bindings
    - backfill
    - data flow reset
- Materialization create

### Automated tests

- n/a

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

## Clean up
### running `test` with data flow reset updates all the drafts 
<img width="2559" height="1278" alt="image" src="https://github.com/user-attachments/assets/a91cfa98-9c00-4e19-beb8-ca901dc2c62c" />

### running `test` with backfill updates drafts to remove reset
<img width="2555" height="1291" alt="image" src="https://github.com/user-attachments/assets/875f5ccd-1ade-46a7-b1da-32e03b72c433" />



