### PR TITLE
sops-utils: Overlay-aware endpoint config parsing

### DIFF
--- a/src/gql-types/graphql.ts
+++ b/src/gql-types/graphql.ts
@@ -654,11 +654,11 @@ export type DataPlane = {
   /** Name of this data-plane under the catalog namespace. */
   name: Scalars['String']['output'];
   /**
-   * Configured private link endpoints for this data-plane. Replacing this
-   * list (via `updateDataPlanePrivateLinks`) triggers reconvergence by the
-   * data-plane controller on its next poll. Returns an empty list to
-   * callers that lack the `ViewDataPlanePrivateNetworking` capability on
-   * this data plane.
+   * Configured private links for this data-plane, each with its
+   * controller-observed provisioning status. Mutating links (via
+   * `addDataPlanePrivateLink` and friends) triggers reconvergence by the
+   * data-plane controller. Returns an empty list to callers that lack the
+   * `ViewDataPlanePrivateNetworking` capability on this data plane.
    */
   privateLinks: Array<PrivateLink>;
   /** Address of reactors within the data-plane. */
@@ -1066,6 +1066,12 @@ export type LockFailure = {
 export type MutationRoot = {
   __typename?: 'MutationRoot';
   /**
+   * Adds a private link to a private data plane. The data-plane controller
+   * converges to provision it on its next poll; the returned link starts
+   * `pending`. Requires `ModifyDataPlanePrivateNetworking` on the data plane.
+   */
+  addDataPlanePrivateLink: PrivateLink;
+  /**
    * Add a user_grant to a service account.
    *
    * The caller must have CreateGrant on BOTH the account's catalog name and
@@ -1161,6 +1167,12 @@ export type MutationRoot = {
    */
   removeAllServiceAccountGrants: ServiceAccount;
   /**
+   * Removes a private link by id. The controller tears down its endpoint on
+   * the next converge. Requires `ModifyDataPlanePrivateNetworking` on the
+   * owning data plane. Returns the removed link id.
+   */
+  removeDataPlanePrivateLink: Scalars['Id']['output'];
+  /**
    * Remove a user_grant from a service account, returning the account in its
    * post-removal state.
    *
@@ -1244,18 +1256,14 @@ export type MutationRoot = {
    */
   updateAlertSubscription: AlertSubscription;
   /**
-   * Replaces the configured private link endpoints on a private data plane.
-   *
-   * The provided list overwrites the entire `private_links` column; partial
-   * updates are intentionally not supported. The data-plane controller
-   * converges to the new configuration on its next poll. Returns the desired
-   * private links state. The `*LinkEndpoints` provisioning results are not echoed here:
-   * they lag this write until the controller converges, so callers needing them re-query `dataPlanes`.
-   *
-   * Requires the `ModifyDataPlanePrivateNetworking` capability on the
-   * private data-plane name.
+   * Replaces the configuration of an existing private link by id. A changed
+   * config resets the observed status to `pending` and re-triggers convergence:
+   * the desired-edit trigger clears the observation columns and bumps the
+   * link's internal generation, so a converge already in flight against the
+   * previous configuration cannot later stamp this link with a stale status.
+   * Requires `ModifyDataPlanePrivateNetworking` on the owning data plane.
    */
-  updateDataPlanePrivateLinks: Array<PrivateLink>;
+  updateDataPlanePrivateLink: PrivateLink;
   /**
    * Update an existing storage mapping for the given catalog prefix.
    *
@@ -1268,6 +1276,12 @@ export type MutationRoot = {
    * are allowed (they were already validated when created).
    */
   updateStorageMapping: UpdateStorageMappingResult;
+};
+
+
+export type MutationRootAddDataPlanePrivateLinkArgs = {
+  config: PrivateLinkConfigInput;
+  dataPlaneName: Scalars['String']['input'];
 };
 
 
@@ -1353,6 +1367,11 @@ export type MutationRootRemoveAllServiceAccountGrantsArgs = {
 };
 
 
+export type MutationRootRemoveDataPlanePrivateLinkArgs = {
+  id: Scalars['Id']['input'];
+};
+
+
 export type MutationRootRemoveServiceAccountGrantArgs = {
   catalogName: Scalars['Name']['input'];
   prefix: Scalars['Prefix']['input'];
@@ -1409,9 +1428,9 @@ export type MutationRootUpdateAlertSubscriptionArgs = {
 };
 
 
-export type MutationRootUpdateDataPlanePrivateLinksArgs = {
-  dataPlaneName: Scalars['String']['input'];
-  privateLinks: Array<PrivateLinkInput>;
+export type MutationRootUpdateDataPlanePrivateLinkArgs = {
+  config: PrivateLinkConfigInput;
+  id: Scalars['Id']['input'];
 };
 
 
@@ -1506,21 +1525,54 @@ export type PrefixesBy = {
   minCapability: Capability;
 };
 
-/**
- * Private link configuration for a customer-owned data plane: AWS
- * PrivateLink, Azure Private Link, or GCP Private Service Connect.
- */
-export type PrivateLink = AwsPrivateLink | AzurePrivateLink | GcpPrivateServiceConnect;
+/** A configured private link and its controller-observed provisioning status. */
+export type PrivateLink = {
+  __typename?: 'PrivateLink';
+  /**
+   * The link configuration (AWS PrivateLink, Azure Private Link, or GCP PSC).
+   * Its variant (`AWSPrivateLink`/`AzurePrivateLink`/`GCPPrivateServiceConnect`)
+   * is the link's cloud provider.
+   */
+  config: PrivateLinkConfig;
+  /**
+   * Provider-specific provisioning details (DNS entries, IPs) once
+   * provisioned; opaque JSON exported by the data-plane controller.
+   */
+  details?: Maybe<Scalars['JSON']['output']>;
+  /** Failure detail when `status` is `failed`. */
+  error?: Maybe<Scalars['String']['output']>;
+  /** Stable identifier of this private link. */
+  id: Scalars['Id']['output'];
+  /** When the controller last observed this link's status. */
+  observedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Controller-observed provisioning status. */
+  status: PrivateLinkProvisioningStatus;
+};
 
 /**
  * Private link configuration for a customer-owned data plane: AWS
  * PrivateLink, Azure Private Link, or GCP Private Service Connect.
  */
-export type PrivateLinkInput = {
+export type PrivateLinkConfig = AwsPrivateLink | AzurePrivateLink | GcpPrivateServiceConnect;
+
+/**
+ * Private link configuration for a customer-owned data plane: AWS
+ * PrivateLink, Azure Private Link, or GCP Private Service Connect.
+ */
+export type PrivateLinkConfigInput = {
   aws?: InputMaybe<AwsPrivateLinkInput>;
   azure?: InputMaybe<AzurePrivateLinkInput>;
   gcp?: InputMaybe<GcpPrivateServiceConnectInput>;
 };
+
+/** Controller-observed provisioning status of a configured private link. */
+export type PrivateLinkProvisioningStatus =
+  /** Provisioning failed; see `error`. */
+  | 'FAILED'
+  /** Not yet provisioned for the current configuration. */
+  | 'PENDING'
+  /** Provisioned; `details` describes the endpoint. */
+  | 'PROVISIONED';
 
 /** Filter connectors by their protocol (capture or materialization). */
 export type ProtocolFilter = {

--- a/src/gql-types/schema.graphql
+++ b/src/gql-types/schema.graphql
@@ -682,11 +682,11 @@ type DataPlane {
   name: String!
 
   """
-  Configured private link endpoints for this data-plane. Replacing this
-  list (via `updateDataPlanePrivateLinks`) triggers reconvergence by the
-  data-plane controller on its next poll. Returns an empty list to
-  callers that lack the `ViewDataPlanePrivateNetworking` capability on
-  this data plane.
+  Configured private links for this data-plane, each with its
+  controller-observed provisioning status. Mutating links (via
+  `addDataPlanePrivateLink` and friends) triggers reconvergence by the
+  data-plane controller. Returns an empty list to callers that lack the
+  `ViewDataPlanePrivateNetworking` capability on this data plane.
   """
   privateLinks: [PrivateLink!]!
 
@@ -1085,6 +1085,13 @@ type LockFailure {
 
 type MutationRoot {
   """
+  Adds a private link to a private data plane. The data-plane controller
+  converges to provision it on its next poll; the returned link starts
+  `pending`. Requires `ModifyDataPlanePrivateNetworking` on the data plane.
+  """
+  addDataPlanePrivateLink(config: PrivateLinkConfigInput!, dataPlaneName: String!): PrivateLink!
+
+  """
   Add a user_grant to a service account.
   
   The caller must have CreateGrant on BOTH the account's catalog name and
@@ -1207,6 +1214,13 @@ type MutationRoot {
   removeAllServiceAccountGrants(catalogName: Name!): ServiceAccount!
 
   """
+  Removes a private link by id. The controller tears down its endpoint on
+  the next converge. Requires `ModifyDataPlanePrivateNetworking` on the
+  owning data plane. Returns the removed link id.
+  """
+  removeDataPlanePrivateLink(id: Id!): Id!
+
+  """
   Remove a user_grant from a service account, returning the account in its
   post-removal state.
   
@@ -1297,18 +1311,14 @@ type MutationRoot {
   updateAlertSubscription(alertTypes: [AlertType!], detail: String, email: String!, prefix: Prefix!): AlertSubscription!
 
   """
-  Replaces the configured private link endpoints on a private data plane.
-  
-  The provided list overwrites the entire `private_links` column; partial
-  updates are intentionally not supported. The data-plane controller
-  converges to the new configuration on its next poll. Returns the desired
-  private links state. The `*LinkEndpoints` provisioning results are not echoed here:
-  they lag this write until the controller converges, so callers needing them re-query `dataPlanes`.
-  
-  Requires the `ModifyDataPlanePrivateNetworking` capability on the
-  private data-plane name.
+  Replaces the configuration of an existing private link by id. A changed
+  config resets the observed status to `pending` and re-triggers convergence:
+  the desired-edit trigger clears the observation columns and bumps the
+  link's internal generation, so a converge already in flight against the
+  previous configuration cannot later stamp this link with a stale status.
+  Requires `ModifyDataPlanePrivateNetworking` on the owning data plane.
   """
-  updateDataPlanePrivateLinks(dataPlaneName: String!, privateLinks: [PrivateLinkInput!]!): [PrivateLink!]!
+  updateDataPlanePrivateLink(config: PrivateLinkConfigInput!, id: Id!): PrivateLink!
 
   """
   Update an existing storage mapping for the given catalog prefix.
@@ -1427,19 +1437,61 @@ input PrefixesBy {
 }
 
 """
-Private link configuration for a customer-owned data plane: AWS
-PrivateLink, Azure Private Link, or GCP Private Service Connect.
+A configured private link and its controller-observed provisioning status.
 """
-union PrivateLink = AWSPrivateLink | AzurePrivateLink | GCPPrivateServiceConnect
+type PrivateLink {
+  """
+  The link configuration (AWS PrivateLink, Azure Private Link, or GCP PSC).
+  Its variant (`AWSPrivateLink`/`AzurePrivateLink`/`GCPPrivateServiceConnect`)
+  is the link's cloud provider.
+  """
+  config: PrivateLinkConfig!
+
+  """
+  Provider-specific provisioning details (DNS entries, IPs) once
+  provisioned; opaque JSON exported by the data-plane controller.
+  """
+  details: JSON
+
+  """Failure detail when `status` is `failed`."""
+  error: String
+
+  """Stable identifier of this private link."""
+  id: Id!
+
+  """When the controller last observed this link's status."""
+  observedAt: DateTime
+
+  """Controller-observed provisioning status."""
+  status: PrivateLinkProvisioningStatus!
+}
 
 """
 Private link configuration for a customer-owned data plane: AWS
 PrivateLink, Azure Private Link, or GCP Private Service Connect.
 """
-input PrivateLinkInput {
+union PrivateLinkConfig = AWSPrivateLink | AzurePrivateLink | GCPPrivateServiceConnect
+
+"""
+Private link configuration for a customer-owned data plane: AWS
+PrivateLink, Azure Private Link, or GCP Private Service Connect.
+"""
+input PrivateLinkConfigInput {
   aws: AWSPrivateLinkInput
   azure: AzurePrivateLinkInput
   gcp: GCPPrivateServiceConnectInput
+}
+
+"""Controller-observed provisioning status of a configured private link."""
+enum PrivateLinkProvisioningStatus {
+  """Provisioning failed; see `error`."""
+  FAILED
+
+  """Not yet provisioned for the current configuration."""
+  PENDING
+
+  """Provisioned; `details` describes the endpoint."""
+  PROVISIONED
 }
 
 """Filter connectors by their protocol (capture or materialization)."""

--- a/src/utils/__tests__/sops-utils.test.ts
+++ b/src/utils/__tests__/sops-utils.test.ts
@@ -1,6 +1,9 @@
 import type { Schema } from 'src/types';
 
-import { copyEncryptedEndpointConfig } from 'src/utils/sops-utils';
+import {
+    applyOverlay,
+    copyEncryptedEndpointConfig,
+} from 'src/utils/sops-utils';
 
 describe('copyEncryptedEndpointConfig', () => {
     const sopsSuffix = '_sops';
@@ -107,5 +110,63 @@ describe('copyEncryptedEndpointConfig', () => {
                 copyEncryptedEndpointConfig(inputSpec, '_sops', false)
             ).toMatchSnapshot();
         });
+    });
+});
+
+describe('applyOverlay', () => {
+    test('merges an overlay leaf alongside an existing sibling', () => {
+        expect(
+            applyOverlay(
+                { advanced: { slot_name: 'flow_slot' } },
+                { advanced: { backfill_chunk_size: 50000 } }
+            )
+        ).toEqual({
+            advanced: { slot_name: 'flow_slot', backfill_chunk_size: 50000 },
+        });
+    });
+
+    test('overlay value supersedes an existing (stale) main-config value', () => {
+        expect(
+            applyOverlay(
+                { advanced: { feature_flags: 'old_value' } },
+                { advanced: { feature_flags: 'new_value' } }
+            )
+        ).toEqual({ advanced: { feature_flags: 'new_value' } });
+    });
+
+    test('populates an overlay field absent from the extracted data', () => {
+        expect(
+            applyOverlay({ address: 'db:5432' }, { advanced: { size: 1 } })
+        ).toEqual({ address: 'db:5432', advanced: { size: 1 } });
+    });
+
+    test('a nested null clears a field (RFC 7396)', () => {
+        expect(applyOverlay({ a: 1, b: 2 }, { b: null })).toEqual({ a: 1 });
+    });
+
+    test('a nested array replaces the existing value wholesale', () => {
+        expect(applyOverlay({ a: [1, 2, 3] }, { a: [4] })).toEqual({
+            a: [4],
+        });
+    });
+
+    test('an empty overlay is a no-op', () => {
+        expect(applyOverlay({ a: { b: 1 } }, {})).toEqual({ a: { b: 1 } });
+    });
+
+    test('a missing, null, or non-object overlay leaves the data unchanged', () => {
+        const data = { advanced: { slot_name: 'flow_slot' } };
+
+        expect(applyOverlay(data, undefined)).toEqual(data);
+        expect(applyOverlay(data, null)).toEqual(data);
+        expect(applyOverlay(data, 'not an object')).toEqual(data);
+        expect(applyOverlay(data, [1, 2, 3])).toEqual(data);
+    });
+
+    test('does not mutate the extracted data', () => {
+        const data = { advanced: { slot_name: 'flow_slot' } };
+        applyOverlay(data, { advanced: { size: 1 } });
+
+        expect(data).toEqual({ advanced: { slot_name: 'flow_slot' } });
     });
 });

--- a/src/utils/sops-utils.ts
+++ b/src/utils/sops-utils.ts
@@ -66,6 +66,29 @@ export const copyEncryptedEndpointConfig = (
     return response;
 };
 
+// Merge a config's `sops.overlay` onto the plaintext `data` extracted from its
+//  encrypted body. A missing or non-object overlay is a no-op, so configs which
+//  predate the overlay feature are unmodified.
+export const applyOverlay = (data: any, overlay: any): any => {
+    if (!isPlainObject(overlay)) {
+        return data;
+    }
+
+    const result: Record<string, any> = isPlainObject(data) ? { ...data } : {};
+
+    Object.entries(overlay).forEach(([key, value]) => {
+        if (value === null) {
+            delete result[key];
+        } else if (isPlainObject(value)) {
+            result[key] = applyOverlay(result[key], value);
+        } else {
+            result[key] = value;
+        }
+    });
+
+    return result;
+};
+
 export const parseEncryptedEndpointConfig = (
     endpointConfig: { [key: string]: any },
     endpointSchema: Schema,
@@ -75,17 +98,24 @@ export const parseEncryptedEndpointConfig = (
     //      bad data and we just need to be safe.
     if (endpointConfig.sops) {
         const {
-            sops: { encrypted_suffix },
+            sops: { encrypted_suffix, overlay },
             ...encryptedEndpointConfig
         } = endpointConfig;
 
         // Generate template and populate data
         const endpointConfigTemplate = createJSONFormDefaults(endpointSchema);
-        endpointConfigTemplate.data = copyEncryptedEndpointConfig(
+        const data = copyEncryptedEndpointConfig(
             encryptedEndpointConfig,
             encrypted_suffix,
             overrideJsonFormDefaults
         );
+
+        // The `sops.overlay` property holds overrides for "nonsensitive" fields
+        //  not covered by the SOPS MAC. We need to merge these in so the form
+        //  renders the correct values and a save preserves them. The UI doesn't
+        //  check non-sensitivity since that would be a lot of work and isn't
+        //  really necessary, the runtime checks nonsensitivity at decrypt time.
+        endpointConfigTemplate.data = applyOverlay(data, overlay);
 
         return endpointConfigTemplate;
     } else {


### PR DESCRIPTION
## Issues

https://github.com/estuary/flow/issues/2985

## Changes

Extends parseEncryptedEndpointConfig to recognize the sops.overlay property and merge it over the plaintext fields extracted from an encrypted config.

This is necessary so that configs with overlays will preserve the overlay values when viewing/editing in the UI, without this we'd see default or stale values showing up instead and saving would clobber any overlay values.

This does _not_ implement the whole "we can now modify nonsensitive fields without re-entering credentials" feature which overlays make possible, that seemed complicated and like something best left to the UI team. This commit is solely about making sure that nothing breaks when we start having configs with overlay properties.

## Tests

### Manually tested

The capture and materialization edit UI for tasks modified to have overlay properties now shows the values from the overlays in the appropriate form fields after this change.

### Automated tests

Added unit tests of the overlay merge operation.