### PR TITLE
Enable configuration of `fieldsRecommended` independent of other default settings

### DIFF
--- a/src/components/materialization/source/SourceConfiguration.tsx
+++ b/src/components/materialization/source/SourceConfiguration.tsx
@@ -15,16 +15,18 @@ function SourceConfiguration() {
         sourceCaptureTargetSchemaSupported,
     } = useBinding_sourceCaptureFlags();
 
-    if (
-        !sourceCaptureDeltaUpdatesSupported &&
-        !sourceCaptureTargetSchemaSupported
-    ) {
-        return null;
-    }
-
     return (
         <Stack spacing={1} sx={{ pb: 2, maxWidth: '50%' }}>
-            <Typography variant="formSectionHeader">
+            <Typography
+                variant="formSectionHeader"
+                style={{
+                    marginBottom:
+                        !sourceCaptureDeltaUpdatesSupported &&
+                        !sourceCaptureTargetSchemaSupported
+                            ? 6
+                            : undefined,
+                }}
+            >
                 {intl.formatMessage({
                     id: 'workflows.sourceCapture.optionalSettings.header',
                 })}


### PR DESCRIPTION
## Issues

The issues directly below are completely resolved by this PR:
https://github.com/estuary/ui/issues/1751

## Changes

### 1751

The following features are included in this PR:

* Enable configuration of `fieldsRecommended` independent of delta update and target schema support.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

_N/A_

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

**_Default Collection Settings_ section | Materialization that does not support delta updates nor target schema**

<img width="513" height="66" alt="pr_screenshot-1799-fields_recommended-only_default_setting" src="https://github.com/user-attachments/assets/2979d491-2ea0-4029-8e05-7efa7c97a1f1" />
