### PR TITLE
RR7 3/5: Clean up admin/billing and collections splat routes

### DIFF
--- a/src/context/Router/index.tsx
+++ b/src/context/Router/index.tsx
@@ -230,7 +230,10 @@ const routes: RouteObject[] = [
                             },
 
                             {
-                                path: `${authenticatedRoutes.collections.path}/*`,
+                                // Splat handled by the `*` child below rather
+                                // than a `path: 'collections/*'` parent, per
+                                // react-router's v7_relativeSplatPath guidance.
+                                path: authenticatedRoutes.collections.path,
                                 children: [
                                     // Check details first as collections create
                                     // opens as dialog meaning we include the
@@ -477,37 +480,26 @@ const routes: RouteObject[] = [
                                             .path,
                                         element: suspended(<AdminApi />),
                                     },
-                                    // TODO (routing cleanup): the `billing/*`
-                                    // subtree below produces /admin/billing and
-                                    // /admin/billing/billing, and is duplicated
-                                    // by the standalone billing route that
-                                    // follows it. Preserved verbatim during the
-                                    // data-router migration; worth pruning.
                                     {
-                                        path: `${authenticatedRoutes.admin.billing.path}/*`,
+                                        path: authenticatedRoutes.admin.billing
+                                            .path,
                                         children: [
+                                            {
+                                                index: true,
+                                                element: lazyElement(
+                                                    <AdminBilling />
+                                                ),
+                                            },
                                             {
                                                 path: authenticatedRoutes.admin
                                                     .billing.addPayment.path,
-                                                element: suspended(
+                                                element: lazyElement(
                                                     <AdminBilling
                                                         showAddPayment
                                                     />
                                                 ),
                                             },
-                                            {
-                                                path: authenticatedRoutes.admin
-                                                    .billing.path,
-                                                element: suspended(
-                                                    <AdminBilling />
-                                                ),
-                                            },
                                         ],
-                                    },
-                                    {
-                                        path: authenticatedRoutes.admin.billing
-                                            .path,
-                                        element: lazyElement(<AdminBilling />),
                                     },
                                     {
                                         path: authenticatedRoutes.admin.settings


### PR DESCRIPTION
Part of the React Router v7 upgrade stack (3 of 5). **Base: `greg/rr7-2-data-router`.**

Two splat-route cleanups, landed before the future-flag PR because `v7_relativeSplatPath` changes how paths resolve inside splat routes.

**admin/billing:** collapse the `billing/*` splat into a `billing` parent with an index route + a `paymentMethod/new` child. This:
- removes the duplicate billing registration and the dead `/admin/billing/billing` route, and
- fixes a latent bug — `/admin/billing/<garbage>` previously rendered an empty content card because the splat swallowed it; it now correctly falls through to **Page Not Found**.
- both billing routes are now consistently `lazyElement`-wrapped (error boundary + suspense).

**collections:** drop the `/*` from the parent path; the existing `*` child already handles the splat. This matches react-router's `v7_relativeSplatPath` guidance and is behavior-preserving.

Verified in-app: `/admin/billing`, `/admin/billing/paymentMethod/new`, `/collections/create/new` (dialog over table), and the new 404 for bad billing subpaths.