### PR TITLE
only showing during dataflow reset

### DIFF
--- a/src/components/shared/Entity/Actions/Save.tsx
+++ b/src/components/shared/Entity/Actions/Save.tsx
@@ -16,6 +16,7 @@ import { entityHeaderButtonSx } from 'src/context/Theme';
 import { useEntityWorkflow } from 'src/context/Workflow';
 import { logRocketEvent } from 'src/services/shared';
 import { useBinding_collectionsBeingBackfilled } from 'src/stores/Binding/hooks';
+import { useBindingStore } from 'src/stores/Binding/Store';
 import { useFormStateStore_isActive } from 'src/stores/FormState/hooks';
 import { LocalStorageKeys } from 'src/utils/localStorage-utils';
 
@@ -36,6 +37,7 @@ function EntityCreateSave({
 
     const confirmationModalContext = useConfirmationModalContext();
     const collectionsBeingBackfilled = useBinding_collectionsBeingBackfilled();
+    const backfillMode = useBindingStore((state) => state.backfillMode);
 
     const isSaving = useEditorStore_isSaving();
     const draftId = useEditorStore_id();
@@ -52,6 +54,7 @@ function EntityCreateSave({
                 if (
                     !dryRun &&
                     entityWorkFlow === 'capture_edit' &&
+                    backfillMode === 'reset' &&
                     collectionsBeingBackfilled.length > 0
                 ) {
                     confirmationModalContext

--- a/src/stores/Binding/hooks.ts
+++ b/src/stores/Binding/hooks.ts
@@ -343,7 +343,7 @@ export const useBinding_collectionsBeingBackfilled = () =>
                 state.backfilledBindings
                     // There is a chance that during rehydration that the resourceConfigs will be
                     //  empty for a little bit. This happens during materialization when a user marks
-                    //  things for backfill, edits the endpoint config, and generates a new catalog.Z
+                    //  things for backfill, edits the endpoint config, and generates a new catalog.
                     .filter((datum) =>
                         Boolean(state.resourceConfigs?.[datum]?.meta)
                     )


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1884

## Changes

### 1884

- checked backfill mode

### misc

- cleaned up typo

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Only shown on `reset` backfill
<img width="993" height="339" alt="image" src="https://github.com/user-attachments/assets/437c5f61-e0e0-4c29-8f1f-dae00872f152" />

### No confirmation on `incremental` backfill
<img width="1270" height="575" alt="image" src="https://github.com/user-attachments/assets/2f63c9dd-5aa7-4254-89e6-9612777e5558" />


