### PR TITLE
Fix data preview showing acknowledgement documents for runtime v2 collections

### DIFF
--- a/src/hooks/journals/__tests__/shared.test.ts
+++ b/src/hooks/journals/__tests__/shared.test.ts
@@ -1,0 +1,128 @@
+import { hasAckTxnFlag } from 'src/hooks/journals/shared';
+
+// Acknowledgement documents are runtime bookkeeping written into collection and
+// ops journals at every transaction commit. They carry no collection key, so the
+// data preview renders them as an empty-keyed row, and the logs table as a row
+// with no level or message.
+//
+// The fourth hyphen-delimited group of a Gazette message UUID is composed as
+// `0x8000 | (clock_sequence & 0x3c00) | flags`, so it varies with the clock and
+// cannot be compared against a fixed value. ACK_TXN is 0x2 within the flags.
+// See `build` in crates/proto-gazette/src/uuid.rs of estuary/flow.
+const ACK_UUID = '9f8e7d6c-1234-11f0-8002-4336974cbbe3';
+const ACK_UUID_WITH_CLOCK_SEQUENCE = '9f8e7d6c-1234-11f0-bc02-4336974cbbe3';
+const CONTINUE_TXN_UUID = 'd2659611-f267-11f0-8001-4336974cbbe3';
+const OUTSIDE_TXN_UUID = 'd2659611-f267-11f0-8000-4336974cbbe3';
+const OUTSIDE_TXN_UUID_WITH_CLOCK_SEQUENCE =
+    'd2659611-f267-11f0-b400-4336974cbbe3';
+
+describe('hasAckTxnFlag', () => {
+    describe('runtime v1 acknowledgements', () => {
+        // The collection ack template built by crates/validation/src/collection.rs.
+        test('collection acknowledgement, with `ack` inside `_meta`', () => {
+            const document = { _meta: { uuid: ACK_UUID, ack: true } };
+
+            expect(hasAckTxnFlag(document._meta.uuid)).toBe(true);
+        });
+
+        // The ops ack template built by go/runtime/ops_publisher.go, which places
+        // `ack` at the document root rather than inside `_meta`.
+        test('ops acknowledgement, with `ack` at the root', () => {
+            const document = { _meta: { uuid: ACK_UUID }, ack: true };
+
+            expect(hasAckTxnFlag(document._meta.uuid)).toBe(true);
+        });
+    });
+
+    describe('runtime v2 acknowledgements', () => {
+        // The shapes written by crates/publisher/src/intents.rs.
+        test('acknowledgement carrying causal hints', () => {
+            const document = {
+                _meta: { uuid: ACK_UUID },
+                is_ack: true,
+                hints: [{ j: [0, 'the/journal/name'], p: [] }],
+            };
+
+            expect(hasAckTxnFlag(document._meta.uuid)).toBe(true);
+        });
+
+        test('secondary acknowledgement, which omits hints', () => {
+            const document = { _meta: { uuid: ACK_UUID }, is_ack: true };
+
+            expect(hasAckTxnFlag(document._meta.uuid)).toBe(true);
+        });
+
+        test('acknowledgement carrying a backfill marker', () => {
+            const document = {
+                _meta: { uuid: ACK_UUID },
+                is_ack: true,
+                backfillBegin: true,
+            };
+
+            expect(hasAckTxnFlag(document._meta.uuid)).toBe(true);
+        });
+    });
+
+    describe('collection documents', () => {
+        test('CONTINUE_TXN document is kept', () => {
+            const document = { _meta: { uuid: CONTINUE_TXN_UUID }, id: 1 };
+
+            expect(hasAckTxnFlag(document._meta.uuid)).toBe(false);
+        });
+
+        test('OUTSIDE_TXN document is kept', () => {
+            expect(hasAckTxnFlag(OUTSIDE_TXN_UUID)).toBe(false);
+        });
+
+        // A user's schema may legitimately define `is_ack`, which is why the flag
+        // rather than the field determines whether a document is bookkeeping.
+        test('document defining its own `is_ack` field is kept', () => {
+            const document = {
+                _meta: { uuid: CONTINUE_TXN_UUID },
+                is_ack: true,
+            };
+
+            expect(hasAckTxnFlag(document._meta.uuid)).toBe(false);
+        });
+    });
+
+    describe('clock-sequence bits', () => {
+        test('acknowledgement is matched when clock-sequence bits are set', () => {
+            expect(hasAckTxnFlag(ACK_UUID_WITH_CLOCK_SEQUENCE)).toBe(true);
+        });
+
+        test('document is kept when clock-sequence bits are set', () => {
+            expect(hasAckTxnFlag(OUTSIDE_TXN_UUID_WITH_CLOCK_SEQUENCE)).toBe(
+                false
+            );
+        });
+    });
+
+    describe('uninterpretable UUIDs are kept', () => {
+        test('empty string', () => {
+            expect(hasAckTxnFlag('')).toBe(false);
+        });
+
+        // `Number.parseInt` stops at the first non-hex character, so a partially
+        // parsed group must not be mistaken for a set of flags.
+        test('not a UUID', () => {
+            expect(hasAckTxnFlag('not-a-uuid-at-all-x')).toBe(false);
+        });
+
+        test('truncated UUID', () => {
+            expect(hasAckTxnFlag('9f8e7d6c-1234-11f0-800')).toBe(false);
+        });
+
+        test('zero UUID', () => {
+            expect(hasAckTxnFlag('00000000-0000-0000-0000-000000000000')).toBe(
+                false
+            );
+        });
+    });
+
+    test('is case insensitive', () => {
+        expect(hasAckTxnFlag(ACK_UUID_WITH_CLOCK_SEQUENCE.toUpperCase())).toBe(
+            true
+        );
+    });
+});

--- a/src/hooks/journals/shared.ts
+++ b/src/hooks/journals/shared.ts
@@ -18,6 +18,36 @@ import { CustomEvents } from 'src/services/types';
 import { INCREMENT } from 'src/utils/dataPlane-utils';
 import { journalStatusIsError } from 'src/utils/misc-utils';
 
+// Gazette packs message flags into the low 10 bits of a v1 UUID's clock-sequence
+// field, which is the fourth hyphen-delimited group. ACK_TXN marks a document as
+// the acknowledgement of a committed transaction: runtime bookkeeping rather than
+// collection data, so it should not be shown to users.
+//
+// The flag is what we test because the acknowledgement body differs by runtime
+// version. Runtime v1 writes the collection's ack template, `{"_meta":{"uuid":...,
+// "ack":true}}`, while runtime v2 writes `{"_meta":{"uuid":...},"is_ack":true,...}`.
+// Only the UUID is common to both, and `is_ack` sits in the user's own namespace
+// where a real document could legitimately carry it.
+//
+// See `build` and `parse` in crates/proto-gazette/src/uuid.rs of estuary/flow.
+const ACK_TXN = 0x2;
+const FLAGS_MASK = 0x3ff;
+const MESSAGE_UUID =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-([0-9a-f]{4})-[0-9a-f]{12}$/i;
+
+export const hasAckTxnFlag = (uuid: string): boolean => {
+    const match = MESSAGE_UUID.exec(uuid);
+
+    // Show, rather than hide, a document whose UUID we cannot interpret.
+    if (match === null) {
+        return false;
+    }
+
+    const flags = Number.parseInt(match[1], 16) & FLAGS_MASK;
+
+    return (flags & ACK_TXN) !== 0;
+};
+
 function isJournalRecord(val: any): val is JournalRecord {
     return val?._meta?.uuid;
 }
@@ -150,10 +180,7 @@ export async function loadDocuments({
             range: [readStart, readEnd],
             allDocs: allDocs
                 .filter(isJournalRecord)
-                .filter(
-                    (record) =>
-                        !(record._meta as unknown as { ack: boolean }).ack
-                ),
+                .filter((record) => !hasAckTxnFlag(record._meta.uuid)),
         };
     };
 


### PR DESCRIPTION
## What

For collections written by runtime v2, the data preview selects an acknowledgement document as its first row, labeled with an empty key, instead of collection data. 

## Root cause

The data preview UI has filtered acknowledgements since it was first built (#298), by testing `_meta.ack`. Runtime V1 builds each collection's `ack_template_json` as `{"_meta":{"uuid":...,"ack":true}}`, and the v1 Go runtime appends that template with the UUID substituted in.

Runtime v2 never reads `ack_template_json`. Its acknowledgements come from `publisher::intents::build_transaction_intents` and are shaped `{"_meta":{"uuid":...},"is_ack":true,"hints":[...]}`, so `_meta.ack` is undefined and the filter passes them through.

An acknowledgement carries no collection key, so `ListView` computes an empty row label when it maps the collection's key pointers over one, and the auto-select effect then selects that row.

## Fix

Identify acknowledgements by the `ACK_TXN` flag that Gazette packs into the low 10 bits of the message UUID's clock-sequence field. Both runtime versions set it, and unlike a body field it is not something a user's schema can collide with.

-  Also filters runtime v1 ops acknowledgements, whose `ack` field sits at the document root (`go/runtime/ops_publisher.go`) where `_meta.ack` never matched it.
-  Keeps documents whose own schema defines `is_ack`, which a body-field filter would wrongly hide.
-  `loadDocuments` is the only journal reader in the UI, so this covers the data preview and the ops logs table.


## Automated tests

-   15 unit tests in `dataPlane-utils.test.ts` covering v1 collection and ops acknowledgements, v2 acknowledgements (with hints, without hints, and carrying a backfill marker), `CONTINUE_TXN` and `OUTSIDE_TXN` documents, a document defining its own `is_ack`, acknowledgements and documents with clock-sequence bits set, and uninterpretable UUIDs.