### PR TITLE
Adding trailing slash to IAM OIDC

### DIFF
--- a/src/components/tables/DataPlanes/DataPlaneDialog.tsx
+++ b/src/components/tables/DataPlanes/DataPlaneDialog.tsx
@@ -16,9 +16,9 @@ import {
 } from 'src/utils/cloudRegions';
 import {
     formatDataPlaneName,
+    formatIamOidc,
     generateDataPlaneOption,
 } from 'src/utils/dataPlane-utils';
-import { OPENID_HOST } from 'src/utils/misc-utils';
 
 const TITLE_ID = 'data-plane-dialog-title';
 
@@ -153,7 +153,7 @@ function DataPlaneDialog({ onClose, dataPlane }: DataPlaneDialogProps) {
                             label={intl.formatMessage({
                                 id: 'data.idProvider',
                             })}
-                            value={`${OPENID_HOST}/${dataPlane.data_plane_fqdn}`}
+                            value={formatIamOidc(dataPlane.data_plane_fqdn)}
                         />
                     ) : null}
                 </Stack>

--- a/src/utils/dataPlane-utils.ts
+++ b/src/utils/dataPlane-utils.ts
@@ -25,7 +25,7 @@ import {
     getCollectionAuthorizationSettings,
     getTaskAuthorizationSettings,
 } from 'src/utils/env-utils';
-import { hasLength } from 'src/utils/misc-utils';
+import { hasLength, OPENID_HOST } from 'src/utils/misc-utils';
 
 export enum SHARD_LABELS {
     EXPOSE_PORT = 'estuary.dev/expose-port',
@@ -290,6 +290,10 @@ export const formatDataPlaneName = (dataPlaneName: DataPlaneName) => {
         : whole;
 
     return formattedName.trim();
+};
+
+export const formatIamOidc = (dataPlaneFqdn: string) => {
+    return `${OPENID_HOST}/${dataPlaneFqdn}/`;
 };
 
 // TODO (data-planes): Determine whether this function should always be called


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1887

## Changes

### 1887

- Add a trailing slash
- Move to a function as that feels "safer" to me

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

<img width="720" height="165" alt="image" src="https://github.com/user-attachments/assets/9fb927a3-4a1b-4843-bc26-8d10ee6c0564" />

