### PR TITLE
Adding timezone to the alerts history page

### DIFF
--- a/src/components/tables/cells/activeResolved/ActiveCell.tsx
+++ b/src/components/tables/cells/activeResolved/ActiveCell.tsx
@@ -17,7 +17,10 @@ function ActiveCell({ firedAt }: ActiveOrResolvedCellsProps) {
 
         return [
             firedAtDate.toLocaleString(DateTime.DATE_FULL),
-            firedAtDate.toLocaleString(DateTime.TIME_WITH_SECONDS),
+            firedAtDate.toLocaleString({
+                ...DateTime.TIME_WITH_SECONDS,
+                timeZoneName: 'short',
+            }),
             intl.formatMessage(
                 { id: 'alerts.table.firedAt.tooltip' },
                 {

--- a/src/components/tables/cells/activeResolved/ResolvedCell.tsx
+++ b/src/components/tables/cells/activeResolved/ResolvedCell.tsx
@@ -20,7 +20,10 @@ function ResolvedCell({ firedAt, resolvedAt }: ActiveOrResolvedCellsProps) {
 
             return [
                 resolvedAtDate.toLocaleString(DateTime.DATE_FULL),
-                resolvedAtDate.toLocaleString(DateTime.TIME_WITH_SECONDS),
+                resolvedAtDate.toLocaleString({
+                    ...DateTime.TIME_WITH_SECONDS,
+                    timeZoneName: 'short',
+                }),
                 intl.formatMessage(
                     { id: 'alerts.table.resolvedAt.tooltip' },
                     {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1803

## Changes

### 1803

- add the timezone

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

<img width="1400" height="760" alt="image" src="https://github.com/user-attachments/assets/d61e969a-a6e8-4cfc-a7aa-815e2baf2433" />

