### PR TITLE
update Estuary IP fallback list

### DIFF
--- a/src/lang/en-US/JsonForms.ts
+++ b/src/lang/en-US/JsonForms.ts
@@ -13,7 +13,7 @@ export const JsonForms: Record<string, string> = {
     'dateTimePicker.picker.footer': `Timezone: UTC`,
     'datePicker.button.ariaLabel': `Open date picker for {label}`,
     'informational.sshEndpoint.title': `All Estuary traffic comes from a group of IPs that can be whitelisted:`,
-    'informational.sshEndpoint.ipv4': `34.121.207.128, 35.226.75.135, 34.68.62.148`,
+    'informational.sshEndpoint.ipv4': `35.226.75.135`,
     'informational.sshEndpoint.ipv6': `does not support IPv6`,
     'timePicker.button.ariaLabel': `Open time picker for {label}`,
 


### PR DESCRIPTION
Updates the hardcoded IP fallback shown when a data plane's CIDR list is unavailable, so it matches current configuration.