### PR TITLE
package.json: bump flow-web 0.5.18 => 0.5.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@dnd-kit/utilities": "^3.2.1",
                 "@emotion/react": "^11.11.1",
                 "@emotion/styled": "^11.11.0",
-                "@estuary/flow-web": "^0.5.18",
+                "@estuary/flow-web": "^0.5.19",
                 "@jsonforms/core": "^3.2.1",
                 "@jsonforms/material-renderers": "^3.2.1",
                 "@jsonforms/react": "^3.2.1",
@@ -1227,9 +1227,9 @@
             }
         },
         "node_modules/@estuary/flow-web": {
-            "version": "0.5.18",
-            "resolved": "https://npm.pkg.github.com/download/@estuary/flow-web/0.5.18/37b9412890d8c747b25028aa0616c8d340baa4f5",
-            "integrity": "sha512-1LRcCgiktIT16a1Ne1RyK6g1HSMJRDyWcky2hb3mUXcABaYkyvhqhyCffJ3CmazXbUZJnxnXNMVX/tlwnN94YQ==",
+            "version": "0.5.19",
+            "resolved": "https://npm.pkg.github.com/download/@estuary/flow-web/0.5.19/5d8b6215813b199e825e1ccf243d0aa5a84b689b",
+            "integrity": "sha512-+swsuTOf8aZKRkcvcZYYC6NfdierXTnWooXjHEQLiMJimiFO7jDkV/Xyh7J/Sy42je2TlGA7Vb2SIa1QEvJdhw==",
             "license": "BSL"
         },
         "node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@estuary/flow-web": "^0.5.18",
+        "@estuary/flow-web": "^0.5.19",
         "@jsonforms/core": "^3.2.1",
         "@jsonforms/material-renderers": "^3.2.1",
         "@jsonforms/react": "^3.2.1",


### PR DESCRIPTION
Support protocol and JSON-Schema enhancements for the redaction feature. No material changes to crate behavior yet. This update simply keeps it from panic-ing on encountering the new feature.