### PR TITLE
RR7 4/5: Enable react-router v7 future flags on v6

### DIFF
--- a/src/context/Router/index.tsx
+++ b/src/context/Router/index.tsx
@@ -547,10 +547,23 @@ const routes: RouteObject[] = [
     },
 ];
 
-const router = createBrowserRouter(routes);
+// Opt into v7 behavior while still on v6 so the v7 package swap is a no-op.
+// These all become defaults in v7 (and are removed at that point).
+// Note: v7_startTransition is a RouterProvider prop, not a router option.
+const router = createBrowserRouter(routes, {
+    future: {
+        v7_relativeSplatPath: true,
+        v7_fetcherPersist: true,
+        v7_normalizeFormMethod: true,
+        v7_partialHydration: true,
+        v7_skipActionErrorRevalidation: true,
+    },
+});
 
 const ApplicationRouter = () => {
-    return <RouterProvider router={router} />;
+    return (
+        <RouterProvider router={router} future={{ v7_startTransition: true }} />
+    );
 };
 
 export default ApplicationRouter;


### PR DESCRIPTION
Part of the React Router v7 upgrade stack (4 of 5). **Base: `greg/rr7-3-splat-cleanup`.**

Opts into v7 routing semantics while still on v6, so the actual package swap (PR 5) is behavior-neutral and easy to roll back.

- `v7_relativeSplatPath` — already satisfied by the splat cleanup in PR 3.
- `v7_fetcherPersist`, `v7_normalizeFormMethod`, `v7_partialHydration`, `v7_skipActionErrorRevalidation` — **no-ops here**: the app uses no loaders/actions/fetchers (audited: no `formMethod`, no `fallbackElement`, no react-router `defer()`/`json()`).
- `v7_startTransition` — set on `RouterProvider` (it's a render flag, not a router option).

Verified the app boots and the collections create dialog still renders over the table under the new splat semantics. Note: these flags are reverted in PR 5 because they become the default in v7.