### PR TITLE
PROD: Fix the wrong index used on bindings

### DIFF
--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -1008,8 +1008,11 @@ const getInitialState = (
                             return;
                         }
 
-                        let liveBuiltBindingIndex = builtSpec
-                            ? getBuiltBindingIndex(builtSpec, collectionName)
+                        let liveBuiltBindingIndex = liveBuiltSpec
+                            ? getBuiltBindingIndex(
+                                  liveBuiltSpec,
+                                  collectionName
+                              )
                             : -1;
 
                         const liveBuiltBinding =


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1755

## Changes

### 1755

-  Fixing a small copy and paste issue

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

N/A
