### PR TITLE
Move account and help menus to side nav footer

### DIFF
--- a/src/components/menus/HelpMenu.tsx
+++ b/src/components/menus/HelpMenu.tsx
@@ -13,6 +13,11 @@ function HelpMenu() {
             icon={<HelpCircle />}
             identifier="help-menu"
             tooltip={intl.formatMessage({ id: 'helpMenu.tooltip' })}
+            hideArrow
+            customMenuPosition={{
+                anchorOrigin: { vertical: 'top', horizontal: 'left' },
+                transformOrigin: { vertical: 'bottom', horizontal: 'left' },
+            }}
         >
             <ExternalLinkMenuItem
                 link={intl.formatMessage({ id: 'helpMenu.docs.link' })}

--- a/src/components/menus/UserMenu.tsx
+++ b/src/components/menus/UserMenu.tsx
@@ -50,6 +50,11 @@ const UserMenu = ({ iconColor }: Props) => {
                 }
                 identifier="account-menu"
                 tooltip={intl.formatMessage({ id: 'accountMenu.tooltip' })}
+                hideArrow
+                customMenuPosition={{
+                    anchorOrigin: { vertical: 'top', horizontal: 'left' },
+                    transformOrigin: { vertical: 'bottom', horizontal: 'left' },
+                }}
             >
                 <MenuItem sx={nonInteractiveMenuStyling}>
                     <ListItemIcon>

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -23,6 +23,8 @@ import {
 import { useIntl } from 'react-intl';
 
 import { authenticatedRoutes } from 'src/app/routes';
+import HelpMenu from 'src/components/menus/HelpMenu';
+import UserMenu from 'src/components/menus/UserMenu';
 import ListItemLink from 'src/components/navigation/ListItemLink';
 import ModeSwitch from 'src/components/navigation/ModeSwitch';
 import { paperBackground } from 'src/context/Theme';
@@ -118,6 +120,10 @@ const Navigation = ({ open, width, onNavigationToggle }: NavigationProps) => {
                             py: 1,
                         }}
                     >
+                        <UserMenu iconColor={theme.palette.text.primary} />
+
+                        <HelpMenu />
+
                         <ModeSwitch />
 
                         <Tooltip

--- a/src/components/navigation/TopBar.tsx
+++ b/src/components/navigation/TopBar.tsx
@@ -4,8 +4,6 @@ import { useTheme } from '@mui/material/styles';
 
 import { HeaderPill } from 'src/components/AgentSkills/HeaderPill';
 import CompanyLogo from 'src/components/graphics/CompanyLogo';
-import HelpMenu from 'src/components/menus/HelpMenu';
-import UserMenu from 'src/components/menus/UserMenu';
 import PageTitle from 'src/components/navigation/PageTitle';
 import SidePanelDocsOpenButton from 'src/components/sidePanelDocs/OpenButton';
 import { UpdateAlert } from 'src/components/UpdateAlert';
@@ -44,10 +42,6 @@ const Topbar = () => {
                     <UpdateAlert />
 
                     <HeaderPill />
-
-                    <HelpMenu />
-
-                    <UserMenu iconColor={theme.palette.text.primary} />
 
                     <SidePanelDocsOpenButton />
                 </Stack>


### PR DESCRIPTION
## Summary
- Move the account (avatar) and help menus from the top-right app bar to the lower-left of the side navigation, above the theme toggle and collapse control.
- Their dropdowns open upward (and drop the downward-pointing arrow) to suit the new bottom-docked position.

## Changes
- `TopBar.tsx`: remove `UserMenu` and `HelpMenu` from the app bar.
- `Navigation.tsx`: render `UserMenu` and `HelpMenu` in the sidebar footer list.
- `UserMenu.tsx` / `HelpMenu.tsx`: open the popup upward and hide the arrow.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (changed files)
- [ ] Sidebar footer placement looks right (expanded + collapsed/rail states)
- [ ] Account/help dropdowns open upward and stay fully visible