### PR TITLE
PROD: We do not need to fail on this as there are times this is not needed

### DIFF
--- a/src/stores/Binding/Store.ts
+++ b/src/stores/Binding/Store.ts
@@ -1121,8 +1121,7 @@ const getInitialState = (
                     // If we did not get pointers we should be okay to carry on like normal. Previously (pre 2026 Q1)
                     //  we were setting a "hydration error" here but that was not being stored properly due to https://github.com/estuary/ui/issues/1870
                     // Pretty sure we are safe just carrying on if we cannot get the pointers. This is mainly true until the
-                    //  pointers we need to fetch are potentially changed. So until then this should be safe to just ignore this
-                    //  being empty and carry on.
+                    //  pointers we need to fetch are potentially changed. So until then this should be safe.
                     return;
                 }
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1870

## Changes

### 1870

- After the first fix with 1870 is exposed that this error has been getting set to `true` for a long time but was not properly getting updated in the store. So we are safe to just ignore if these are empty.

## Tests

### Manually tested

- Went to `http://localhost:3000/captures/create/new?connectorId=0d%3A26%3A1f%3A6e%3Ac6%3Ae9%3A48%3A00` as it was showing the error on load of the page

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

Before:
<img width="1364" height="1238" alt="image" src="https://github.com/user-attachments/assets/da6adbf5-b846-4163-895a-9270c8689750" />

After:
<img width="1373" height="1057" alt="image" src="https://github.com/user-attachments/assets/6819163a-0b25-4c06-a274-015352a1eadc" />


