### PR TITLE
PROD - fix issue with connector ordering/grouping

### DIFF
--- a/src/components/connectors/Grid/ConnectorCards.tsx
+++ b/src/components/connectors/Grid/ConnectorCards.tsx
@@ -1,5 +1,8 @@
 import type { ConnectorCardsProps } from 'src/components/connectors/Grid/types';
-import type { ConnectorProto } from 'src/gql-types/graphql';
+import type {
+    ConnectorProto,
+    ConnectorsGridQuery,
+} from 'src/gql-types/graphql';
 import type { EntityWithCreateWorkflow, TableState } from 'src/types';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -29,6 +32,37 @@ import {
     getEmptyTableMessage,
 } from 'src/utils/table-utils';
 
+type RawConnectorEdges = ConnectorsGridQuery['connectors']['edges'];
+type RawConnectorNode = RawConnectorEdges[number]['node'];
+
+type ConnectorNode = RawConnectorNode & {
+    defaultSpec: NonNullable<RawConnectorNode['defaultSpec']>;
+};
+
+const groupRecommendedAlphaSort = (arr: ConnectorNode[]): ConnectorNode[] => {
+    return arr
+        .slice()
+        .sort(
+            (a, b) =>
+                (b.recommended ? 1 : 0) - (a.recommended ? 1 : 0) ||
+                (a.title ?? '').localeCompare(b.title ?? '')
+        );
+};
+
+const getGroupedNodes = (edges: RawConnectorEdges): ConnectorNode[] => {
+    const nodes = (edges ?? [])
+        .map((edge) => edge.node)
+        .filter(
+            (
+                node
+            ): node is typeof node & {
+                defaultSpec: NonNullable<typeof node.defaultSpec>;
+            } => node.defaultSpec !== null
+        );
+
+    return groupRecommendedAlphaSort(nodes);
+};
+
 export default function ConnectorCards({
     condensed,
     protocol,
@@ -56,27 +90,11 @@ export default function ConnectorCards({
     });
 
     const selectData = useMemo(() => {
-        const nodes = (queryData?.connectors.edges ?? [])
-            .map((edge) => edge.node)
-            .filter(
-                (
-                    node
-                ): node is typeof node & {
-                    defaultSpec: NonNullable<typeof node.defaultSpec>;
-                } => node.defaultSpec !== null
-            );
+        const nodes = getGroupedNodes(queryData?.connectors.edges ?? []);
 
-        const groupRecommendedAlphaSort = (arr: typeof nodes) => {
-            return arr
-                .slice()
-                .sort(
-                    (a, b) =>
-                        (b.recommended ? 1 : 0) - (a.recommended ? 1 : 0) ||
-                        (a.title ?? '').localeCompare(b.title ?? '')
-                );
-        };
-
-        if (!searchQuery) return groupRecommendedAlphaSort(nodes);
+        if (!searchQuery) {
+            return groupRecommendedAlphaSort(nodes);
+        }
 
         const q = searchQuery.toLowerCase();
         return groupRecommendedAlphaSort(

--- a/src/components/connectors/Grid/ConnectorCards.tsx
+++ b/src/components/connectors/Grid/ConnectorCards.tsx
@@ -40,13 +40,11 @@ type ConnectorNode = RawConnectorNode & {
 };
 
 const groupRecommendedAlphaSort = (arr: ConnectorNode[]): ConnectorNode[] => {
-    return arr
-        .slice()
-        .sort(
-            (a, b) =>
-                (b.recommended ? 1 : 0) - (a.recommended ? 1 : 0) ||
-                (a.title ?? '').localeCompare(b.title ?? '')
-        );
+    return arr.sort(
+        (a, b) =>
+            (b.recommended ? 1 : 0) - (a.recommended ? 1 : 0) ||
+            (a.title ?? '').localeCompare(b.title ?? '')
+    );
 };
 
 const getSortedNodes = (edges: RawConnectorEdges): ConnectorNode[] => {

--- a/src/components/connectors/Grid/ConnectorCards.tsx
+++ b/src/components/connectors/Grid/ConnectorCards.tsx
@@ -66,13 +66,25 @@ export default function ConnectorCards({
                 } => node.defaultSpec !== null
             );
 
-        if (!searchQuery) return nodes;
+        const groupRecommendedAlphaSort = (arr: typeof nodes) => {
+            return arr
+                .slice()
+                .sort(
+                    (a, b) =>
+                        (b.recommended ? 1 : 0) - (a.recommended ? 1 : 0) ||
+                        (a.title ?? '').localeCompare(b.title ?? '')
+                );
+        };
+
+        if (!searchQuery) return groupRecommendedAlphaSort(nodes);
 
         const q = searchQuery.toLowerCase();
-        return nodes.filter(
-            (node) =>
-                node.title?.toLowerCase().includes(q) ||
-                node.detail?.toLowerCase().includes(q)
+        return groupRecommendedAlphaSort(
+            nodes.filter(
+                (node) =>
+                    node.title?.toLowerCase().includes(q) ||
+                    node.detail?.toLowerCase().includes(q)
+            )
         );
     }, [queryData, searchQuery]);
 

--- a/src/components/connectors/Grid/ConnectorCards.tsx
+++ b/src/components/connectors/Grid/ConnectorCards.tsx
@@ -91,16 +91,14 @@ export default function ConnectorCards({
         const nodes = getSortedNodes(queryData?.connectors.edges ?? []);
 
         if (!searchQuery) {
-            return groupRecommendedAlphaSort(nodes);
+            return nodes;
         }
 
         const q = searchQuery.toLowerCase();
-        return groupRecommendedAlphaSort(
-            nodes.filter(
-                (node) =>
-                    node.title?.toLowerCase().includes(q) ||
-                    node.detail?.toLowerCase().includes(q)
-            )
+        return nodes.filter(
+            (node) =>
+                node.title?.toLowerCase().includes(q) ||
+                node.detail?.toLowerCase().includes(q)
         );
     }, [queryData, searchQuery]);
 

--- a/src/components/connectors/Grid/ConnectorCards.tsx
+++ b/src/components/connectors/Grid/ConnectorCards.tsx
@@ -49,7 +49,7 @@ const groupRecommendedAlphaSort = (arr: ConnectorNode[]): ConnectorNode[] => {
         );
 };
 
-const getGroupedNodes = (edges: RawConnectorEdges): ConnectorNode[] => {
+const getSortedNodes = (edges: RawConnectorEdges): ConnectorNode[] => {
     const nodes = (edges ?? [])
         .map((edge) => edge.node)
         .filter(
@@ -90,7 +90,7 @@ export default function ConnectorCards({
     });
 
     const selectData = useMemo(() => {
-        const nodes = getGroupedNodes(queryData?.connectors.edges ?? []);
+        const nodes = getSortedNodes(queryData?.connectors.edges ?? []);
 
         if (!searchQuery) {
             return groupRecommendedAlphaSort(nodes);


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1963

## Changes

### 1963

- Fix the ordering/grouping of the connectors
- Also broke out the functions to not be declared in the memo

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Recommended grouped to top
<img width="2491" height="1215" alt="image" src="https://github.com/user-attachments/assets/707fcabb-476d-4c1d-8551-9796dd65c16c" />

### Filtering
<img width="2456" height="1204" alt="image" src="https://github.com/user-attachments/assets/2f71aef1-7bf9-4243-926e-c26dc2cd5436" />

### Nothing found
<img width="2524" height="608" alt="image" src="https://github.com/user-attachments/assets/ca108c40-b92f-4ae8-bb47-e47151bf41b9" />
