### PR TITLE
Render `parser` configs in endpoint configs

### DIFF
--- a/src/forms/overrides/material/complex/MaterialOneOfRenderer_Discriminator.tsx
+++ b/src/forms/overrides/material/complex/MaterialOneOfRenderer_Discriminator.tsx
@@ -156,21 +156,18 @@ export const Custom_MaterialOneOfRenderer_Discriminator = ({
 
     const discriminatorProperty = getDiscriminator(schema);
 
-    oneOfRenderInfos.map((renderer) => {
-        const { uischema: rendererUischema } = renderer as any;
+    oneOfRenderInfos.map((oneOfRenderer) => {
+        const { uischema: rendererUischema } = oneOfRenderer as any;
 
         rendererUischema.elements = rendererUischema.elements.filter(
             (el: any) => {
-                // Remove any that are missing elements or somehow don't have scope (should never happen)
-                if (el === null || !el.scope) return false;
-
                 // We now want to try to hide the input that is rendering the discriminator
                 //  since we are rendering the tabs this is just duplicating information
                 //      This is not supported out of the box https://jsonforms.discourse.group/t/use-default-uischema-and-only-apply-rule-to-one-field/1742
                 //  So we have to look at the pathSegments and filter our the one that matches the discriminator
                 //      This should be safe according to JSONForms https://jsonforms.discourse.group/t/hiding-a-specific-path-when-rendering-a-complex-oneof/2795
 
-                const pathSegments = el.scope?.split('/');
+                const pathSegments = el?.scope?.split('/');
                 if (pathSegments && pathSegments.length > 0) {
                     // Get the last segment as that should match property names
                     //  based on `isRequired` in jsonforms/packages/core/src/mappers/renderer.ts
@@ -186,11 +183,12 @@ export const Custom_MaterialOneOfRenderer_Discriminator = ({
                     return renderOneOfOption;
                 }
 
+                // Default to rendering things as this is how JsonForms handles things
                 return true;
             }
         );
 
-        return renderer;
+        return oneOfRenderer;
     });
 
     const openNewTab = (newIndex: number) => {


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1851

## Changes

### 1851

- Always rendering things unless we know not to. 

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

<img width="991" height="442" alt="image" src="https://github.com/user-attachments/assets/72f0fd78-5879-421a-86c0-c286fb7a1380" />

