### PR TITLE
Sharing access can lead to infinite loading when the call fails

### DIFF
--- a/src/app/guards/hooks.ts
+++ b/src/app/guards/hooks.ts
@@ -42,7 +42,6 @@ const useDirectiveGuard = (
             return null;
         }
 
-        setServerError(error ?? null);
         if (error) {
             return 'errored';
         }
@@ -60,6 +59,10 @@ const useDirectiveGuard = (
         options?.token,
         serverError,
     ]);
+
+    useEffect(() => {
+        setServerError(error ?? null);
+    }, [error]);
 
     // The memo above was getting called more often than planned and I think it might have
     //  been part of https://github.com/estuary/ui/issues/999. So the thinking here is that


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1759

## Changes

### 1759

- Should have never set state inside the memo :facepalm: 

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

<img width="2530" height="1267" alt="image" src="https://github.com/user-attachments/assets/43d23eb8-4713-4df2-8a53-65b4c452feec" />

legal - network error
<img width="2560" height="1301" alt="image" src="https://github.com/user-attachments/assets/8bc1245b-26d7-4a4e-b587-8e281c4853d0" />

Legal - working
<img width="2559" height="761" alt="image" src="https://github.com/user-attachments/assets/aaa79199-815e-4a43-867a-b15e8fb20007" />


Tenant - network error
<img width="2558" height="1301" alt="image" src="https://github.com/user-attachments/assets/434c599c-ea76-4ca6-a0d2-6d0dc848ad2c" />

Tenant - name taken
<img width="2559" height="1293" alt="image" src="https://github.com/user-attachments/assets/21ceee29-2473-404f-ba90-dc181f241439" />

Tenant - working
<img width="2557" height="711" alt="image" src="https://github.com/user-attachments/assets/4f5cb7ed-69a2-4dda-b8bc-143c745fc14f" />
