### PR TITLE
Disable nginx version disclosure in error responses

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -34,6 +34,9 @@ http {
     # disable content-type sniffing on some browsers.
     add_header X-Content-Type-Options nosniff;
 
+    # Server tokens off to hide nginx version number
+    server_tokens off;
+
     # Enable gzip
     gzip on;
     gzip_min_length  500;
@@ -61,7 +64,7 @@ http {
             # just use the request id for right now
             # need to generate a true one
             set $cspNonce $request_id;
-            
+
             # Put the nonce into the html response
             sub_filter_once off;
             sub_filter_types *;
@@ -81,7 +84,7 @@ http {
             # Log Rocket - https://docs.logrocket.com/docs/troubleshooting-sessions#due-to-content-security-policy
             # Stripe - https://docs.stripe.com/security/guide#content-security-policy
             # BE CAREFUL WHEN EDITING
-            #   This is all pretty brittle 
+            #   This is all pretty brittle
             #   Most things are on a single line because adding new lines broke it in prod somehow
 
             add_header Content-Security-Policy "


### PR DESCRIPTION
## Issues

https://github.com/estuary/security/issues/453

## Summary
Disables nginx version information from being displayed in HTTP error responses to address security finding from penetration testing.
Changes

Added `server_tokens off;` directive to nginx configuration
Prevents nginx version (1.29.1) from being exposed in 404/error pages

## Security Issue Addressed
Our pen testers identified that error responses were leaking the nginx version in response bodies. While this is a low-risk information disclosure issue, it provides unnecessary reconnaissance data to potential attackers who could:

- Identify if we're running a vulnerable version
- Tailor exploits to the specific nginx version
- Combine this info with other potential weaknesses