### PR TITLE
Skip `connectorTag` for `transformations` during `binding hydration`

### DIFF
--- a/src/components/derivation/Create/index.tsx
+++ b/src/components/derivation/Create/index.tsx
@@ -84,7 +84,7 @@ function DerivationCreate() {
                     </Collapse>
 
                     <Collapse in={!showConfirmation}>
-                        <ConnectorTagProvider>
+                        <ConnectorTagProvider applicable={false}>
                             <BindingHydrator>
                                 <TransformationCreate
                                     key={newCollectionKey}

--- a/src/components/derivation/Create/index.tsx
+++ b/src/components/derivation/Create/index.tsx
@@ -12,6 +12,7 @@ import Instructions from 'src/components/derivation/Create/Instructions';
 import DialogTitleWithClose from 'src/components/shared/Dialog/TitleWithClose';
 import AdminCapabilityGuard from 'src/components/shared/guards/AdminCapability';
 import TransformationCreate from 'src/components/transformation/create';
+import { ConnectorTagProvider } from 'src/context/ConnectorTag';
 import { useZustandStore } from 'src/context/Zustand/provider';
 import { GlobalSearchParams } from 'src/hooks/searchParams/useGlobalSearchParams';
 import { useBinding_resetState } from 'src/stores/Binding/hooks';
@@ -83,18 +84,20 @@ function DerivationCreate() {
                     </Collapse>
 
                     <Collapse in={!showConfirmation}>
-                        <BindingHydrator>
-                            <TransformationCreate
-                                key={newCollectionKey}
-                                draftCreationCallback={(draftId) => {
-                                    if (draftId) {
-                                        setDraftId(draftId);
-                                        setShowConfirmation(true);
-                                    }
-                                }}
-                                closeDialog={closeDialog}
-                            />
-                        </BindingHydrator>
+                        <ConnectorTagProvider>
+                            <BindingHydrator>
+                                <TransformationCreate
+                                    key={newCollectionKey}
+                                    draftCreationCallback={(draftId) => {
+                                        if (draftId) {
+                                            setDraftId(draftId);
+                                            setShowConfirmation(true);
+                                        }
+                                    }}
+                                    closeDialog={closeDialog}
+                                />
+                            </BindingHydrator>
+                        </ConnectorTagProvider>
                     </Collapse>
                 </AdminCapabilityGuard>
             </DialogContent>

--- a/src/context/ConnectorTag.tsx
+++ b/src/context/ConnectorTag.tsx
@@ -8,7 +8,6 @@ import { useClient } from 'urql';
 
 import { CONNECTOR_TAG_QUERY } from 'src/api/gql/connectors';
 import ErrorComponent from 'src/components/shared/Error';
-import { useEntityWorkflow } from 'src/context/Workflow';
 import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'src/hooks/searchParams/useGlobalSearchParams';
@@ -35,22 +34,29 @@ export type ConnectorTagState =
 
 const ConnectorTagContext = createContext<ConnectorTagState | null>(null);
 
+interface Props extends BaseComponentProps {
+    applicable?: boolean; // Pass `false` for workflows that do not use a connector (transformations).
+}
+
 // When applicable - ALWAYS use within ConnectorSelectedGuard to ensure we have valid values in URL
-export const ConnectorTagProvider = ({ children }: BaseComponentProps) => {
+export const ConnectorTagProvider = ({
+    applicable = true,
+    children,
+}: Props) => {
     const connectorImagePath = useGlobalSearchParams(
         GlobalSearchParams.CONNECTOR_IMAGE_PATH
     );
     const client = useClient();
     const intl = useIntl();
-    const workflow = useEntityWorkflow();
 
     const [connectorTagState, setConnectorTagState] =
-        useState<ConnectorTagState | null>(null);
+        useState<ConnectorTagState | null>(() =>
+            applicable ? null : { applicable: false }
+        );
     const [fetchError, setFetchError] = useState<boolean | null>(false);
 
     useEffect(() => {
-        if (workflow === 'collection_create') {
-            setConnectorTagState({ applicable: false });
+        if (!applicable) {
             return;
         }
 
@@ -106,7 +112,7 @@ export const ConnectorTagProvider = ({ children }: BaseComponentProps) => {
                 }
 
                 setConnectorTagState({
-                    applicable: true,
+                    applicable,
                     data: {
                         ...spec,
                         connector: {
@@ -124,7 +130,7 @@ export const ConnectorTagProvider = ({ children }: BaseComponentProps) => {
                 });
                 setFetchError(true);
             });
-    }, [client, connectorImagePath, workflow]);
+    }, [applicable, client, connectorImagePath]);
 
     if (fetchError) {
         return (

--- a/src/context/ConnectorTag.tsx
+++ b/src/context/ConnectorTag.tsx
@@ -8,6 +8,7 @@ import { useClient } from 'urql';
 
 import { CONNECTOR_TAG_QUERY } from 'src/api/gql/connectors';
 import ErrorComponent from 'src/components/shared/Error';
+import { useEntityWorkflow } from 'src/context/Workflow';
 import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'src/hooks/searchParams/useGlobalSearchParams';
@@ -25,22 +26,34 @@ export type ConnectorTagData = NonNullable<
     >;
 };
 
-const ConnectorTagContext = createContext<ConnectorTagData | null>(null);
+// `applicable: false` means the workflow does not use a connector (transformations).
+// `applicable: true` means the connector tag was fetched and is available.
+// `null` context means the fetch is still in progress.
+export type ConnectorTagState =
+    | { applicable: false }
+    | { applicable: true; data: ConnectorTagData };
 
-// ALWAYS used within ConnectorSelectedGuard to ensure we have valid values in URL
+const ConnectorTagContext = createContext<ConnectorTagState | null>(null);
+
+// When applicable - ALWAYS use within ConnectorSelectedGuard to ensure we have valid values in URL
 export const ConnectorTagProvider = ({ children }: BaseComponentProps) => {
     const connectorImagePath = useGlobalSearchParams(
         GlobalSearchParams.CONNECTOR_IMAGE_PATH
     );
     const client = useClient();
     const intl = useIntl();
+    const workflow = useEntityWorkflow();
 
-    const [connectorTag, setConnectorTag] = useState<ConnectorTagData | null>(
-        null
-    );
+    const [connectorTagState, setConnectorTagState] =
+        useState<ConnectorTagState | null>(null);
     const [fetchError, setFetchError] = useState<boolean | null>(false);
 
     useEffect(() => {
+        if (workflow === 'collection_create') {
+            setConnectorTagState({ applicable: false });
+            return;
+        }
+
         if (!hasLength(connectorImagePath)) {
             logRocketEvent('Connectors:fetch', {
                 noImagePath: true,
@@ -92,13 +105,16 @@ export const ConnectorTagProvider = ({ children }: BaseComponentProps) => {
                     });
                 }
 
-                setConnectorTag({
-                    ...spec,
-                    connector: {
-                        id: connector.id,
-                        imageName: connector.imageName,
-                        logoUrl: connector.logoUrl,
-                        title: connector.title,
+                setConnectorTagState({
+                    applicable: true,
+                    data: {
+                        ...spec,
+                        connector: {
+                            id: connector.id,
+                            imageName: connector.imageName,
+                            logoUrl: connector.logoUrl,
+                            title: connector.title,
+                        },
                     },
                 });
             })
@@ -108,7 +124,7 @@ export const ConnectorTagProvider = ({ children }: BaseComponentProps) => {
                 });
                 setFetchError(true);
             });
-    }, [client, connectorImagePath]);
+    }, [client, connectorImagePath, workflow]);
 
     if (fetchError) {
         return (
@@ -124,13 +140,12 @@ export const ConnectorTagProvider = ({ children }: BaseComponentProps) => {
         );
     }
 
-    // While loading we don't want to show anything
-    if (!connectorTag) {
+    if (!connectorTagState) {
         return null;
     }
 
     return (
-        <ConnectorTagContext.Provider value={connectorTag}>
+        <ConnectorTagContext.Provider value={connectorTagState}>
             {children}
         </ConnectorTagContext.Provider>
     );
@@ -139,11 +154,17 @@ export const ConnectorTagProvider = ({ children }: BaseComponentProps) => {
 export const useConnectorTag = (): ConnectorTagData => {
     const context = useContext(ConnectorTagContext);
 
-    if (!context) {
+    if (!context?.applicable) {
         throw new Error(
-            'useConnectorTag must be used within a ConnectorTagProvider'
+            'useConnectorTag must be used within a ConnectorTagProvider with an applicable connector'
         );
     }
 
-    return context;
+    return context.data;
+};
+
+// Use when the caller can safely skip the tag (BindingHydrator). This way we do not
+//  have to write a bunch of null safe code in the flows that will always require a connector.
+export const useConnectorTag_nullable = (): ConnectorTagState | null => {
+    return useContext(ConnectorTagContext);
 };

--- a/src/stores/Binding/Hydrator.tsx
+++ b/src/stores/Binding/Hydrator.tsx
@@ -2,7 +2,7 @@ import type { BaseComponentProps } from 'src/types';
 
 import { useEffect, useRef } from 'react';
 
-import { useConnectorTag } from 'src/context/ConnectorTag';
+import { useConnectorTag_nullable } from 'src/context/ConnectorTag';
 import { useEntityType } from 'src/context/EntityContext';
 import {
     useEntityWorkflow,
@@ -30,7 +30,7 @@ export const BindingHydrator = ({ children }: BaseComponentProps) => {
 
     const getTrialPrefixes = useTrialPrefixes();
 
-    const connectorTag = useConnectorTag();
+    const connectorTagState = useConnectorTag_nullable();
 
     const hydrated = useBinding_hydrated();
     const setHydrated = useBinding_setHydrated();
@@ -43,7 +43,11 @@ export const BindingHydrator = ({ children }: BaseComponentProps) => {
     );
 
     useEffect(() => {
-        if ((workflow && connectorTag) || workflow === 'collection_create') {
+        if (workflow && connectorTagState) {
+            const connectorTag = connectorTagState.applicable
+                ? connectorTagState.data
+                : null;
+
             setActive(true);
 
             // TODO (Workflow Hydrator) - when moving bindings into the parent hydrator
@@ -84,7 +88,7 @@ export const BindingHydrator = ({ children }: BaseComponentProps) => {
                 });
         }
     }, [
-        connectorTag,
+        connectorTagState,
         editWorkflow,
         entityType,
         getTrialPrefixes,


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1967

## Changes

### 1967

- Allow connector tag context to be skippable

## Tests

### Manually tested

- Capture, Materialization - create and edit
- Transformation - create

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Transform
<img width="1506" height="728" alt="image" src="https://github.com/user-attachments/assets/2809f826-aabb-4684-8208-895fc7e7f0d0" />

### Capture
<img width="1447" height="873" alt="image" src="https://github.com/user-attachments/assets/97ff77f5-61f3-4f14-94e1-6d2f637b3a81" />

<img width="1415" height="998" alt="image" src="https://github.com/user-attachments/assets/81bf49cd-3927-4865-ba72-1f8dcc36a29d" />

### Materialization
<img width="1427" height="904" alt="image" src="https://github.com/user-attachments/assets/6813a89d-c40d-41ff-8467-bf2523da2fa4" />

<img width="1442" height="1016" alt="image" src="https://github.com/user-attachments/assets/dfe88d9c-c8a4-4dd3-8054-3b324fe0798a" />
