### PR TITLE
Enable the configuration of `groupBy` in materialization workflows

### DIFF
--- a/src/components/fieldSelection/FieldActions/GroupByKeys/SaveButton.tsx
+++ b/src/components/fieldSelection/FieldActions/GroupByKeys/SaveButton.tsx
@@ -1,0 +1,39 @@
+import type { BaseProps } from 'src/components/fieldSelection/types';
+
+import { Button } from '@mui/material';
+
+import { useIntl } from 'react-intl';
+
+import { useBindingStore } from 'src/stores/Binding/Store';
+import { useFormStateStore_isActive } from 'src/stores/FormState/hooks';
+import { hasLength } from 'src/utils/misc-utils';
+
+const SaveButton = ({ bindingUUID, loading, selections }: BaseProps) => {
+    const intl = useIntl();
+
+    const setSingleGroupBy = useBindingStore((state) => state.setSingleGroupBy);
+
+    const formActive = useFormStateStore_isActive();
+
+    return (
+        <Button
+            disabled={loading || formActive || !hasLength(selections)}
+            onClick={() => {
+                if (!selections) {
+                    // TODO: display error.
+
+                    return;
+                }
+
+                setSingleGroupBy(bindingUUID, []);
+            }}
+            size="small"
+            style={{ textWrap: 'nowrap' }}
+            variant="outlined"
+        >
+            {intl.formatMessage({ id: 'cta.evolve' })}
+        </Button>
+    );
+};
+
+export default SaveButton;

--- a/src/components/fieldSelection/FieldActions/GroupByKeys/index.tsx
+++ b/src/components/fieldSelection/FieldActions/GroupByKeys/index.tsx
@@ -1,0 +1,125 @@
+import type { BaseProps } from 'src/components/fieldSelection/types';
+
+import { useState } from 'react';
+
+import {
+    Autocomplete,
+    Box,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
+
+import { arrayMove } from '@dnd-kit/sortable';
+import { useIntl } from 'react-intl';
+
+import SaveButton from 'src/components/fieldSelection/FieldActions/GroupByKeys/SaveButton';
+import SortableTags from 'src/components/schema/KeyAutoComplete/SortableTags';
+
+const TITLE_ID = 'configure-groupBy-keys-title';
+
+const GroupByKeys = ({ bindingUUID, loading, selections }: BaseProps) => {
+    const intl = useIntl();
+
+    const [open, setOpen] = useState(false);
+
+    const [localCopyValue, setLocalCopyValue] = useState<string[]>([]);
+
+    return (
+        <>
+            <Button
+                onClick={() => {
+                    setOpen(true);
+                }}
+                variant="outlined"
+            >
+                {intl.formatMessage({ id: 'fieldSelection.cta.groupBy' })}
+            </Button>
+
+            <Dialog
+                open={open}
+                maxWidth="md"
+                fullWidth
+                aria-labelledby={TITLE_ID}
+            >
+                <DialogTitle>
+                    {intl.formatMessage({
+                        id: 'fieldSelection.groupBy.header',
+                    })}
+                </DialogTitle>
+
+                <DialogContent>
+                    <Typography style={{ marginBottom: 24 }}>
+                        {intl.formatMessage({
+                            id: 'fieldSelection.groupBy.description',
+                        })}
+                    </Typography>
+
+                    <Autocomplete
+                        multiple
+                        options={selections?.map(({ field }) => field) ?? []}
+                        renderInput={(params) => {
+                            return <TextField {...params} variant="standard" />;
+                        }}
+                        renderTags={(tagValues, getTagProps, ownerState) => {
+                            return (
+                                <SortableTags
+                                    getTagProps={getTagProps}
+                                    onOrderChange={async (activeId, overId) => {
+                                        const oldIndex =
+                                            localCopyValue.indexOf(activeId);
+                                        const newIndex =
+                                            localCopyValue.indexOf(overId);
+
+                                        const updatedArray = arrayMove<string>(
+                                            localCopyValue,
+                                            oldIndex,
+                                            newIndex
+                                        );
+
+                                        setLocalCopyValue(updatedArray);
+                                        // await changeHandler?.(
+                                        //     null,
+                                        //     updatedArray,
+                                        //     'orderingUpdated'
+                                        // );
+                                    }}
+                                    ownerState={ownerState}
+                                    values={tagValues}
+                                />
+                            );
+                        }}
+                    />
+                </DialogContent>
+
+                <DialogActions>
+                    <Stack direction="row" spacing={1}>
+                        <Button
+                            component={Box}
+                            disabled={loading}
+                            onClick={() => {
+                                setOpen(false);
+                            }}
+                            variant="text"
+                        >
+                            {intl.formatMessage({ id: 'cta.cancel' })}
+                        </Button>
+
+                        <SaveButton
+                            bindingUUID={bindingUUID}
+                            loading={loading}
+                            selections={selections}
+                        />
+                    </Stack>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+};
+
+export default GroupByKeys;

--- a/src/components/tables/FieldSelection/index.tsx
+++ b/src/components/tables/FieldSelection/index.tsx
@@ -12,6 +12,7 @@ import { useUnmount } from 'react-use';
 import { useEditorStore_persistedDraftId } from 'src/components/editor/Store/hooks';
 import AlgorithmMenu from 'src/components/fieldSelection/FieldActions/AlgorithmMenu';
 import ExcludeAllButton from 'src/components/fieldSelection/FieldActions/ExcludeAllButton';
+import GroupByKeys from 'src/components/fieldSelection/FieldActions/GroupByKeys';
 import EntityTableBody from 'src/components/tables/EntityTable/TableBody';
 import EntityTableHeader from 'src/components/tables/EntityTable/TableHeader';
 import FieldFilter from 'src/components/tables/FieldSelection/FieldFilter';
@@ -147,11 +148,23 @@ export default function FieldSelectionTable({
                     justifyContent: 'space-between',
                 }}
             >
-                <AlgorithmMenu
-                    bindingUUID={bindingUUID}
-                    loading={loading}
-                    selections={selections}
-                />
+                <Stack
+                    direction="row"
+                    spacing={1}
+                    sx={{ alignItems: 'center' }}
+                >
+                    <AlgorithmMenu
+                        bindingUUID={bindingUUID}
+                        loading={loading}
+                        selections={selections}
+                    />
+
+                    <GroupByKeys
+                        bindingUUID={bindingUUID}
+                        loading={loading}
+                        selections={selections}
+                    />
+                </Stack>
 
                 <Stack
                     direction="row"

--- a/src/hooks/fieldSelection/useValidateFieldSelection.ts
+++ b/src/hooks/fieldSelection/useValidateFieldSelection.ts
@@ -263,7 +263,8 @@ export default function useValidateFieldSelection() {
                             const updatedSelections = getFieldSelection(
                                 result.outcomes,
                                 fieldStanza,
-                                builtBinding?.collection.projections
+                                builtBinding?.collection.projections,
+                                builtBinding?.collection.key
                             );
 
                             validatedRequests.push({

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -232,6 +232,9 @@ export const Workflows: Record<string, string> = {
     'fieldSelection.outcomeButton.select.header.conflict': `A reason to include this field is:`,
     'fieldSelection.outcomeButton.tooltip': `Click to view outcome`,
     'fieldSelection.outcomeButton.tooltip.conflict': `Click to review conflict`,
+    'fieldSelection.cta.groupBy': `Grouped Keys`,
+    'fieldSelection.groupBy.header': `Configure Grouped Keys`,
+    'fieldSelection.groupBy.description': `Here is a placeholder for a description.`,
 
     // Messages from binding editing
     'updateBinding.error.noBinding': `Unable to update the proper binding. Contact Support.`,

--- a/src/stores/Binding/slices/FieldSelection.ts
+++ b/src/stores/Binding/slices/FieldSelection.ts
@@ -22,8 +22,14 @@ export type SelectionAlgorithm =
     | 'depthTwo'
     | 'depthUnlimited';
 
+export interface GroupKeyMetadata {
+    explicit: boolean;
+    implicit: boolean;
+}
+
 export interface FieldSelection {
     field: string;
+    groupBy: GroupKeyMetadata;
     mode: FieldSelectionType | null;
     outcome: FieldOutcome;
     meta?: Schema;

--- a/src/stores/Binding/slices/FieldSelection.ts
+++ b/src/stores/Binding/slices/FieldSelection.ts
@@ -80,6 +80,7 @@ export interface StoreWithFieldSelection {
         bindingUUIDs: string[],
         serverUpdateFailed?: boolean
     ) => void;
+    setSingleGroupBy: (bindingUUID: string, targetKeys: string[]) => void;
 
     selectionAlgorithm: SelectionAlgorithm | null;
     setSelectionAlgorithm: (
@@ -223,6 +224,29 @@ export const getStoreWithFieldSelectionSettings = (
         );
     },
 
+    setMultiSelection: (bindingUUID, targetFields, targetMode) => {
+        set(
+            produce((state: BindingState) => {
+                const evaluatedStatus = getHydrationStatus(
+                    state.selections[bindingUUID].status
+                );
+
+                state.selections[bindingUUID].hydrating =
+                    isHydrating(evaluatedStatus);
+                state.selections[bindingUUID].status = evaluatedStatus;
+
+                Object.values(state.selections[bindingUUID].value)
+                    .filter(({ field }) => targetFields.includes(field))
+                    .forEach(({ field }) => {
+                        state.selections[bindingUUID].value[field].mode =
+                            targetMode;
+                    });
+            }),
+            false,
+            'Multiple Field Selections Set'
+        );
+    },
+
     setRecommendFields: (bindingUUID, value) => {
         set(
             produce((state: BindingState) => {
@@ -253,26 +277,19 @@ export const getStoreWithFieldSelectionSettings = (
         );
     },
 
-    setMultiSelection: (bindingUUID, targetFields, targetMode) => {
+    setSingleGroupBy: (bindingUUID, targetKeys) => {
         set(
             produce((state: BindingState) => {
-                const evaluatedStatus = getHydrationStatus(
-                    state.selections[bindingUUID].status
+                Object.keys(state.selections[bindingUUID].value).forEach(
+                    (field) => {
+                        state.selections[bindingUUID].value[
+                            field
+                        ].groupBy.explicit = targetKeys.includes(field);
+                    }
                 );
-
-                state.selections[bindingUUID].hydrating =
-                    isHydrating(evaluatedStatus);
-                state.selections[bindingUUID].status = evaluatedStatus;
-
-                Object.values(state.selections[bindingUUID].value)
-                    .filter(({ field }) => targetFields.includes(field))
-                    .forEach(({ field }) => {
-                        state.selections[bindingUUID].value[field].mode =
-                            targetMode;
-                    });
             }),
             false,
-            'Multiple Field Selections Set'
+            'Single GroupBy Set'
         );
     },
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/issue_number

## Changes

### issue_number

-   changes...

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
