### PR TITLE
Fixing zindex for LLM skills toast and hiding when docs are open

### DIFF
--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -84,7 +84,7 @@ function AppLayout() {
                 />
             </Box>
 
-            <Toast />
+            <Toast docsPanelOpen={displaySidePanel} />
 
             <Box
                 sx={{

--- a/src/components/AgentSkills/Toast.tsx
+++ b/src/components/AgentSkills/Toast.tsx
@@ -30,7 +30,11 @@ const toastIn = keyframes`
     100% { opacity: 1; transform: translateY(0)    scale(1);    }
 `;
 
-export function Toast() {
+interface ToastProps {
+    docsPanelOpen?: boolean;
+}
+
+export function Toast({ docsPanelOpen }: ToastProps) {
     const theme = useTheme();
     const mode = theme.palette.mode;
     const intl = useIntl();
@@ -38,7 +42,9 @@ export function Toast() {
     const toastDismissed = useAgentSkillsStore((s) => s.toastDismissed);
     const dismissToast = useAgentSkillsStore((s) => s.dismissToast);
 
-    if (toastDismissed) {
+    // If the docs panel is open just hide the toast. That way it cannot cover up
+    //  the cookie consent banner in the docs.
+    if (toastDismissed || docsPanelOpen) {
         return null;
     }
 

--- a/src/components/AgentSkills/Toast.tsx
+++ b/src/components/AgentSkills/Toast.tsx
@@ -23,6 +23,7 @@ import {
     useAgentSkillsStore,
 } from 'src/components/AgentSkills/shared';
 import { SparkleIcon } from 'src/components/AgentSkills/SparkleIcon';
+import { toastIndex } from 'src/context/Theme';
 
 const toastIn = keyframes`
     0%   { opacity: 0; transform: translateY(16px) scale(0.98); }
@@ -64,7 +65,7 @@ export function Toast() {
                 'display': 'block',
                 'animation': `${toastIn} 750ms cubic-bezier(.2,.9,.25,1) 1s both`,
                 'transition': 'transform 200ms ease, box-shadow 200ms ease',
-                'zIndex': theme.zIndex.snackbar,
+                'zIndex': toastIndex,
                 '&:hover': {
                     transform: 'translateY(-2px)',
                     boxShadow:

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -344,6 +344,9 @@ const accordionButton = zIndexIncrement * 5;
 // Need to make the sticky header be on top
 export const headerLinkIndex = zIndexIncrement * 30;
 
+// Want to make sure it is near the top but right under the screen disable overlay
+export const toastIndex = zIndexIncrement * 35;
+
 // Popper component z index must be greater than 100, the z index of the reflex splitter component.
 export const popperIndex = zIndexIncrement * 500;
 


### PR DESCRIPTION
## Issues

https://github.com/estuary/ui/issues/1984

## Changes

### 1984

- Updated zindex
- Hide the toast if the docs panel is open

## Tests

### Manually tested

-   scenarios you manually tested

### Automated tests

-   unit testing covered

#### Playwright tests ran locally

-   [ ] Admin
-   [ ] Captures
-   [ ] Collections
-   [ ] HomePage
-   [ ] Login
-   [ ] Materialization

## Screenshots

### Modal open
Should be below the overlay now - initially thought this could be rare but I guess with Alert details this could happen.
<img width="2559" height="1293" alt="image" src="https://github.com/user-attachments/assets/885a0cab-0441-4dcd-8390-a35ba46b9ecf" />


### Docs Open
<img width="2559" height="1282" alt="image" src="https://github.com/user-attachments/assets/551d935d-2c8b-4326-b50b-da1b89b7933f" />

### Docs Closed
When opening it does animate back in smoothly
<img width="2560" height="1294" alt="image" src="https://github.com/user-attachments/assets/84be3431-255f-40a3-bc6b-a9b8a5e80ae4" />



