### PR TITLE
Make sure months on stats are in UTC

### DIFF
--- a/src/gql-types/graphql.ts
+++ b/src/gql-types/graphql.ts
@@ -112,6 +112,49 @@ export type Alert = {
   resolvedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
+/** A single row from `public.alert_configs`. */
+export type AlertConfigEntry = {
+  __typename?: 'AlertConfigEntry';
+  catalogPrefixOrName: Scalars['String']['output'];
+  config: Scalars['JSON']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  detail?: Maybe<Scalars['String']['output']>;
+  /**
+   * The fully-resolved effective config at this scope, merging all
+   * ancestor prefix layers and controller defaults.
+   */
+  effective: EffectiveAlertConfig;
+  id: Scalars['Id']['output'];
+  lastModifiedBy?: Maybe<Scalars['UUID']['output']>;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+export type AlertConfigEntryConnection = {
+  __typename?: 'AlertConfigEntryConnection';
+  /** A list of edges. */
+  edges: Array<AlertConfigEntryEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type AlertConfigEntryEdge = {
+  __typename?: 'AlertConfigEntryEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: AlertConfigEntry;
+};
+
+/**
+ * Optional filter for the `alertConfigs` query. When omitted, all accessible
+ * rows are returned.
+ */
+export type AlertConfigsFilter = {
+  /** Filter on the `catalog_prefix_or_name` column. */
+  catalogPrefixOrName?: InputMaybe<PrefixFilter>;
+};
+
 export type AlertConnection = {
   __typename?: 'AlertConnection';
   /** A list of edges. */
@@ -515,12 +558,24 @@ export type DiscoverChange = {
   target: Scalars['Collection']['output'];
 };
 
+export type EffectiveAlertConfig = {
+  __typename?: 'EffectiveAlertConfig';
+  config: Scalars['JSON']['output'];
+  provenance: Array<FieldProvenance>;
+};
+
 /** A generic error that can be associated with a particular draft spec for a given operation. */
 export type Error = {
   __typename?: 'Error';
   catalogName: Scalars['String']['output'];
   detail: Scalars['String']['output'];
   scope?: Maybe<Scalars['String']['output']>;
+};
+
+export type FieldProvenance = {
+  __typename?: 'FieldProvenance';
+  path: Scalars['String']['output'];
+  source?: Maybe<Scalars['String']['output']>;
 };
 
 /** Status of the inferred schema */
@@ -613,6 +668,11 @@ export type LiveSpec = {
   catalogType: CatalogType;
   createdAt: Scalars['DateTime']['output'];
   dataPlaneId: Scalars['Id']['output'];
+  /**
+   * The fully-resolved effective alert config for this task, merging all
+   * ancestor prefix layers and controller defaults.
+   */
+  effectiveAlertConfig: EffectiveAlertConfig;
   isDisabled: Scalars['Boolean']['output'];
   lastBuildId: Scalars['Id']['output'];
   lastPubId: Scalars['Id']['output'];
@@ -821,6 +881,22 @@ export type MutationRoot = {
    */
   testConnectionHealth: ConnectionHealthTestResult;
   /**
+   * Creates or replaces the alert config at `catalogPrefixOrName`.
+   *
+   * `catalogPrefixOrName` is either a catalog prefix ending in `/`
+   * (applies to all tasks under that prefix) or an exact catalog name
+   * with no trailing slash (applies to that single task). Exact catalog
+   * names must refer to a task that currently exists in `live_specs`;
+   * prefixes have no such constraint.
+   *
+   * To clear all configured overrides while keeping the row, pass an empty
+   * `{}` config.
+   *
+   * If `detail` is omitted or `null` on update, the existing `detail`
+   * value is preserved.
+   */
+  updateAlertConfig: UpdateAlertConfigResult;
+  /**
    * Updates the alert subscription for the given prefix and email, returning
    * the updated subscription.
    */
@@ -882,6 +958,13 @@ export type MutationRootRedeemInviteLinkArgs = {
 export type MutationRootTestConnectionHealthArgs = {
   catalogPrefix: Scalars['Prefix']['input'];
   spec: Scalars['JSON']['input'];
+};
+
+
+export type MutationRootUpdateAlertConfigArgs = {
+  catalogPrefixOrName: Scalars['String']['input'];
+  config: Scalars['JSON']['input'];
+  detail?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1026,6 +1109,15 @@ export type PublicationStatus = {
 
 export type QueryRoot = {
   __typename?: 'QueryRoot';
+  /**
+   * Lists alert-config rows visible to the caller.
+   *
+   * Results are limited to readable prefixes and sorted by
+   * `catalog_prefix_or_name`. `filter.catalogPrefixOrName.startsWith` can
+   * narrow the results further. Passing a full catalog name returns at
+   * most one exact-name row.
+   */
+  alertConfigs: AlertConfigEntryConnection;
   /** Returns a complete list of alert subscriptions. */
   alertSubscriptions: Array<AlertSubscription>;
   /** Returns all possible alert types with their user-facing metadata. */
@@ -1083,6 +1175,13 @@ export type QueryRoot = {
    * Results are paginated and sorted by catalog_prefix.
    */
   storageMappings: StorageMappingConnection;
+};
+
+
+export type QueryRootAlertConfigsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<AlertConfigsFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -1439,6 +1538,14 @@ export type StorageMappingsBy = {
    * At least one of `exactPrefixes` or `underPrefix` must be provided.
    */
   underPrefix?: InputMaybe<Scalars['Prefix']['input']>;
+};
+
+/** Result of the `updateAlertConfig` mutation. */
+export type UpdateAlertConfigResult = {
+  __typename?: 'UpdateAlertConfigResult';
+  catalogPrefixOrName: Scalars['String']['output'];
+  created: Scalars['Boolean']['output'];
+  id: Scalars['Id']['output'];
 };
 
 /** Result of updating a storage mapping. */

--- a/src/gql-types/schema.graphql
+++ b/src/gql-types/schema.graphql
@@ -83,6 +83,49 @@ type Alert {
   resolvedAt: DateTime
 }
 
+"""A single row from `public.alert_configs`."""
+type AlertConfigEntry {
+  catalogPrefixOrName: String!
+  config: JSON!
+  createdAt: DateTime!
+  detail: String
+
+  """
+  The fully-resolved effective config at this scope, merging all
+  ancestor prefix layers and controller defaults.
+  """
+  effective: EffectiveAlertConfig!
+  id: Id!
+  lastModifiedBy: UUID
+  updatedAt: DateTime!
+}
+
+type AlertConfigEntryConnection {
+  """A list of edges."""
+  edges: [AlertConfigEntryEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+}
+
+"""An edge in a connection."""
+type AlertConfigEntryEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AlertConfigEntry!
+}
+
+"""
+Optional filter for the `alertConfigs` query. When omitted, all accessible
+rows are returned.
+"""
+input AlertConfigsFilter {
+  """Filter on the `catalog_prefix_or_name` column."""
+  catalogPrefixOrName: PrefixFilter
+}
+
 type AlertConnection {
   """A list of edges."""
   edges: [AlertEdge!]!
@@ -570,6 +613,11 @@ type DiscoverChange {
   target: Collection!
 }
 
+type EffectiveAlertConfig {
+  config: JSON!
+  provenance: [FieldProvenance!]!
+}
+
 """
 A generic error that can be associated with a particular draft spec for a given operation.
 """
@@ -577,6 +625,11 @@ type Error {
   catalogName: String!
   detail: String!
   scope: String
+}
+
+type FieldProvenance {
+  path: String!
+  source: String
 }
 
 scalar Id
@@ -682,6 +735,12 @@ type LiveSpec {
   catalogType: CatalogType!
   createdAt: DateTime!
   dataPlaneId: Id!
+
+  """
+  The fully-resolved effective alert config for this task, merging all
+  ancestor prefix layers and controller defaults.
+  """
+  effectiveAlertConfig: EffectiveAlertConfig!
   isDisabled: Boolean!
   lastBuildId: Id!
   lastPubId: Id!
@@ -863,6 +922,23 @@ type MutationRoot {
   testConnectionHealth(catalogPrefix: Prefix!, spec: JSON!): ConnectionHealthTestResult!
 
   """
+  Creates or replaces the alert config at `catalogPrefixOrName`.
+  
+  `catalogPrefixOrName` is either a catalog prefix ending in `/`
+  (applies to all tasks under that prefix) or an exact catalog name
+  with no trailing slash (applies to that single task). Exact catalog
+  names must refer to a task that currently exists in `live_specs`;
+  prefixes have no such constraint.
+  
+  To clear all configured overrides while keeping the row, pass an empty
+  `{}` config.
+  
+  If `detail` is omitted or `null` on update, the existing `detail`
+  value is preserved.
+  """
+  updateAlertConfig(catalogPrefixOrName: String!, config: JSON!, detail: String): UpdateAlertConfigResult!
+
+  """
   Updates the alert subscription for the given prefix and email, returning
   the updated subscription.
   """
@@ -1022,6 +1098,16 @@ type PublicationStatus {
 }
 
 type QueryRoot {
+  """
+  Lists alert-config rows visible to the caller.
+  
+  Results are limited to readable prefixes and sorted by
+  `catalog_prefix_or_name`. `filter.catalogPrefixOrName.startsWith` can
+  narrow the results further. Passing a full catalog name returns at
+  most one exact-name row.
+  """
+  alertConfigs(after: String, filter: AlertConfigsFilter, first: Int): AlertConfigEntryConnection!
+
   """Returns a complete list of alert subscriptions."""
   alertSubscriptions(by: AlertSubscriptionsBy!): [AlertSubscription!]!
 
@@ -1443,6 +1529,13 @@ entities without requiring a central allocating authority.
 * [RFC4122: A Universally Unique Identifier (UUID) URN Namespace](http://tools.ietf.org/html/rfc4122)
 """
 scalar UUID
+
+"""Result of the `updateAlertConfig` mutation."""
+type UpdateAlertConfigResult {
+  catalogPrefixOrName: String!
+  created: Boolean!
+  id: Id!
+}
 
 """Result of updating a storage mapping."""
 type UpdateStorageMappingResult {

--- a/src/services/__tests__/luxon.test.ts
+++ b/src/services/__tests__/luxon.test.ts
@@ -1,0 +1,108 @@
+import { DateTime } from 'luxon';
+
+import { DataGrains } from 'src/components/graphs/types';
+import { LUXON_GRAIN_SETTINGS } from 'src/services/luxon';
+
+// The chart formatter calls DateTime.fromISO(ts) without { setZone: true }, so Luxon
+// converts the UTC timestamp to the local timezone by default.  Users in timezones
+// behind UTC (e.g. EDT = UTC-4) will see April 1 00:00 UTC arrive as March 31 20:00
+// local — a one-month shift.  The shortFormat / longFormat functions sometimes call
+// .toUTC() before formatting so the label always reflects the UTC month.
+
+describe('LUXON_GRAIN_SETTINGS', () => {
+    describe('monthly grain', () => {
+        const { shortFormat, longFormat, relativeUnit, timeUnit } =
+            LUXON_GRAIN_SETTINGS[DataGrains.monthly];
+
+        // Helper: April 1 00:00 UTC expressed in EDT (UTC-4) — the same instant a
+        // user behind UTC would get from DateTime.fromISO('2026-04-01T00:00:00+00:00').
+        const aprilUTCasEDT = DateTime.fromObject(
+            { year: 2026, month: 3, day: 31, hour: 20 },
+            { zone: 'America/New_York' }
+        );
+
+        describe('shortFormat', () => {
+            test('returns the UTC month for a UTC DateTime', () => {
+                expect(shortFormat(DateTime.utc(2026, 4, 1))).toBe('Apr');
+            });
+
+            test('returns UTC month when local time is in the previous month (regression)', () => {
+                // aprilUTCasEDT is March 31 locally but April 1 in UTC.
+                // Without .toUTC() this would return "Mar".
+                expect(aprilUTCasEDT.toUTC().month).toBe(4); // sanity-check the fixture
+                expect(shortFormat(aprilUTCasEDT)).toBe('Apr');
+            });
+
+            test('returns the UTC month for a UTC ISO string parsed by DateTime.fromISO', () => {
+                // DateTime.fromISO without {setZone:true} uses local zone. This test
+                // runs in whatever TZ the CI uses, but the UTC date is unambiguous.
+                const val = DateTime.fromISO('2026-01-01T00:00:00+00:00');
+                expect(shortFormat(val)).toBe('Jan');
+            });
+
+            test('formats each month correctly in UTC', () => {
+                const months = [
+                    'Jan',
+                    'Feb',
+                    'Mar',
+                    'Apr',
+                    'May',
+                    'Jun',
+                    'Jul',
+                    'Aug',
+                    'Sep',
+                    'Oct',
+                    'Nov',
+                    'Dec',
+                ];
+                months.forEach((name, idx) => {
+                    expect(shortFormat(DateTime.utc(2026, idx + 1, 1))).toBe(
+                        name
+                    );
+                });
+            });
+        });
+
+        describe('longFormat', () => {
+            test('includes the UTC month name and year', () => {
+                expect(longFormat(DateTime.utc(2026, 4, 1))).toContain('April');
+                expect(longFormat(DateTime.utc(2026, 4, 1))).toContain('2026');
+            });
+
+            test('returns UTC month when local time is in the previous month (regression)', () => {
+                // Same instant as the shortFormat regression test.
+                expect(longFormat(aprilUTCasEDT)).toContain('April');
+                expect(longFormat(aprilUTCasEDT)).toContain('2026');
+            });
+        });
+
+        test('uses months as the relativeUnit and month as the timeUnit', () => {
+            expect(relativeUnit).toBe('months');
+            expect(timeUnit).toBe('month');
+        });
+    });
+
+    describe('daily grain', () => {
+        const { shortFormat, relativeUnit, timeUnit } =
+            LUXON_GRAIN_SETTINGS[DataGrains.daily];
+
+        test('formats as "MMM dd" in UTC', () => {
+            expect(shortFormat(DateTime.utc(2026, 4, 15))).toBe('Apr 15');
+        });
+
+        test('uses days / day for relativeUnit / timeUnit', () => {
+            expect(relativeUnit).toBe('days');
+            expect(timeUnit).toBe('day');
+        });
+    });
+
+    describe('hourly grain', () => {
+        const { relativeUnit, timeUnit } =
+            LUXON_GRAIN_SETTINGS[DataGrains.hourly];
+
+        test('uses hours / hour for relativeUnit / timeUnit', () => {
+            expect(relativeUnit).toBe('hours');
+            expect(timeUnit).toBe('hour');
+        });
+    });
+});

--- a/src/services/luxon.ts
+++ b/src/services/luxon.ts
@@ -55,10 +55,12 @@ export const LUXON_GRAIN_SETTINGS: {
         selectedLabelKey: 'detailsPanel.recentUsage.filter.label.year',
         longFormat: (val) =>
             val
+                .toUTC()
                 .setLocale(navigator.language ?? 'en-US')
                 .toLocaleString({ month: 'long', year: 'numeric' }),
         shortFormat: (val) =>
             val
+                .toUTC()
                 .setLocale(navigator.language ?? 'en-US')
                 .toLocaleString({ month: 'short' }),
     },


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1965

## Changes

### 1965

- Added `toUTC` to ensure monthly stays in the proper month

### Misc

- Update codegen even though that isn't related to this

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

<img width="1097" height="474" alt="image" src="https://github.com/user-attachments/assets/285a7fdb-2be2-49cd-8ae1-0e10e8c92058" />

