### PR TITLE
Replace hand-written GraphQL types with codegen types

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -1,10 +1,18 @@
 import { loadEnvFile } from 'node:process';
 import type { CodegenConfig } from '@graphql-codegen/cli';
+import type { Types } from '@graphql-codegen/plugin-helpers';
+import type { IntrospectionOptions } from 'graphql';
 
 loadEnvFile(process.env.LOCAL ? '.env.development.local' : '.env');
 
 const config: CodegenConfig = {
-    schema: process.env.VITE_GQL_URL,
+    schema: [
+        {
+            [process.env.VITE_GQL_URL as string]: {
+                inputValueDeprecation: true,
+            } satisfies Partial<IntrospectionOptions> as Types.UrlSchemaOptions,
+        },
+    ],
     documents: 'src/**/*.{ts,tsx}',
     generates: {
         './src/gql-types/schema.graphql': {
@@ -20,6 +28,18 @@ const config: CodegenConfig = {
             config: {
                 // generates string unions instead of enums
                 enumsAsTypes: true,
+                // custom scalars that serialize as strings on the wire;
+                // JSON/JSONObject intentionally stay `any`
+                scalars: {
+                    Collection: 'string',
+                    DateTime: 'string',
+                    Id: 'string',
+                    NaiveDate: 'string',
+                    Name: 'string',
+                    Prefix: 'string',
+                    Url: 'string',
+                    UUID: 'string',
+                },
             },
         },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
             "devDependencies": {
                 "@graphql-codegen/cli": "^6.2.1",
                 "@graphql-codegen/client-preset": "^5.2.4",
+                "@graphql-codegen/plugin-helpers": "^6.2.1",
                 "@graphql-codegen/schema-ast": "^5.0.1",
                 "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
                 "@storybook/addon-a11y": "^10.3.4",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "devDependencies": {
         "@graphql-codegen/cli": "^6.2.1",
         "@graphql-codegen/client-preset": "^5.2.4",
+        "@graphql-codegen/plugin-helpers": "^6.2.1",
         "@graphql-codegen/schema-ast": "^5.0.1",
         "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
         "@storybook/addon-a11y": "^10.3.4",

--- a/src/api/gql/dataPlanes.ts
+++ b/src/api/gql/dataPlanes.ts
@@ -1,45 +1,9 @@
+import type { DataPlanesQuery } from 'src/gql-types/graphql';
 import type { CloudProvider } from 'src/utils/cloudRegions';
 
-import { gql } from 'urql';
+import { graphql } from 'src/gql-types';
 
-interface DataPlaneGqlNode {
-    name: string;
-    cloudProvider: CloudProvider;
-    isPublic: boolean;
-    region: string;
-    cidrBlocks: string[];
-    awsIamUserArn: string | null;
-    gcpServiceAccountEmail: string | null;
-    azureApplicationClientId: string | null;
-    azureApplicationName: string | null;
-    fqdn: string;
-}
-
-export interface DataPlaneNode extends DataPlaneGqlNode {
-    scope: 'public' | 'private';
-}
-
-// Transform GQL response to exported type (adds snake_case aliases and derived fields)
-export const toDataPlaneNode = (node: DataPlaneGqlNode): DataPlaneNode => {
-    return {
-        ...node,
-        scope: node.isPublic ? 'public' : 'private',
-    };
-};
-
-interface DataPlanesResponse {
-    dataPlanes: {
-        edges: {
-            node: DataPlaneGqlNode;
-        }[];
-        pageInfo: {
-            hasNextPage: boolean;
-            endCursor: string;
-        };
-    };
-}
-
-export const DATA_PLANES_QUERY = gql<DataPlanesResponse, { after?: string }>`
+export const DATA_PLANES_QUERY = graphql(`
     query DataPlanes($after: String) {
         dataPlanes(first: 100, after: $after) {
             edges {
@@ -62,4 +26,21 @@ export const DATA_PLANES_QUERY = gql<DataPlanesResponse, { after?: string }>`
             }
         }
     }
-`;
+`);
+
+type DataPlaneGqlNode = DataPlanesQuery['dataPlanes']['edges'][number]['node'];
+
+export interface DataPlaneNode extends Omit<DataPlaneGqlNode, 'cloudProvider'> {
+    // Narrower than the schema's DataPlaneCloudProvider, which also allows LOCAL
+    cloudProvider: CloudProvider;
+    scope: 'public' | 'private';
+}
+
+// Transform GQL response to exported type (adds derived fields)
+export const toDataPlaneNode = (node: DataPlaneGqlNode): DataPlaneNode => {
+    return {
+        ...node,
+        cloudProvider: node.cloudProvider as CloudProvider,
+        scope: node.isPublic ? 'public' : 'private',
+    };
+};

--- a/src/api/gql/liveSpecs.ts
+++ b/src/api/gql/liveSpecs.ts
@@ -1,33 +1,8 @@
-import { gql } from 'urql';
-
 import { useAllPages } from 'src/api/gql/useAllPages';
+import { graphql } from 'src/gql-types';
 import { useTenantStore } from 'src/stores/Tenant';
 
-interface LiveSpecsQueryResponse {
-    liveSpecs: {
-        edges: {
-            cursor: string;
-            node: {
-                catalogName: string;
-                liveSpec: {
-                    catalogType: string;
-                };
-            };
-        }[];
-        pageInfo: {
-            hasNextPage: boolean;
-            endCursor: string;
-        };
-    };
-}
-
-const LiveSpecsQuery = gql<
-    LiveSpecsQueryResponse,
-    {
-        prefix: string;
-        after?: string;
-    }
->`
+const LiveSpecsQuery = graphql(`
     query LiveSpecsQuery($prefix: Prefix!, $after: String) {
         liveSpecs(by: { prefix: $prefix }, first: 100, after: $after) {
             edges {
@@ -45,7 +20,7 @@ const LiveSpecsQuery = gql<
             }
         }
     }
-`;
+`);
 
 export function useLiveSpecs() {
     const selectedTenant = useTenantStore((state) => state.selectedTenant);

--- a/src/api/gql/storageMappings.ts
+++ b/src/api/gql/storageMappings.ts
@@ -3,8 +3,9 @@ import type { CloudProvider } from 'src/utils/cloudRegions';
 
 import { useCallback } from 'react';
 
-import { gql, useClient, useQuery } from 'urql';
+import { useClient, useQuery } from 'urql';
 
+import { graphql } from 'src/gql-types';
 import { useTenantStore } from 'src/stores/Tenant';
 
 // Public types
@@ -58,30 +59,20 @@ interface ServerFragmentStore {
     account_tenant_id?: string | null;
 }
 
+// Shape of the storage mapping `spec` field, which the schema types as JSON
+interface StorageMappingSpec {
+    stores: ServerFragmentStore[];
+    data_planes: string[];
+}
+
 interface StorageMappingVariables {
     catalogPrefix: string;
-    spec: {
-        stores: ServerFragmentStore[];
-        data_planes: string[];
-    };
+    spec: StorageMappingSpec;
     detail?: string;
 }
 
-interface CreateStorageMappingResult {
-    created: boolean;
-    catalogPrefix: string;
-}
-
-interface UpdateStorageMappingResult {
-    republish: boolean;
-    catalogPrefix: string;
-}
-
 // GraphQL Mutations
-const CREATE_STORAGE_MAPPING = gql<
-    { createStorageMapping: CreateStorageMappingResult | null },
-    StorageMappingVariables
->`
+const CREATE_STORAGE_MAPPING = graphql(`
     mutation CreateStorageMapping(
         $catalogPrefix: Prefix!
         $spec: JSON!
@@ -95,12 +86,9 @@ const CREATE_STORAGE_MAPPING = gql<
             catalogPrefix
         }
     }
-`;
+`);
 
-const UPDATE_STORAGE_MAPPING = gql<
-    { updateStorageMapping: UpdateStorageMappingResult | null },
-    StorageMappingVariables
->`
+const UPDATE_STORAGE_MAPPING = graphql(`
     mutation UpdateStorageMapping(
         $catalogPrefix: Prefix!
         $spec: JSON!
@@ -115,20 +103,9 @@ const UPDATE_STORAGE_MAPPING = gql<
             republish
         }
     }
-`;
+`);
 
-const TEST_CONNECTION_HEALTH = gql<
-    {
-        testConnectionHealth: {
-            results: {
-                fragmentStore: ServerFragmentStore;
-                dataPlaneName: string;
-                error: string | null;
-            }[];
-        } | null;
-    },
-    StorageMappingVariables
->`
+const TEST_CONNECTION_HEALTH = graphql(`
     mutation TestConnectionHealth($catalogPrefix: Prefix!, $spec: JSON!) {
         testConnectionHealth(catalogPrefix: $catalogPrefix, spec: $spec) {
             results {
@@ -138,24 +115,9 @@ const TEST_CONNECTION_HEALTH = gql<
             }
         }
     }
-`;
+`);
 
-interface StorageMappingsQueryResponse {
-    storageMappings: {
-        edges: {
-            cursor: string;
-            node: {
-                catalogPrefix: string;
-                spec: {
-                    data_planes: string[];
-                    stores: ServerFragmentStore[];
-                };
-            };
-        }[];
-    };
-}
-
-const QUERY = gql<StorageMappingsQueryResponse, { underPrefix: string }>`
+const QUERY = graphql(`
     query StorageMappingQuery($underPrefix: Prefix!) {
         storageMappings(by: { underPrefix: $underPrefix }) {
             edges {
@@ -167,7 +129,7 @@ const QUERY = gql<StorageMappingsQueryResponse, { underPrefix: string }>`
             }
         }
     }
-`;
+`);
 
 // Maps cloud provider names to storage provider variants (for GraphQL mutations)
 const CLOUD_TO_STORAGE_PROVIDER: Record<CloudProvider, StorageProvider> = {
@@ -268,7 +230,7 @@ export function useStorageMappingService() {
                 result.data?.testConnectionHealth?.results.map((r) => ({
                     fragmentStore: fromServerStore(r.fragmentStore),
                     dataPlaneName: r.dataPlaneName,
-                    error: r.error,
+                    error: r.error ?? null,
                 })) ?? []
             );
         },
@@ -276,9 +238,7 @@ export function useStorageMappingService() {
     );
 
     const create = useCallback(
-        async (
-            input: StorageMappingInput
-        ): Promise<CreateStorageMappingResult> => {
+        async (input: StorageMappingInput) => {
             const result = await client.mutation(CREATE_STORAGE_MAPPING, {
                 catalogPrefix: input.catalogPrefix,
                 detail: input.detail,
@@ -286,7 +246,7 @@ export function useStorageMappingService() {
                     stores: input.spec.fragmentStores.map(toServerStore),
                     data_planes: input.spec.dataPlanes,
                 },
-            });
+            } satisfies StorageMappingVariables);
 
             if (result.error) {
                 throw new Error(
@@ -309,9 +269,7 @@ export function useStorageMappingService() {
     );
 
     const update = useCallback(
-        async (
-            input: StorageMappingInput
-        ): Promise<UpdateStorageMappingResult> => {
+        async (input: StorageMappingInput) => {
             const result = await client.mutation(UPDATE_STORAGE_MAPPING, {
                 catalogPrefix: input.catalogPrefix,
                 detail: input.detail,
@@ -319,7 +277,7 @@ export function useStorageMappingService() {
                     stores: input.spec.fragmentStores.map(toServerStore),
                     data_planes: input.spec.dataPlanes,
                 },
-            });
+            } satisfies StorageMappingVariables);
 
             if (result.error) {
                 throw new Error(
@@ -358,13 +316,17 @@ export function useStorageMappings() {
     });
 
     const storageMappings: StorageMapping[] =
-        data?.storageMappings.edges.map((edge) => ({
-            catalogPrefix: edge.node.catalogPrefix,
-            spec: {
-                fragmentStores: edge.node.spec.stores.map(fromServerStore),
-                dataPlanes: edge.node.spec.data_planes ?? [],
-            },
-        })) ?? [];
+        data?.storageMappings.edges.map((edge) => {
+            const spec = edge.node.spec as StorageMappingSpec;
+
+            return {
+                catalogPrefix: edge.node.catalogPrefix,
+                spec: {
+                    fragmentStores: spec.stores.map(fromServerStore),
+                    dataPlanes: spec.data_planes ?? [],
+                },
+            };
+        }) ?? [];
 
     return {
         storageMappings,

--- a/src/api/gql/useAllPages.ts
+++ b/src/api/gql/useAllPages.ts
@@ -8,7 +8,7 @@ interface Connection<TNode> {
     edges: { node: TNode }[];
     pageInfo: {
         hasNextPage: boolean;
-        endCursor: string;
+        endCursor?: string | null;
     };
 }
 
@@ -30,7 +30,7 @@ interface UseAllPagesResult<TResult> {
  */
 export function useAllPages<
     TData,
-    TVariables extends AnyVariables & { after?: string },
+    TVariables extends AnyVariables & { after?: string | null },
     TNode,
     TResult,
 >(

--- a/src/gql-types/graphql.ts
+++ b/src/gql-types/graphql.ts
@@ -14,14 +14,14 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
-  Collection: { input: any; output: any; }
+  Collection: { input: string; output: string; }
   /**
    * Implement the DateTime<Utc> scalar
    *
    * The input/output is a string in RFC3339 format.
    */
-  DateTime: { input: any; output: any; }
-  Id: { input: any; output: any; }
+  DateTime: { input: string; output: string; }
+  Id: { input: string; output: string; }
   /** A scalar that can represent any JSON value. */
   JSON: { input: any; output: any; }
   /** A scalar that can represent any JSON Object value. */
@@ -35,9 +35,9 @@ export type Scalars = {
    * * `1994-11-13`
    * * `2000-02-24`
    */
-  NaiveDate: { input: any; output: any; }
-  Name: { input: any; output: any; }
-  Prefix: { input: any; output: any; }
+  NaiveDate: { input: string; output: string; }
+  Name: { input: string; output: string; }
+  Prefix: { input: string; output: string; }
   /**
    * A UUID is a unique 128-bit number, stored as 16 octets. UUIDs are parsed as
    * Strings within GraphQL. UUIDs are used to assign unique identifiers to
@@ -48,9 +48,9 @@ export type Scalars = {
    * * [Wikipedia: Universally Unique Identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier)
    * * [RFC4122: A Universally Unique Identifier (UUID) URN Namespace](http://tools.ietf.org/html/rfc4122)
    */
-  UUID: { input: any; output: any; }
+  UUID: { input: string; output: string; }
   /** URL is a String implementing the [URL Standard](http://url.spec.whatwg.org/) */
-  Url: { input: any; output: any; }
+  Url: { input: string; output: string; }
 };
 
 export type AwsPrivateLink = {
@@ -1973,7 +1973,7 @@ export type CreateAlertSubscriptionMutationMutationVariables = Exact<{
 }>;
 
 
-export type CreateAlertSubscriptionMutationMutation = { __typename?: 'MutationRoot', createAlertSubscription: { __typename?: 'AlertSubscription', catalogPrefix: any, email?: string | null } };
+export type CreateAlertSubscriptionMutationMutation = { __typename?: 'MutationRoot', createAlertSubscription: { __typename?: 'AlertSubscription', catalogPrefix: string, email?: string | null } };
 
 export type DeleteAlertSubscriptionMutationMutationVariables = Exact<{
   prefix: Scalars['Prefix']['input'];
@@ -1981,14 +1981,14 @@ export type DeleteAlertSubscriptionMutationMutationVariables = Exact<{
 }>;
 
 
-export type DeleteAlertSubscriptionMutationMutation = { __typename?: 'MutationRoot', deleteAlertSubscription: { __typename?: 'AlertSubscription', catalogPrefix: any, email?: string | null } };
+export type DeleteAlertSubscriptionMutationMutation = { __typename?: 'MutationRoot', deleteAlertSubscription: { __typename?: 'AlertSubscription', catalogPrefix: string, email?: string | null } };
 
 export type AlertSubscriptionsQueryVariables = Exact<{
   prefix: Scalars['Prefix']['input'];
 }>;
 
 
-export type AlertSubscriptionsQuery = { __typename?: 'QueryRoot', alertSubscriptions: Array<{ __typename?: 'AlertSubscription', alertTypes: Array<AlertType>, catalogPrefix: any, email?: string | null, updatedAt: any }> };
+export type AlertSubscriptionsQuery = { __typename?: 'QueryRoot', alertSubscriptions: Array<{ __typename?: 'AlertSubscription', alertTypes: Array<AlertType>, catalogPrefix: string, email?: string | null, updatedAt: string }> };
 
 export type UpdateAlertSubscriptionMutationMutationVariables = Exact<{
   prefix: Scalars['Prefix']['input'];
@@ -1998,7 +1998,7 @@ export type UpdateAlertSubscriptionMutationMutationVariables = Exact<{
 }>;
 
 
-export type UpdateAlertSubscriptionMutationMutation = { __typename?: 'MutationRoot', updateAlertSubscription: { __typename?: 'AlertSubscription', catalogPrefix: any, email?: string | null } };
+export type UpdateAlertSubscriptionMutationMutation = { __typename?: 'MutationRoot', updateAlertSubscription: { __typename?: 'AlertSubscription', catalogPrefix: string, email?: string | null } };
 
 export type AlertTypeQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2011,7 +2011,7 @@ export type ConnectorsGridQueryVariables = Exact<{
 }>;
 
 
-export type ConnectorsGridQuery = { __typename?: 'QueryRoot', connectors: { __typename?: 'ConnectorConnection', edges: Array<{ __typename?: 'ConnectorEdge', cursor: string, node: { __typename?: 'Connector', id: any, imageName: string, logoUrl?: string | null, title?: string | null, recommended: boolean, detail?: string | null, defaultSpec?: { __typename?: 'ConnectorSpec', id: any, imageTag: string, documentationUrl?: string | null, protocol?: ConnectorProto | null } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
+export type ConnectorsGridQuery = { __typename?: 'QueryRoot', connectors: { __typename?: 'ConnectorConnection', edges: Array<{ __typename?: 'ConnectorEdge', cursor: string, node: { __typename?: 'Connector', id: string, imageName: string, logoUrl?: string | null, title?: string | null, recommended: boolean, detail?: string | null, defaultSpec?: { __typename?: 'ConnectorSpec', id: string, imageTag: string, documentationUrl?: string | null, protocol?: ConnectorProto | null } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
 
 export type ConnectorTagDataQueryVariables = Exact<{
   imageName: Scalars['String']['input'];
@@ -2019,7 +2019,7 @@ export type ConnectorTagDataQueryVariables = Exact<{
 }>;
 
 
-export type ConnectorTagDataQuery = { __typename?: 'QueryRoot', connector?: { __typename?: 'Connector', id: any, imageName: string, logoUrl?: string | null, title?: string | null } | null, connectorSpec?: { __typename?: 'ConnectorSpec', id: any, imageTag: string, defaultCaptureInterval?: string | null, disableBackfill: boolean, documentationUrl?: string | null, endpointSpecSchema?: any | null, resourceSpecSchema?: any | null, protocol?: ConnectorProto | null } | null };
+export type ConnectorTagDataQuery = { __typename?: 'QueryRoot', connector?: { __typename?: 'Connector', id: string, imageName: string, logoUrl?: string | null, title?: string | null } | null, connectorSpec?: { __typename?: 'ConnectorSpec', id: string, imageTag: string, defaultCaptureInterval?: string | null, disableBackfill: boolean, documentationUrl?: string | null, endpointSpecSchema?: any | null, resourceSpecSchema?: any | null, protocol?: ConnectorProto | null } | null };
 
 export type DataPlanesQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -2034,7 +2034,7 @@ export type InviteLinksQueryVariables = Exact<{
 }>;
 
 
-export type InviteLinksQuery = { __typename?: 'QueryRoot', inviteLinks: { __typename?: 'InviteLinkConnection', edges: Array<{ __typename?: 'InviteLinkEdge', cursor: string, node: { __typename?: 'InviteLink', token: any, ssoProviderId?: any | null, catalogPrefix: any, capability: Capability, singleUse: boolean, detail?: string | null, createdAt: any } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
+export type InviteLinksQuery = { __typename?: 'QueryRoot', inviteLinks: { __typename?: 'InviteLinkConnection', edges: Array<{ __typename?: 'InviteLinkEdge', cursor: string, node: { __typename?: 'InviteLink', token: string, ssoProviderId?: string | null, catalogPrefix: string, capability: Capability, singleUse: boolean, detail?: string | null, createdAt: string } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
 export type CreateInviteLinkMutationVariables = Exact<{
   catalogPrefix: Scalars['Prefix']['input'];
@@ -2044,7 +2044,7 @@ export type CreateInviteLinkMutationVariables = Exact<{
 }>;
 
 
-export type CreateInviteLinkMutation = { __typename?: 'MutationRoot', createInviteLink: { __typename?: 'InviteLink', token: any, catalogPrefix: any, capability: Capability, singleUse: boolean, detail?: string | null, createdAt: any } };
+export type CreateInviteLinkMutation = { __typename?: 'MutationRoot', createInviteLink: { __typename?: 'InviteLink', token: string, catalogPrefix: string, capability: Capability, singleUse: boolean, detail?: string | null, createdAt: string } };
 
 export type DeleteInviteLinkMutationVariables = Exact<{
   token: Scalars['UUID']['input'];
@@ -2058,7 +2058,7 @@ export type RedeemInviteLinkMutationVariables = Exact<{
 }>;
 
 
-export type RedeemInviteLinkMutation = { __typename?: 'MutationRoot', redeemInviteLink: { __typename?: 'RedeemInviteLinkResult', capability: Capability, catalogPrefix: any } };
+export type RedeemInviteLinkMutation = { __typename?: 'MutationRoot', redeemInviteLink: { __typename?: 'RedeemInviteLinkResult', capability: Capability, catalogPrefix: string } };
 
 export type LiveSpecsQueryQueryVariables = Exact<{
   prefix: Scalars['Prefix']['input'];
@@ -2066,7 +2066,7 @@ export type LiveSpecsQueryQueryVariables = Exact<{
 }>;
 
 
-export type LiveSpecsQueryQuery = { __typename?: 'QueryRoot', liveSpecs: { __typename?: 'LiveSpecRefConnection', edges: Array<{ __typename?: 'LiveSpecRefEdge', cursor: string, node: { __typename?: 'LiveSpecRef', catalogName: any, liveSpec?: { __typename?: 'LiveSpec', catalogType: CatalogType } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
+export type LiveSpecsQueryQuery = { __typename?: 'QueryRoot', liveSpecs: { __typename?: 'LiveSpecRefConnection', edges: Array<{ __typename?: 'LiveSpecRefEdge', cursor: string, node: { __typename?: 'LiveSpecRef', catalogName: string, liveSpec?: { __typename?: 'LiveSpec', catalogType: CatalogType } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
 
 export type RefreshTokensQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2074,7 +2074,7 @@ export type RefreshTokensQueryVariables = Exact<{
 }>;
 
 
-export type RefreshTokensQuery = { __typename?: 'QueryRoot', refreshTokens: { __typename?: 'RefreshTokenInfoConnection', edges: Array<{ __typename?: 'RefreshTokenInfoEdge', cursor: string, node: { __typename?: 'RefreshTokenInfo', id: any, detail?: string | null, createdAt: any, uses: number, expired: boolean } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
+export type RefreshTokensQuery = { __typename?: 'QueryRoot', refreshTokens: { __typename?: 'RefreshTokenInfoConnection', edges: Array<{ __typename?: 'RefreshTokenInfoEdge', cursor: string, node: { __typename?: 'RefreshTokenInfo', id: string, detail?: string | null, createdAt: string, uses: number, expired: boolean } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
 export type CreateRefreshTokenMutationVariables = Exact<{
   detail?: InputMaybe<Scalars['String']['input']>;
@@ -2083,7 +2083,7 @@ export type CreateRefreshTokenMutationVariables = Exact<{
 }>;
 
 
-export type CreateRefreshTokenMutation = { __typename?: 'MutationRoot', createRefreshToken: { __typename?: 'RefreshTokenResult', id: any, secret: string } };
+export type CreateRefreshTokenMutation = { __typename?: 'MutationRoot', createRefreshToken: { __typename?: 'RefreshTokenResult', id: string, secret: string } };
 
 export type RevokeRefreshTokenMutationVariables = Exact<{
   id: Scalars['Id']['input'];
@@ -2099,7 +2099,7 @@ export type CreateStorageMappingMutationVariables = Exact<{
 }>;
 
 
-export type CreateStorageMappingMutation = { __typename?: 'MutationRoot', createStorageMapping: { __typename?: 'CreateStorageMappingResult', catalogPrefix: any } };
+export type CreateStorageMappingMutation = { __typename?: 'MutationRoot', createStorageMapping: { __typename?: 'CreateStorageMappingResult', catalogPrefix: string } };
 
 export type UpdateStorageMappingMutationVariables = Exact<{
   catalogPrefix: Scalars['Prefix']['input'];
@@ -2108,7 +2108,7 @@ export type UpdateStorageMappingMutationVariables = Exact<{
 }>;
 
 
-export type UpdateStorageMappingMutation = { __typename?: 'MutationRoot', updateStorageMapping: { __typename?: 'UpdateStorageMappingResult', catalogPrefix: any, republish: boolean } };
+export type UpdateStorageMappingMutation = { __typename?: 'MutationRoot', updateStorageMapping: { __typename?: 'UpdateStorageMappingResult', catalogPrefix: string, republish: boolean } };
 
 export type TestConnectionHealthMutationVariables = Exact<{
   catalogPrefix: Scalars['Prefix']['input'];
@@ -2123,7 +2123,7 @@ export type StorageMappingQueryQueryVariables = Exact<{
 }>;
 
 
-export type StorageMappingQueryQuery = { __typename?: 'QueryRoot', storageMappings: { __typename?: 'StorageMappingConnection', edges: Array<{ __typename?: 'StorageMappingEdge', cursor: string, node: { __typename?: 'StorageMapping', catalogPrefix: any, spec: any } }> } };
+export type StorageMappingQueryQuery = { __typename?: 'QueryRoot', storageMappings: { __typename?: 'StorageMappingConnection', edges: Array<{ __typename?: 'StorageMappingEdge', cursor: string, node: { __typename?: 'StorageMapping', catalogPrefix: string, spec: any } }> } };
 
 export type AlertingOverviewQueryQueryVariables = Exact<{
   prefix: Scalars['String']['input'];
@@ -2131,7 +2131,7 @@ export type AlertingOverviewQueryQueryVariables = Exact<{
 }>;
 
 
-export type AlertingOverviewQueryQuery = { __typename?: 'QueryRoot', alerts: { __typename?: 'AlertConnection', edges: Array<{ __typename?: 'AlertEdge', node: { __typename?: 'Alert', alertType: AlertType, firedAt: any, catalogName: string, resolvedAt?: any | null, alertDetails: any } }> } };
+export type AlertingOverviewQueryQuery = { __typename?: 'QueryRoot', alerts: { __typename?: 'AlertConnection', edges: Array<{ __typename?: 'AlertEdge', node: { __typename?: 'Alert', alertType: AlertType, firedAt: string, catalogName: string, resolvedAt?: string | null, alertDetails: any } }> } };
 
 export type ActiveAlertCountQueryVariables = Exact<{
   catalogName: Scalars['Name']['input'];
@@ -2145,7 +2145,7 @@ export type ActiveAlertsQueryQueryVariables = Exact<{
 }>;
 
 
-export type ActiveAlertsQueryQuery = { __typename?: 'QueryRoot', liveSpecs: { __typename?: 'LiveSpecRefConnection', edges: Array<{ __typename?: 'LiveSpecRefEdge', node: { __typename?: 'LiveSpecRef', activeAlerts?: Array<{ __typename?: 'Alert', alertType: AlertType, catalogName: string, firedAt: any, alertDetails: any }> | null } }> } };
+export type ActiveAlertsQueryQuery = { __typename?: 'QueryRoot', liveSpecs: { __typename?: 'LiveSpecRefConnection', edges: Array<{ __typename?: 'LiveSpecRefEdge', node: { __typename?: 'LiveSpecRef', activeAlerts?: Array<{ __typename?: 'Alert', alertType: AlertType, catalogName: string, firedAt: string, alertDetails: any }> | null } }> } };
 
 export type AlertHistoryQueryQueryVariables = Exact<{
   catalogName?: InputMaybe<Array<Scalars['Name']['input']> | Scalars['Name']['input']>;
@@ -2154,7 +2154,7 @@ export type AlertHistoryQueryQueryVariables = Exact<{
 }>;
 
 
-export type AlertHistoryQueryQuery = { __typename?: 'QueryRoot', liveSpecs: { __typename?: 'LiveSpecRefConnection', edges: Array<{ __typename?: 'LiveSpecRefEdge', node: { __typename?: 'LiveSpecRef', alertHistory?: { __typename?: 'AlertConnection', edges: Array<{ __typename?: 'AlertEdge', cursor: string, node: { __typename?: 'Alert', alertType: AlertType, catalogName: string, firedAt: any, resolvedAt?: any | null, alertDetails: any } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } | null } }> } };
+export type AlertHistoryQueryQuery = { __typename?: 'QueryRoot', liveSpecs: { __typename?: 'LiveSpecRefConnection', edges: Array<{ __typename?: 'LiveSpecRefEdge', node: { __typename?: 'LiveSpecRef', alertHistory?: { __typename?: 'AlertConnection', edges: Array<{ __typename?: 'AlertEdge', cursor: string, node: { __typename?: 'Alert', alertType: AlertType, catalogName: string, firedAt: string, resolvedAt?: string | null, alertDetails: any } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } | null } }> } };
 
 export type PageInfoFieldsFragment = { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null };
 
@@ -2163,7 +2163,7 @@ export type AuthRolesQueryQueryVariables = Exact<{
 }>;
 
 
-export type AuthRolesQueryQuery = { __typename?: 'QueryRoot', prefixes: { __typename?: 'PrefixRefConnection', edges: Array<{ __typename?: 'PrefixRefEdge', node: { __typename?: 'PrefixRef', prefix: any, userCapability: Capability } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
+export type AuthRolesQueryQuery = { __typename?: 'QueryRoot', prefixes: { __typename?: 'PrefixRefConnection', edges: Array<{ __typename?: 'PrefixRefEdge', node: { __typename?: 'PrefixRef', prefix: string, userCapability: Capability } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null } } };
 
 export const PageInfoFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PageInfoFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PageInfo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hasNextPage"}},{"kind":"Field","name":{"kind":"Name","value":"hasPreviousPage"}},{"kind":"Field","name":{"kind":"Name","value":"startCursor"}},{"kind":"Field","name":{"kind":"Name","value":"endCursor"}}]}}]} as unknown as DocumentNode<PageInfoFieldsFragment, unknown>;
 export const CreateAlertSubscriptionMutationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateAlertSubscriptionMutation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"prefix"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Prefix"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"email"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"alertTypes"}},"type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AlertType"}}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"detail"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createAlertSubscription"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"prefix"},"value":{"kind":"Variable","name":{"kind":"Name","value":"prefix"}}},{"kind":"Argument","name":{"kind":"Name","value":"email"},"value":{"kind":"Variable","name":{"kind":"Name","value":"email"}}},{"kind":"Argument","name":{"kind":"Name","value":"alertTypes"},"value":{"kind":"Variable","name":{"kind":"Name","value":"alertTypes"}}},{"kind":"Argument","name":{"kind":"Name","value":"detail"},"value":{"kind":"Variable","name":{"kind":"Name","value":"detail"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"catalogPrefix"}},{"kind":"Field","name":{"kind":"Name","value":"email"}}]}}]}}]} as unknown as DocumentNode<CreateAlertSubscriptionMutationMutation, CreateAlertSubscriptionMutationMutationVariables>;

--- a/src/stores/Entities/hooks.ts
+++ b/src/stores/Entities/hooks.ts
@@ -1,21 +1,18 @@
 import type { PostgrestError } from '@supabase/postgrest-js';
 import type { EntitiesState } from 'src/stores/Entities/types';
 import type { AuthRoles, Capability } from 'src/types';
-import type {
-    AuthRolesQueryResponse,
-    PaginationVariables,
-} from 'src/types/gql';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useShallow } from 'zustand/react/shallow';
 
 import useSWR from 'swr';
-import { gql, useQuery } from 'urql';
+import { useQuery } from 'urql';
 
 import { getAllStorageMappingStores } from 'src/api/storageMappings';
 import { singleCallSettings } from 'src/context/SWR';
 import { useUserInfoSummaryStore } from 'src/context/UserInfoSummary/useUserInfoSummaryStore';
+import { graphql } from 'src/gql-types';
 import { logRocketEvent } from 'src/services/shared';
 import { BASE_ERROR } from 'src/services/supabase';
 import { useEntitiesStore } from 'src/stores/Entities/Store';
@@ -135,7 +132,7 @@ const useEntitiesStore_populateState = () => {
 // The 7500 was kind of picked through "vibes"
 //  It should keep the payload around 1000kB
 //  That should load in around 1 second for 4g
-const authRolesQuery = gql<AuthRolesQueryResponse, PaginationVariables>`
+const authRolesQuery = graphql(`
     query AuthRolesQuery($after: String) {
         prefixes(by: { minCapability: read }, first: 7500, after: $after) {
             edges {
@@ -150,7 +147,7 @@ const authRolesQuery = gql<AuthRolesQueryResponse, PaginationVariables>`
             }
         }
     }
-`;
+`);
 
 export const useHydrateStateWithGql = () => {
     const { populateState } = useEntitiesStore_populateState();

--- a/src/types/gql.ts
+++ b/src/types/gql.ts
@@ -61,7 +61,7 @@ export interface AlertsVariables {
 
 // TODO (typing) - we need more versions of pagination
 //  as some endpoints only support before/last (AlertHistory)
-export interface PaginationVariables {
+interface PaginationVariables {
     before?: string | undefined;
     after?: string | undefined;
     first?: number | undefined;
@@ -101,19 +101,6 @@ export interface AlertHistoryQueryResponse {
         edges: {
             node: LiveSpecNode;
         }[];
-    };
-}
-
-interface AuthRolesNode {
-    prefix: string;
-    userCapability: string;
-}
-export interface AuthRolesQueryResponse {
-    prefixes: {
-        edges: {
-            node: AuthRolesNode;
-        }[];
-        pageInfo?: Pick<PageInfo, 'hasNextPage' | 'endCursor'>;
     };
 }
 


### PR DESCRIPTION
Replaces hand-written GraphQL response/variable types with codegen-generated ones. Codegen was already scanning these documents (`documents: 'src/**/*.{ts,tsx}'` picks up urql `gql` tags) — the hand-written generics on `gql<Response, Variables>` were *overriding* the generated types. Switching to the client-preset `graphql()` function lets the generated `TypedDocumentNode` flow through urql, and documents are now validated against the live schema at codegen time.

## Migrated (7 documents)

- `stores/Entities/hooks.ts` — AuthRolesQuery (deletes `AuthRolesQueryResponse`/`AuthRolesNode` from `src/types/gql.ts`)
- `api/gql/storageMappings.ts` — 4 mutations/queries (deletes `StorageMappingsQueryResponse`, `CreateStorageMappingResult`, `UpdateStorageMappingResult`; JSON payload shapes stay as explicit local interfaces cast at the boundary)
- `api/gql/liveSpecs.ts` — LiveSpecsQuery (deletes `LiveSpecsQueryResponse`)
- `api/gql/dataPlanes.ts` — DataPlanes (node type now derived from the generated `DataPlanesQuery`)

## Drift the hand-written types were hiding

- `CreateStorageMappingResult` claimed a `created` field the mutation never selects
- `PageInfo.endCursor` and `StorageHealthItem.error` typed non-null; both nullable in the schema
- `DataPlane.cloudProvider` is an enum that also allows `LOCAL`, which the local `CloudProvider` type doesn't model — now narrowed by one explicit cast in `toDataPlaneNode`
- `AuthRolesQueryResponse.userCapability` was plain `string`; it's now the schema enum

## Supporting changes

- Custom scalars that serialize as strings (`Prefix`, `DateTime`, `Id`, `Name`, `UUID`, …) now map to `string` instead of `any`; `JSON`/`JSONObject` intentionally stay `any`
- `useAllPages` accepts nullable `endCursor`/`after` (matching the schema's `PageInfo`)
- Enables `inputValueDeprecation` during introspection

## Alerts-related types left alone

The alerts cluster (9 raw `gql` documents across `api/alerts.ts`, `AlertHistory`, `AlertingOverview`, `AlertsAreActiveBadge`) is deferred until the in-flight alerts UI overhaul lands, to avoid conflicts.