### PR TITLE
Ensuring data exists before setting default on single `discriminator`

### DIFF
--- a/src/forms/overrides/material/complex/MaterialOneOfRenderer_Discriminator.tsx
+++ b/src/forms/overrides/material/complex/MaterialOneOfRenderer_Discriminator.tsx
@@ -233,13 +233,13 @@ export const Custom_MaterialOneOfRenderer_Discriminator = ({
     //  the source-shopify-native connector as it can contain multiple discriminators
     //  in the stores array. If we do not set this on edit then the user cannot add
     //  new stores.
-    // NOTE: Must run in useEffect to avoid "setState during render" warning — calling
-    //  handleChange directly in the render body updates JsonFormsStateProvider while
-    //  this component is still rendering.
+    // We need to wait for data to exist so that we do not override any setting the user
+    //  is setting and spread out default value into the data
     useEffect(() => {
         if (
             defaultDiscriminator.current &&
             required &&
+            data &&
             !hasOwnProperty(data, discriminatorProperty)
         ) {
             const defaultVal = getDiscriminatorDefaultValue(
@@ -256,11 +256,14 @@ export const Custom_MaterialOneOfRenderer_Discriminator = ({
             defaultDiscriminator.current = false;
 
             handleChange(path, {
+                ...data,
                 [discriminatorProperty]: defaultVal?.[discriminatorProperty],
             });
         }
+        // We really only care about data so that once that is "changed" and exists
+        //  then we can make sure the default discriminator is set on it
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [data]);
 
     const singleOption = oneOfRenderInfos.length === 1;
 

--- a/src/gql-types/graphql.ts
+++ b/src/gql-types/graphql.ts
@@ -301,6 +301,8 @@ export type Connector = {
    * spec that should be used when configuring newly created tasks.
    */
   defaultSpec?: Maybe<ConnectorSpec>;
+  /** A string that contains a list of connector details (latency, batch, etc.) */
+  detail?: Maybe<Scalars['String']['output']>;
   /** Link to an external site with more information about the endpoint */
   externalUrl: Scalars['String']['output'];
   /** Unique id of the connector */
@@ -309,14 +311,10 @@ export type Connector = {
   imageName: Scalars['String']['output'];
   /** The connector's logo image, represented as a URL per locale */
   logoUrl?: Maybe<Scalars['String']['output']>;
-  /** A longform description of this connector */
-  longDescription?: Maybe<Scalars['String']['output']>;
   /** The protocol of this connector (capture or materialization). */
   protocol?: Maybe<ConnectorProto>;
   /** Whether this connector should appear in a promoted position in connector listings */
   recommended: Scalars['Boolean']['output'];
-  /** Brief human readable description, at most a few sentences */
-  shortDescription?: Maybe<Scalars['String']['output']>;
   /** Look up the spec for a specific image tag of this connector. */
   spec?: Maybe<ConnectorSpec>;
   /** The title, a few words at most */

--- a/src/gql-types/schema.graphql
+++ b/src/gql-types/schema.graphql
@@ -307,6 +307,11 @@ type Connector {
   """
   defaultSpec: ConnectorSpec
 
+  """
+  A string that contains a list of connector details (latency, batch, etc.)
+  """
+  detail: String
+
   """Link to an external site with more information about the endpoint"""
   externalUrl: String!
 
@@ -321,9 +326,6 @@ type Connector {
   """The connector's logo image, represented as a URL per locale"""
   logoUrl: String
 
-  """A longform description of this connector"""
-  longDescription: String
-
   """The protocol of this connector (capture or materialization)."""
   protocol: ConnectorProto
 
@@ -331,9 +333,6 @@ type Connector {
   Whether this connector should appear in a promoted position in connector listings
   """
   recommended: Boolean!
-
-  """Brief human readable description, at most a few sentences"""
-  shortDescription: String
 
   """Look up the spec for a specific image tag of this connector."""
   spec(


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1961

## Changes

### 1961

- We need to ensure `data` exists before setting the discriminator

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

<img width="1131" height="981" alt="image" src="https://github.com/user-attachments/assets/3beb9a0d-4ad0-4272-9dcd-2930369032ae" />

