### PR TITLE
Reverting the previous `npm audit fix` run due to issue with `qs.parse`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3391,9 +3391,9 @@
             }
         },
         "node_modules/@remix-run/router": {
-            "version": "1.23.2",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-            "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+            "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
@@ -5183,23 +5183,22 @@
             "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
         },
         "node_modules/asn1.js": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "node_modules/asn1.js/node_modules/bn.js": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+            "dev": true
         },
         "node_modules/assert": {
             "version": "2.0.0",
@@ -5351,11 +5350,10 @@
             }
         },
         "node_modules/bn.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-            "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -5433,91 +5431,34 @@
             }
         },
         "node_modules/browserify-rsa": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
-            "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+            "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "bn.js": "^5.2.1",
-                "randombytes": "^2.1.0",
-                "safe-buffer": "^5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
+                "bn.js": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
-        },
-        "node_modules/browserify-rsa/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/browserify-sign": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-            "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+            "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "bn.js": "^5.2.2",
-                "browserify-rsa": "^4.1.1",
+                "bn.js": "^5.2.1",
+                "browserify-rsa": "^4.1.0",
                 "create-hash": "^1.2.0",
                 "create-hmac": "^1.1.7",
-                "elliptic": "^6.6.1",
+                "elliptic": "^6.5.4",
                 "inherits": "^2.0.4",
-                "parse-asn1": "^5.1.9",
-                "readable-stream": "^2.3.8",
+                "parse-asn1": "^5.1.6",
+                "readable-stream": "^3.6.2",
                 "safe-buffer": "^5.2.1"
             },
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 4"
             }
-        },
-        "node_modules/browserify-sign/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/browserify-sign/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/browserify-sign/node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -5538,23 +5479,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/browserify-sign/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/browserify-zlib": {
             "version": "0.2.0",
@@ -6060,13 +5984,6 @@
                 "url": "https://opencollective.com/core-js"
             }
         },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/correct-license-metadata": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/correct-license-metadata/-/correct-license-metadata-1.4.0.tgz",
@@ -6163,66 +6080,26 @@
             }
         },
         "node_modules/crypto-browserify": {
-            "version": "3.12.1",
-            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
-            "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserify-cipher": "^1.0.1",
-                "browserify-sign": "^4.2.3",
-                "create-ecdh": "^4.0.4",
-                "create-hash": "^1.2.0",
-                "create-hmac": "^1.1.7",
-                "diffie-hellman": "^5.0.3",
-                "hash-base": "~3.0.4",
-                "inherits": "^2.0.4",
-                "pbkdf2": "^3.1.2",
-                "public-encrypt": "^4.0.3",
-                "randombytes": "^2.1.0",
-                "randomfill": "^1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             },
             "engines": {
-                "node": ">= 0.10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": "*"
             }
-        },
-        "node_modules/crypto-browserify/node_modules/hash-base": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
-            "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "safe-buffer": "^5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/crypto-browserify/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/css-in-js-utils": {
             "version": "3.1.0",
@@ -8456,50 +8333,18 @@
             }
         },
         "node_modules/hash-base": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
-            "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+            "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.4",
-                "readable-stream": "^2.3.8",
-                "safe-buffer": "^5.2.1",
-                "to-buffer": "^1.2.1"
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">=4"
             }
-        },
-        "node_modules/hash-base/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/hash-base/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/hash-base/node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -8520,23 +8365,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/hash-base/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/hash.js": {
             "version": "1.1.7",
@@ -10552,11 +10380,10 @@
             "dev": true
         },
         "node_modules/node-stdlib-browser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
-            "integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.2.0.tgz",
+            "integrity": "sha512-VSjFxUhRhkyed8AtLwSCkMrJRfQ3e2lGtG3sP6FEgaLKBBbxM/dLfjRe1+iLhjvyLFW3tBQ8+c0pcOtXGbAZJg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "assert": "^2.0.0",
                 "browser-resolve": "^2.0.0",
@@ -10565,8 +10392,8 @@
                 "console-browserify": "^1.1.0",
                 "constants-browserify": "^1.0.0",
                 "create-require": "^1.1.1",
-                "crypto-browserify": "^3.12.1",
-                "domain-browser": "4.22.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^4.22.0",
                 "events": "^3.0.0",
                 "https-browserify": "^1.0.0",
                 "isomorphic-timers-promises": "^1.0.1",
@@ -10582,7 +10409,7 @@
                 "string_decoder": "^1.0.0",
                 "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.1",
-                "url": "^0.11.4",
+                "url": "^0.11.0",
                 "util": "^0.12.4",
                 "vm-browserify": "^1.0.1"
             },
@@ -11228,42 +11055,17 @@
             }
         },
         "node_modules/parse-asn1": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
-            "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "asn1.js": "^4.10.1",
-                "browserify-aes": "^1.2.0",
-                "evp_bytestokey": "^1.0.3",
-                "pbkdf2": "^3.1.5",
-                "safe-buffer": "^5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
+                "asn1.js": "^5.2.0",
+                "browserify-aes": "^1.0.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3",
+                "safe-buffer": "^5.1.1"
             }
-        },
-        "node_modules/parse-asn1/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/parse-conflict-json": {
             "version": "3.0.1",
@@ -11414,21 +11216,55 @@
             }
         },
         "node_modules/pbkdf2": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
-            "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+            "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "create-hash": "^1.2.0",
+                "create-hash": "~1.1.3",
                 "create-hmac": "^1.1.7",
-                "ripemd160": "^2.0.3",
+                "ripemd160": "=2.0.1",
                 "safe-buffer": "^5.2.1",
-                "sha.js": "^2.4.12",
-                "to-buffer": "^1.2.1"
+                "sha.js": "^2.4.11",
+                "to-buffer": "^1.2.0"
             },
             "engines": {
-                "node": ">= 0.10"
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/create-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+            "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/hash-base": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+            "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/ripemd160": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+            "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^2.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "node_modules/pbkdf2/node_modules/safe-buffer": {
@@ -11606,13 +11442,6 @@
                 "node": ">= 0.6.0"
             }
         },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/proggy": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/proggy/-/proggy-2.0.0.tgz",
@@ -11729,6 +11558,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.x"
             }
         },
         "node_modules/querystring-es3": {
@@ -12018,12 +11857,12 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.30.3",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-            "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+            "version": "6.30.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
+            "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.2"
+                "@remix-run/router": "1.23.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -12033,13 +11872,13 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.30.3",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-            "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+            "version": "6.30.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
+            "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.2",
-                "react-router": "6.30.3"
+                "@remix-run/router": "1.23.0",
+                "react-router": "6.30.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -12514,17 +12353,13 @@
             }
         },
         "node_modules/ripemd160": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
-            "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "hash-base": "^3.1.2",
-                "inherits": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 0.8"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "node_modules/rollup": {
@@ -14334,17 +14169,13 @@
             }
         },
         "node_modules/url": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-            "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "punycode": "^1.4.1",
-                "qs": "^6.12.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
             }
         },
         "node_modules/url-parse": {
@@ -14358,11 +14189,10 @@
             }
         },
         "node_modules/url/node_modules/punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-            "dev": true,
-            "license": "MIT"
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+            "dev": true
         },
         "node_modules/urql": {
             "version": "5.0.0",


### PR DESCRIPTION
Allows endpoint config to render correctly