### PR TITLE
Consolidate api.estuary.dev URL env vars and update port 

### DIFF
--- a/.env
+++ b/.env
@@ -7,12 +7,8 @@ PORT=3000
 VITE_SUPABASE_URL=https://eyrcnmuzzyriypdajwdk.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco
 
-VITE_GQL_URL=https://api.estuary.dev/api/graphql
-
-VITE_TASK_AUTHORIZATION_URL=https://api.estuary.dev/authorize/user/task
-VITE_COLLECTION_AUTHORIZATION_URL=https://api.estuary.dev/authorize/user/collection
-
-VITE_ENTITY_STATUS_BASE_URL=https://api.estuary.dev/api/v1/catalog/status
+# Base URL for the Estuary API. Endpoint paths are appended at each call site.
+VITE_ESTUARY_API_URL=https://api.estuary.dev
 
 VITE_MARKETPLACE_VERIFY_URL=https://gcp-marketplace-verify-mo7rswd2xq-uc.a.run.app
 

--- a/.env.development.local
+++ b/.env.development.local
@@ -1,15 +1,10 @@
 # These properties are used when running locally.
 
 VITE_SUPABASE_URL=http://localhost:5431
-VITE_GQL_URL=http://localhost:8675/api/graphql
+VITE_ESTUARY_API_URL=http://localhost:8675
 
 # Supabase CLI v1.40
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
-
-VITE_TASK_AUTHORIZATION_URL=http://localhost:8675/authorize/user/task
-VITE_COLLECTION_AUTHORIZATION_URL=http://localhost:8675/authorize/user/collection
-
-VITE_ENTITY_STATUS_BASE_URL=http://localhost:8675/api/v1/catalog/status
 
 VITE_MARKETPLACE_VERIFY_URL=http://example.com
 

--- a/codegen.ts
+++ b/codegen.ts
@@ -8,7 +8,7 @@ loadEnvFile(process.env.LOCAL ? '.env.development.local' : '.env');
 const config: CodegenConfig = {
     schema: [
         {
-            [process.env.VITE_GQL_URL as string]: {
+            [`${process.env.VITE_ESTUARY_API_URL}/api/graphql`]: {
                 inputValueDeprecation: true,
             } satisfies Partial<IntrospectionOptions> as Types.UrlSchemaOptions,
         },

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -58,10 +58,7 @@ foo_enabled=true
 
 | Key                                 | Description                                            |
 | ----------------------------------- | ------------------------------------------------------ |
-| `VITE_GQL_URL`                      | GraphQL server URL                                     |
-| `VITE_TASK_AUTHORIZATION_URL`       | Fetching access to read ops logs or stats for tasks    |
-| `VITE_COLLECTION_AUTHORIZATION_URL` | Access to read ops logs for tasks                      |
-| `VITE_ENTITY_STATUS_BASE_URL`       | Used on details pages to fetch status / related tasks  |
+| `VITE_ESTUARY_API_URL`              | Base URL for the Estuary API; endpoint paths (GraphQL, task/collection authorization, entity status) are appended at each call site |
 | `VITE_MARKETPLACE_VERIFY_URL`       | Endpoint for verifying GCP Marketplace subscriptions   |
 | `VITE_DEFAULT_DATA_PLANE_SUFFIX`    | Default data-plane suffix appended to data-plane names |
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -18,7 +18,7 @@ PostgreSQL database, Edge Functions, and auth.
 
 Real-time catalog data (alerts, live specs, shard status).
 
-- Configured via `VITE_GQL_URL` environment variable
+- Configured via the `VITE_ESTUARY_API_URL` base URL, with the `/api/graphql` path appended in `src/utils/env-utils.ts`
 - URQL client library
 - Pagination via before/after cursors
 - GraphiQL explorer available at `http://localhost:3000/test/gql` in development

--- a/src/api/entityStatus.ts
+++ b/src/api/entityStatus.ts
@@ -4,9 +4,9 @@ import type {
 } from 'src/types/controlPlane';
 
 import { client } from 'src/services/client';
-import { getEntityStatusSettings } from 'src/utils/env-utils';
+import { requireEstuaryApiUrl } from 'src/utils/env-utils';
 
-const { entityStatusBaseEndpoint } = getEntityStatusSettings();
+const entityStatusBaseEndpoint = `${requireEstuaryApiUrl()}/api/v1/catalog/status`;
 
 // Local API documentation can be found here: http://localhost:8675/api/v1/docs
 export const getEntityStatus = async (

--- a/src/context/GlobalProviders.tsx
+++ b/src/context/GlobalProviders.tsx
@@ -16,10 +16,10 @@ import { logRocketEvent } from 'src/services/shared';
 if (
     !import.meta.env.VITE_SUPABASE_URL ||
     !import.meta.env.VITE_SUPABASE_ANON_KEY ||
-    !import.meta.env.VITE_GQL_URL
+    !import.meta.env.VITE_ESTUARY_API_URL
 ) {
     throw new Error(
-        'Missing at least 1 environment config: [VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_GQL_URL]'
+        'Missing at least 1 environment config: [VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_ESTUARY_API_URL]'
     );
 }
 

--- a/src/context/URQL.tsx
+++ b/src/context/URQL.tsx
@@ -10,6 +10,7 @@ import { requestPolicyExchange } from '@urql/exchange-request-policy';
 import { Client, fetchExchange, Provider } from 'urql';
 
 import { useUserStore } from 'src/context/User/useUserContextStore';
+import { getGqlUrl } from 'src/utils/env-utils';
 import { getAuthHeader } from 'src/utils/misc-utils';
 
 function invalidateQuery(
@@ -32,7 +33,7 @@ function UrqlConfigProvider({ children }: BaseComponentProps) {
 
     const gqlClient = useMemo(() => {
         return new Client({
-            url: import.meta.env.VITE_GQL_URL,
+            url: getGqlUrl(),
             preferGetMethod: false,
             exchanges: [
                 // WARNING - order is important on exchanges

--- a/src/pages/dev/gqlExplorer.tsx
+++ b/src/pages/dev/gqlExplorer.tsx
@@ -7,7 +7,7 @@ import { useUserStore } from 'src/context/User/useUserContextStore';
 const sandbox = ['allow-scripts', 'allow-same-origin', 'allow-popups'].join(
     ' '
 );
-const ENDPOINT = `http://localhost:8675/graphiql`;
+const ENDPOINT = `${import.meta.env.VITE_ESTUARY_API_URL}/graphiql`;
 
 const GqlExplorer = () => {
     const session = useUserStore((state) => state.session);

--- a/src/utils/dataPlane-utils.ts
+++ b/src/utils/dataPlane-utils.ts
@@ -22,10 +22,7 @@ import {
     DATA_PLANE_PREFIX,
     DATA_PLANE_SETTINGS,
 } from 'src/settings/dataPlanes';
-import {
-    getCollectionAuthorizationSettings,
-    getTaskAuthorizationSettings,
-} from 'src/utils/env-utils';
+import { requireEstuaryApiUrl } from 'src/utils/env-utils';
 import { hasLength, OPENID_HOST } from 'src/utils/misc-utils';
 
 export enum SHARD_LABELS {
@@ -139,7 +136,7 @@ export interface TaskAuthorizationResponse {
     shardIdPrefix: string;
 }
 
-const { taskAuthorizationEndpoint } = getTaskAuthorizationSettings();
+const taskAuthorizationEndpoint = `${requireEstuaryApiUrl()}/authorize/user/task`;
 
 // The broker authorization that comes back from /authorize/user/task is only good
 // for reading the ops stats or logs journals of a specific task. Collection
@@ -169,8 +166,7 @@ interface CollectionAuthorizationResponse {
     retryMillis: number;
 }
 
-const { collectionAuthorizationEndpoint } =
-    getCollectionAuthorizationSettings();
+const collectionAuthorizationEndpoint = `${requireEstuaryApiUrl()}/authorize/user/collection`;
 
 // The broker authorization that comes back from /authorize/user/collection is only good
 // for reading the ops logs journals of a specific collection.

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -16,7 +16,7 @@ export const defaultDataPlaneSuffix = ((): string => {
 
 // Base URL for the Estuary API. Endpoint paths live at each call site so the
 // host is configured in exactly one place.
-const requireEstuaryApiUrl = (): string => {
+export const requireEstuaryApiUrl = (): string => {
     const estuaryApiUrl = import.meta.env.VITE_ESTUARY_API_URL;
 
     if (estuaryApiUrl) {
@@ -148,14 +148,6 @@ export const getMarketplaceSettings = () => {
     }
 };
 
-export const getTaskAuthorizationSettings = () => ({
-    taskAuthorizationEndpoint: `${requireEstuaryApiUrl()}/authorize/user/task`,
-});
-
-export const getCollectionAuthorizationSettings = () => ({
-    collectionAuthorizationEndpoint: `${requireEstuaryApiUrl()}/authorize/user/collection`,
-});
-
 export const getGoogleTageManagerSettings = () => {
     const settings = {
         enabled: import.meta.env.VITE_GOOGLE_TAG_MANAGER_ENABLED === ENABLED,
@@ -176,7 +168,3 @@ export const getDocsSettings = () => {
 
     return settings;
 };
-
-export const getEntityStatusSettings = () => ({
-    entityStatusBaseEndpoint: `${requireEstuaryApiUrl()}/api/v1/catalog/status`,
-});

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -14,6 +14,20 @@ export const defaultDataPlaneSuffix = ((): string => {
     }
 })();
 
+// Base URL for the Estuary API. Endpoint paths live at each call site so the
+// host is configured in exactly one place.
+const requireEstuaryApiUrl = (): string => {
+    const estuaryApiUrl = import.meta.env.VITE_ESTUARY_API_URL;
+
+    if (estuaryApiUrl) {
+        return estuaryApiUrl;
+    } else {
+        throw new Error('Missing Estuary API base URL: VITE_ESTUARY_API_URL');
+    }
+};
+
+export const getGqlUrl = (): string => `${requireEstuaryApiUrl()}/api/graphql`;
+
 export const getLoginSettings = () => {
     const showEmail = import.meta.env.VITE_SHOW_EMAIL_LOGIN === ENABLED;
     const showSSO = import.meta.env.VITE_SHOW_SSO === ENABLED;
@@ -134,31 +148,13 @@ export const getMarketplaceSettings = () => {
     }
 };
 
-export const getTaskAuthorizationSettings = () => {
-    const taskAuthorizationEndpoint = import.meta.env
-        .VITE_TASK_AUTHORIZATION_URL;
+export const getTaskAuthorizationSettings = () => ({
+    taskAuthorizationEndpoint: `${requireEstuaryApiUrl()}/authorize/user/task`,
+});
 
-    if (taskAuthorizationEndpoint) {
-        return { taskAuthorizationEndpoint };
-    } else {
-        throw new Error(
-            'Missing endpoint to access data plane information for tasks: VITE_TASK_AUTHORIZATION_URL'
-        );
-    }
-};
-
-export const getCollectionAuthorizationSettings = () => {
-    const collectionAuthorizationEndpoint = import.meta.env
-        .VITE_COLLECTION_AUTHORIZATION_URL;
-
-    if (collectionAuthorizationEndpoint) {
-        return { collectionAuthorizationEndpoint };
-    } else {
-        throw new Error(
-            'Missing endpoint to access data plane information for collections: VITE_COLLECTION_AUTHORIZATION_URL'
-        );
-    }
-};
+export const getCollectionAuthorizationSettings = () => ({
+    collectionAuthorizationEndpoint: `${requireEstuaryApiUrl()}/authorize/user/collection`,
+});
 
 export const getGoogleTageManagerSettings = () => {
     const settings = {
@@ -181,15 +177,6 @@ export const getDocsSettings = () => {
     return settings;
 };
 
-export const getEntityStatusSettings = () => {
-    const entityStatusBaseEndpoint = import.meta.env
-        .VITE_ENTITY_STATUS_BASE_URL;
-
-    if (entityStatusBaseEndpoint) {
-        return { entityStatusBaseEndpoint };
-    } else {
-        throw new Error(
-            'Missing endpoint to access entity status: VITE_ENTITY_STATUS_BASE_URL'
-        );
-    }
-};
+export const getEntityStatusSettings = () => ({
+    entityStatusBaseEndpoint: `${requireEstuaryApiUrl()}/api/v1/catalog/status`,
+});


### PR DESCRIPTION
The base host `api.estuary.dev` was duplicated across four `VITE_` URL vars. This replaces them with a single `VITE_ESTUARY_API_URL` base var and builds the endpoint paths at each call site.

- `.env` / `.env.development.local`: four full-URL vars → one `VITE_ESTUARY_API_URL` base
- `src/utils/env-utils.ts`: `requireEstuaryApiUrl()` helper + `getGqlUrl()`; task/collection/entity-status getters append their paths
- `URQL.tsx`, `GlobalProviders.tsx`, `gqlExplorer.tsx`, `codegen.ts`: consume the base and append `/api/graphql`, `/graphiql`, etc.
- `docs/ENV.md`, `docs/INTEGRATIONS.md`: updated

Behavior is preserved: the committed local base is `http://localhost:8675`, the same port gqlExplorer's `/graphiql` already used. Typecheck and lint pass.
