### PR TITLE
Handling when a field has no types

### DIFF
--- a/src/components/projections/Edit/ProjectionList.tsx
+++ b/src/components/projections/Edit/ProjectionList.tsx
@@ -20,6 +20,7 @@ import { snackbarSettings } from 'src/utils/notification-utils';
 //   The form state store does not exist outside of workflows and thus its
 //   actions cannot be called in any collection schema table-related components.
 export const ProjectionList = ({
+    cannotExist,
     collection,
     editable,
     maxChips,
@@ -54,107 +55,118 @@ export const ProjectionList = ({
                         <Tooltip
                             placement="bottom-start"
                             title={
-                                metadata?.systemDefined
+                                cannotExist
                                     ? intl.formatMessage({
-                                          id: 'projection.tooltip.systemDefinedField',
+                                          id: 'projection.tooltip.cannotExist',
                                       })
-                                    : ''
+                                    : metadata?.systemDefined
+                                      ? intl.formatMessage({
+                                            id: 'projection.tooltip.systemDefinedField',
+                                        })
+                                      : ''
                             }
                         >
-                            <OutlinedChip
-                                diminishedText={Boolean(
-                                    metadata?.systemDefined && list.length > 1
-                                )}
-                                disabled={deletionQueue.includes(
-                                    metadata.field
-                                )}
-                                label={metadata.field}
-                                onDelete={
-                                    editable && !metadata?.systemDefined
-                                        ? async () => {
-                                              setDeletionQueue(
-                                                  deletionQueue.concat(
+                            <span>
+                                <OutlinedChip
+                                    diminishedText={Boolean(
+                                        metadata?.systemDefined &&
+                                            list.length > 1
+                                    )}
+                                    disabled={Boolean(
+                                        (cannotExist &&
+                                            metadata?.systemDefined) ||
+                                            deletionQueue.includes(
+                                                metadata.field
+                                            )
+                                    )}
+                                    label={metadata.field}
+                                    onDelete={
+                                        editable && !metadata?.systemDefined
+                                            ? async () => {
+                                                  setDeletionQueue(
+                                                      deletionQueue.concat(
+                                                          metadata.field
+                                                      )
+                                                  );
+
+                                                  removeSingleProjection(
+                                                      collection,
                                                       metadata.field
                                                   )
-                                              );
-
-                                              removeSingleProjection(
-                                                  collection,
-                                                  metadata.field
-                                              )
-                                                  .then(
-                                                      () => {
-                                                          removeSingleStoredProjection(
-                                                              metadata,
-                                                              collection
-                                                          );
-
-                                                          logRocketEvent(
-                                                              CustomEvents.PROJECTION,
-                                                              {
-                                                                  collection,
-                                                                  operation:
-                                                                      'remove',
-                                                              }
-                                                          );
-                                                          logRocketConsole(
-                                                              `${CustomEvents.PROJECTION}:remove:success`,
-                                                              { metadata }
-                                                          );
-                                                      },
-                                                      (error) => {
-                                                          logRocketEvent(
-                                                              CustomEvents.PROJECTION,
-                                                              {
-                                                                  collection,
-                                                                  error: true,
-                                                                  operation:
-                                                                      'remove',
-                                                              }
-                                                          );
-                                                          logRocketConsole(
-                                                              `${CustomEvents.PROJECTION}:remove:failed`,
-                                                              {
-                                                                  error,
+                                                      .then(
+                                                          () => {
+                                                              removeSingleStoredProjection(
                                                                   metadata,
-                                                              }
-                                                          );
+                                                                  collection
+                                                              );
 
-                                                          enqueueSnackbar(
-                                                              intl.formatMessage(
+                                                              logRocketEvent(
+                                                                  CustomEvents.PROJECTION,
                                                                   {
-                                                                      id: 'projection.error.alert.removalFailure',
+                                                                      collection,
+                                                                      operation:
+                                                                          'remove',
                                                                   }
-                                                              ),
-                                                              {
-                                                                  ...snackbarSettings,
-                                                                  variant:
-                                                                      'error',
-                                                              }
+                                                              );
+                                                              logRocketConsole(
+                                                                  `${CustomEvents.PROJECTION}:remove:success`,
+                                                                  { metadata }
+                                                              );
+                                                          },
+                                                          (error) => {
+                                                              logRocketEvent(
+                                                                  CustomEvents.PROJECTION,
+                                                                  {
+                                                                      collection,
+                                                                      error: true,
+                                                                      operation:
+                                                                          'remove',
+                                                                  }
+                                                              );
+                                                              logRocketConsole(
+                                                                  `${CustomEvents.PROJECTION}:remove:failed`,
+                                                                  {
+                                                                      error,
+                                                                      metadata,
+                                                                  }
+                                                              );
+
+                                                              enqueueSnackbar(
+                                                                  intl.formatMessage(
+                                                                      {
+                                                                          id: 'projection.error.alert.removalFailure',
+                                                                      }
+                                                                  ),
+                                                                  {
+                                                                      ...snackbarSettings,
+                                                                      variant:
+                                                                          'error',
+                                                                  }
+                                                              );
+                                                          }
+                                                      )
+                                                      .finally(() => {
+                                                          setDeletionQueue(
+                                                              deletionQueue.filter(
+                                                                  (el) =>
+                                                                      el !==
+                                                                      metadata.field
+                                                              )
                                                           );
-                                                      }
-                                                  )
-                                                  .finally(() => {
-                                                      setDeletionQueue(
-                                                          deletionQueue.filter(
-                                                              (el) =>
-                                                                  el !==
-                                                                  metadata.field
-                                                          )
-                                                      );
-                                                  });
-                                          }
-                                        : undefined
-                                }
-                                size="small"
-                                sx={{
-                                    fontFamily: metadata?.systemDefined
-                                        ? 'monospace'
-                                        : undefined,
-                                    maxWidth: 400,
-                                }}
-                                variant="outlined"
-                            />
+                                                      });
+                                              }
+                                            : undefined
+                                    }
+                                    size="small"
+                                    sx={{
+                                        fontFamily: metadata?.systemDefined
+                                            ? 'monospace'
+                                            : undefined,
+                                        maxWidth: 400,
+                                    }}
+                                    variant="outlined"
+                                />
+                            </span>
                         </Tooltip>
                     </Box>
                 ))}

--- a/src/components/projections/Edit/types.ts
+++ b/src/components/projections/Edit/types.ts
@@ -27,6 +27,7 @@ export interface EditProjectionDialogProps extends BaseEditProjectionProps {
 export interface ProjectionListProps {
     collection: string | undefined;
     projectedFields: ProjectionMetadata[];
+    cannotExist?: boolean;
     editable?: boolean;
     maxChips?: number;
 }

--- a/src/components/shared/ChipList/index.tsx
+++ b/src/components/shared/ChipList/index.tsx
@@ -20,6 +20,10 @@ function ChipList({
 
     // Format data coming in so we can still pass in a list of strings
     const formattedValues = useMemo(() => {
+        if (!values || values.length < 1) {
+            return [];
+        }
+
         return values.map((value) => {
             return typeof value === 'string'
                 ? {

--- a/src/components/tables/Schema/Rows.tsx
+++ b/src/components/tables/Schema/Rows.tsx
@@ -38,12 +38,14 @@ function Row({ columns, row }: RowProps) {
             }
         }
 
-        return row.inference.types;
+        return row.inference.types ?? [];
     }, [row]);
 
     const detailsColumnVisible =
         !isCaptureWorkflow ||
         isColumnVisible(columns, optionalColumnIntlKeys.details);
+
+    const fieldCannotExist = Boolean(row.inference.exists === 'CANNOT');
 
     return (
         <TableRow
@@ -56,6 +58,7 @@ function Row({ columns, row }: RowProps) {
         >
             {row.field ? (
                 <FieldList
+                    cannotExist={fieldCannotExist}
                     editable={isCaptureWorkflow}
                     field={row.field}
                     pointer={row.ptr}
@@ -88,7 +91,7 @@ function Row({ columns, row }: RowProps) {
                 </TableCell>
             ) : null}
 
-            {isCaptureWorkflow && row.field ? (
+            {!fieldCannotExist && isCaptureWorkflow && row.field ? (
                 <ProjectionActions field={row.field} pointer={row.ptr} />
             ) : isCaptureWorkflow ? (
                 <TableCell />

--- a/src/components/tables/cells/projections/FieldList.tsx
+++ b/src/components/tables/cells/projections/FieldList.tsx
@@ -9,6 +9,7 @@ import { useCollectionIndex } from 'src/hooks/projections/useCollectionIndex';
 import { useProjectedFields } from 'src/hooks/projections/useProjectedFields';
 
 export const FieldList = ({
+    cannotExist,
     editable,
     field,
     pointer,
@@ -32,6 +33,7 @@ export const FieldList = ({
     return (
         <TableCell sx={sticky ? getStickyTableCell() : undefined}>
             <ProjectionList
+                cannotExist={cannotExist}
                 collection={collection}
                 editable={editable}
                 maxChips={1}

--- a/src/components/tables/cells/types.ts
+++ b/src/components/tables/cells/types.ts
@@ -39,6 +39,7 @@ export interface FieldActionsProps {
 export interface FieldListProps {
     field: string;
     pointer: string | undefined;
+    cannotExist?: boolean;
     editable?: boolean;
     sticky?: boolean;
 }

--- a/src/lang/en-US/Workflows.ts
+++ b/src/lang/en-US/Workflows.ts
@@ -484,6 +484,7 @@ export const Workflows: Record<string, string> = {
     'projection.label.fieldName.current': `Current Name`,
     'projection.label.fieldName.new': `New Name`,
     'projection.tooltip.systemDefinedField': `The system-defined alias for this location.`,
+    'projection.tooltip.cannotExist': `The location cannot exist. It may be outside of permitted array bounds, is a disallowed property, or has an impossible type.`,
 
     'schemaManagement.options.manual.description': `You fully control the schema. You're responsible for changes.`,
     'schemaManagement.options.manual.label': `Manually manage schemas`,


### PR DESCRIPTION
Handling fields that cannot exist.

## Issues

https://github.com/estuary/ui/issues/1809

## Changes

### 1809

- Allow empty types to be "rendered" (renders empty)
- Disable `rename` cta when field cannot exist
- Render `cannot` exist field disabled and with special tooltip

## Tests

### Manually tested

- Capture edit with the spec that blew up

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

`associations` is a cannot exist field
<img width="1786" height="313" alt="image" src="https://github.com/user-attachments/assets/250c87c6-cc90-4714-ab91-01cddbba15b3" />

<img width="1774" height="332" alt="image" src="https://github.com/user-attachments/assets/9ac3c55e-1dcb-4964-a518-f2c4d3a88b5d" />

