### PR TITLE
Prevent submission of alert subscriptions with uncommitted input

### DIFF
--- a/src/components/admin/Settings/PrefixAlerts/Dialog/SaveButton.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/SaveButton.tsx
@@ -29,6 +29,10 @@ function SaveButton({ closeDialog }: Props) {
         selectableTableStoreSelectors.query.hydrate
     );
 
+    const inputUncommitted = useAlertSubscriptionsStore(
+        (state) => state.inputUncommitted
+    );
+
     const prefix = useAlertSubscriptionsStore((state) => state.prefix);
     const prefixErrorsExist = useAlertSubscriptionsStore(
         (state) => state.prefixErrorsExist
@@ -53,8 +57,13 @@ function SaveButton({ closeDialog }: Props) {
 
     const disabled = useMemo(
         () =>
-            Boolean(!hasLength(prefix) || prefixErrorsExist || !subscriptions),
-        [prefix, prefixErrorsExist, subscriptions]
+            Boolean(
+                !hasLength(prefix) ||
+                    prefixErrorsExist ||
+                    !subscriptions ||
+                    inputUncommitted
+            ),
+        [inputUncommitted, prefix, prefixErrorsExist, subscriptions]
     );
 
     const onClick = async (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/admin/Settings/PrefixAlerts/EmailSelector.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/EmailSelector.tsx
@@ -2,7 +2,7 @@ import type { AutocompleteRenderInputParams } from '@mui/material';
 import type { EmailDictionary } from 'src/components/admin/Settings/PrefixAlerts/types';
 import type { Grant_UserExt } from 'src/types';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import {
     Autocomplete,
@@ -17,6 +17,7 @@ import {
 
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import useAlertSubscriptionsStore from 'src/components/admin/Settings/PrefixAlerts/useAlertSubscriptionsStore';
 import UserAvatar from 'src/components/shared/UserAvatar';
 import usePrefixAdministrators from 'src/hooks/usePrefixAdministrators';
 import useUserInformationByPrefix from 'src/hooks/useUserInformationByPrefix';
@@ -68,6 +69,10 @@ function EmailSelector({
 
     const [inputValue, setInputValue] = useState('');
 
+    const setInputUncommitted = useAlertSubscriptionsStore(
+        (state) => state.setInputUncommitted
+    );
+
     const { data: adminPrefixes } = usePrefixAdministrators(
         prefix,
         minCapability
@@ -96,6 +101,11 @@ function EmailSelector({
             ) as Values,
         [emails, userInfo]
     );
+
+    useEffect(() => {
+        setInputUncommitted(inputValue.length > 0);
+    }, [inputValue, setInputUncommitted]);
+
     return (
         <FormControl fullWidth>
             <Autocomplete

--- a/src/components/admin/Settings/PrefixAlerts/useAlertSubscriptionsStore.ts
+++ b/src/components/admin/Settings/PrefixAlerts/useAlertSubscriptionsStore.ts
@@ -17,11 +17,15 @@ interface AlertSubscriptionState {
         subscriptions: AlertSubscriptionState['subscriptions'],
         error: AlertSubscriptionState['initializationError']
     ) => void;
+    inputUncommitted: boolean;
     prefix: string;
     prefixErrorsExist: boolean;
     saveErrors: (PostgrestError | null | undefined)[];
     subscriptions: PrefixSubscriptionDictionary | null | undefined;
     resetState: () => void;
+    setInputUncommitted: (
+        value: AlertSubscriptionState['inputUncommitted']
+    ) => void;
     setSaveErrors: (value: AlertSubscriptionState['saveErrors']) => void;
     setUpdatedEmails: (value: AlertSubscriptionState['updatedEmails']) => void;
     updatePrefix: (value: string, errors: string | null) => void;
@@ -32,6 +36,7 @@ const getInitialState = (): Pick<
     AlertSubscriptionState,
     | 'existingEmails'
     | 'initializationError'
+    | 'inputUncommitted'
     | 'prefix'
     | 'prefixErrorsExist'
     | 'saveErrors'
@@ -40,6 +45,7 @@ const getInitialState = (): Pick<
 > => ({
     existingEmails: {},
     initializationError: null,
+    inputUncommitted: false,
     prefix: '',
     prefixErrorsExist: false,
     saveErrors: [],
@@ -85,6 +91,15 @@ const useAlertSubscriptionsStore = create<AlertSubscriptionState>()(
                 ),
 
             resetState: () => set(getInitialState(), false, 'state reset'),
+
+            setInputUncommitted: (value) =>
+                set(
+                    produce((state: AlertSubscriptionState) => {
+                        state.inputUncommitted = value;
+                    }),
+                    false,
+                    'input uncommitted set'
+                ),
 
             setSaveErrors: (value) =>
                 set(

--- a/src/components/inputs/PrefixedName/PrefixSelector.tsx
+++ b/src/components/inputs/PrefixedName/PrefixSelector.tsx
@@ -51,7 +51,6 @@ function PrefixSelector({
                     required
                     size="small"
                     sx={{
-                        maxWidth: 250,
                         minWidth: 100,
                     }}
                     variant={variantString}


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/issue_number

## Changes

### issue_number

-   changes...

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

_If applicable - please include some screenshots of the new UI_
