### PR TITLE
Already have `val` passed in for `updateOnIncompatibleSchemaChange` so not need to fetch it

### DIFF
--- a/src/components/editor/Bindings/OnIncompatibleSchemaChange/Form.tsx
+++ b/src/components/editor/Bindings/OnIncompatibleSchemaChange/Form.tsx
@@ -52,17 +52,16 @@ function Form({ bindingIndex = -1 }: OnIncompatibleSchemaChangeProps) {
 
     const updateServer = useCallback(
         async (
-            value?: AutoCompleteOptionForIncompatibleSchemaChange | null
+            value?:
+                | AutoCompleteOptionForIncompatibleSchemaChange['val']
+                | undefined
         ) => {
             setFormState({ status: FormStatus.UPDATING, error: null });
 
-            return updateOnIncompatibleSchemaChange(value?.val, bindingMetadata)
+            return updateOnIncompatibleSchemaChange(value, bindingMetadata)
                 .then(() => {
                     if (currentBindingUUID) {
-                        setIncompatibleSchemaChange(
-                            value?.val,
-                            currentBindingUUID
-                        );
+                        setIncompatibleSchemaChange(value, currentBindingUUID);
                     }
 
                     setFormState({ status: FormStatus.UPDATED });


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1789

## Changes

### 1789

- The `val` is already passed in and do not need to fetch from the nesting.

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

<img width="1661" height="1213" alt="image" src="https://github.com/user-attachments/assets/6f568df4-cc99-439b-9326-b27cc6717c7c" />

