### PR TITLE
PROD if `source` missing default for `fieldsRecommended`

### DIFF
--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -327,6 +327,7 @@ export const generateTaskSpec = (
         if (options.defaultFieldsRecommended) {
             const targetSourceProperty = getSourceCapturePropKey(draftSpec);
 
+            draftSpec[targetSourceProperty] ??= {};
             draftSpec[targetSourceProperty].fieldsRecommended = 1;
         }
     }


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1788
https://github.com/estuary/ui/issues/1796

## Changes

### 1796

- default the object so it is always there

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Source/SourceCapture existing
<img width="688" height="533" alt="image" src="https://github.com/user-attachments/assets/1b36f81e-a052-4bef-89c0-025ef2d9ca71" />

<img width="1132" height="978" alt="image" src="https://github.com/user-attachments/assets/395ebf27-8301-4975-8fa2-62b5ca97ca73" />

### Source/SourceCapture not existing
<img width="811" height="519" alt="image" src="https://github.com/user-attachments/assets/28b1d563-b12d-4fea-98f9-9868dd44465d" />

<img width="1148" height="969" alt="image" src="https://github.com/user-attachments/assets/4d1f717c-fb4e-455a-8810-b1f743b78a9f" />
