### PR TITLE
Add global organization selector

### DIFF
--- a/src/app/guards/TenantGuard/index.tsx
+++ b/src/app/guards/TenantGuard/index.tsx
@@ -9,6 +9,7 @@ import { useUserInfoSummaryStore } from 'src/context/UserInfoSummary/useUserInfo
 import useGlobalSearchParams, {
     GlobalSearchParams,
 } from 'src/hooks/searchParams/useGlobalSearchParams';
+import { useInitializeSelectedTenant } from 'src/hooks/useInitializeSelectedTenant';
 
 // This is a way to very simply "hide" the flow where anyone
 //  can create a tenant but allow us to test it out in prod.
@@ -26,6 +27,8 @@ function TenantGuard({ children }: BaseComponentProps) {
     const hasAnyAccess = useUserInfoSummaryStore((state) => state.hasAnyAccess);
     const mutate = useUserInfoSummaryStore((state) => state.mutate);
     const usedSSO = useUserStore((state) => state.userDetails?.usedSSO);
+
+    useInitializeSelectedTenant();
 
     const showOnboarding = !hasAnyAccess || showBeta;
     if (showOnboarding) {

--- a/src/components/admin/Settings/index.tsx
+++ b/src/components/admin/Settings/index.tsx
@@ -1,11 +1,10 @@
-import { Divider, Grid, Stack } from '@mui/material';
+import { Divider, Stack } from '@mui/material';
 
 import { authenticatedRoutes } from 'src/app/routes';
 import DataPlanes from 'src/components/admin/Settings/DataPlanes';
 import PrefixAlerts from 'src/components/admin/Settings/PrefixAlerts';
 import { StorageMappings } from 'src/components/admin/Settings/StorageMappings';
 import AdminTabs from 'src/components/admin/Tabs';
-import TenantSelector from 'src/components/shared/TenantSelector';
 import usePageTitle from 'src/hooks/usePageTitle';
 
 function Settings() {
@@ -16,19 +15,6 @@ function Settings() {
     return (
         <>
             <AdminTabs />
-
-            <Grid
-                container
-                spacing={{ xs: 3, md: 2 }}
-                sx={{ p: 2, justifyContent: 'flex-end' }}
-            >
-                <Grid
-                    size={{ xs: 12, md: 3 }}
-                    sx={{ mt: 2.5, display: 'flex', alignItems: 'end' }}
-                >
-                    <TenantSelector />
-                </Grid>
-            </Grid>
 
             <PrefixAlerts />
 

--- a/src/components/home/dashboard/index.tsx
+++ b/src/components/home/dashboard/index.tsx
@@ -1,20 +1,10 @@
-import { Box, Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 
 import EntityStatOverview from 'src/components/home/dashboard/EntityStatOverview';
-import TenantSelector from 'src/components/shared/TenantSelector';
 
 export default function Dashboard() {
     return (
         <Grid container spacing={{ xs: 2 }} style={{ marginTop: 16 }}>
-            <Grid
-                size={{ xs: 12 }}
-                sx={{ display: 'flex', justifyContent: 'flex-end' }}
-            >
-                <Box style={{ width: 300 }}>
-                    <TenantSelector />
-                </Box>
-            </Grid>
-
             <EntityStatOverview />
         </Grid>
     );

--- a/src/components/menus/OrgMenu.tsx
+++ b/src/components/menus/OrgMenu.tsx
@@ -8,7 +8,6 @@ import {
 } from '@mui/material';
 
 import { Check } from 'iconoir-react';
-import { FormattedMessage, useIntl } from 'react-intl';
 
 import PrefixSelector from 'src/components/inputs/PrefixedName/PrefixSelector';
 import { useUserInfoSummaryStore } from 'src/context/UserInfoSummary/useUserInfoSummaryStore';
@@ -21,7 +20,6 @@ interface OrgMenuProps {
 }
 
 export const OrgMenu = ({ anchorEl, onClose }: OrgMenuProps) => {
-    const intl = useIntl();
     const selectedTenant = useTenantStore((state) => state.selectedTenant);
     const setSelectedTenant = useTenantStore(
         (state) => state.setSelectedTenant
@@ -39,16 +37,12 @@ export const OrgMenu = ({ anchorEl, onClose }: OrgMenuProps) => {
                 fullWidth
                 maxWidth="xs"
             >
-                <DialogTitle>
-                    <FormattedMessage id="tenant.organization" />
-                </DialogTitle>
+                <DialogTitle>Organization</DialogTitle>
                 <DialogContent>
                     <PrefixSelector
                         disabled={false}
                         error={false}
-                        label={intl.formatMessage({
-                            id: 'tenant.organization',
-                        })}
+                        label="Organization"
                         labelId="org-switcher"
                         onChange={(newValue) => {
                             setSelectedTenant(newValue);
@@ -92,7 +86,7 @@ export const OrgMenu = ({ anchorEl, onClose }: OrgMenuProps) => {
                     color: 'text.secondary',
                 }}
             >
-                <FormattedMessage id="tenant.organization" />
+                Organization
             </Typography>
 
             {tenantNames.map((tenant) => {

--- a/src/components/menus/OrgMenu.tsx
+++ b/src/components/menus/OrgMenu.tsx
@@ -1,0 +1,125 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    MenuItem,
+    Popover,
+    Typography,
+} from '@mui/material';
+
+import { Check } from 'iconoir-react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import PrefixSelector from 'src/components/inputs/PrefixedName/PrefixSelector';
+import { useUserInfoSummaryStore } from 'src/context/UserInfoSummary/useUserInfoSummaryStore';
+import { useEntitiesStore_tenantsWithAdmin } from 'src/stores/Entities/hooks';
+import { useTenantStore } from 'src/stores/Tenant';
+
+interface OrgMenuProps {
+    anchorEl: HTMLElement | null;
+    onClose: () => void;
+}
+
+export const OrgMenu = ({ anchorEl, onClose }: OrgMenuProps) => {
+    const intl = useIntl();
+    const selectedTenant = useTenantStore((state) => state.selectedTenant);
+    const setSelectedTenant = useTenantStore(
+        (state) => state.setSelectedTenant
+    );
+    const tenantNames = useEntitiesStore_tenantsWithAdmin();
+    const hasSupportAccess = useUserInfoSummaryStore(
+        (state) => state.hasSupportAccess
+    );
+
+    if (hasSupportAccess) {
+        return (
+            <Dialog
+                open={Boolean(anchorEl)}
+                onClose={onClose}
+                fullWidth
+                maxWidth="xs"
+            >
+                <DialogTitle>
+                    <FormattedMessage id="tenant.organization" />
+                </DialogTitle>
+                <DialogContent>
+                    <PrefixSelector
+                        disabled={false}
+                        error={false}
+                        label={intl.formatMessage({
+                            id: 'tenant.organization',
+                        })}
+                        labelId="org-switcher"
+                        onChange={(newValue) => {
+                            setSelectedTenant(newValue);
+                            onClose();
+                        }}
+                        options={tenantNames}
+                        value={selectedTenant}
+                        variantString="outlined"
+                    />
+                </DialogContent>
+            </Dialog>
+        );
+    }
+
+    return (
+        <Popover
+            open={Boolean(anchorEl)}
+            anchorEl={anchorEl}
+            onClose={onClose}
+            anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
+            transformOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+            slotProps={{
+                paper: {
+                    sx: {
+                        width: 240,
+                        p: 1,
+                        borderRadius: 2,
+                    },
+                },
+            }}
+        >
+            <Typography
+                sx={{
+                    px: 1,
+                    pt: 0.5,
+                    pb: 1,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.5,
+                    color: 'text.secondary',
+                }}
+            >
+                <FormattedMessage id="tenant.organization" />
+            </Typography>
+
+            {tenantNames.map((tenant) => {
+                const label = tenant.replace(/\/$/, '');
+                const isSelected = tenant === selectedTenant;
+
+                return (
+                    <MenuItem
+                        key={tenant}
+                        selected={isSelected}
+                        onClick={() => {
+                            setSelectedTenant(tenant);
+                            onClose();
+                        }}
+                        sx={{
+                            borderRadius: 1,
+                            fontSize: 13,
+                            py: 0.75,
+                            justifyContent: 'space-between',
+                        }}
+                    >
+                        {label}
+
+                        {isSelected ? <Check /> : null}
+                    </MenuItem>
+                );
+            })}
+        </Popover>
+    );
+};

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Box, List, Stack, useTheme } from '@mui/material';
 
 import {
+    Building,
     CloudDownload,
     CloudUpload,
     DatabaseScript,
@@ -17,9 +18,11 @@ import { Pill as AgentSkillsPill } from 'src/components/AgentSkills/Pill';
 import CompanyLogo from 'src/components/graphics/CompanyLogo';
 import CompanyMark from 'src/components/graphics/CompanyMark';
 import { HelpMenu } from 'src/components/menus/HelpMenu';
+import { OrgMenu } from 'src/components/menus/OrgMenu';
 import NavLink, { NavButton } from 'src/components/navigation/NavItems';
 import { UserButton, UserMenu } from 'src/components/navigation/User';
 import { UpdateAlert } from 'src/components/UpdateAlert';
+import { useTenantStore } from 'src/stores/Tenant';
 import { useNavigationStore } from 'src/stores/useNavigationStore';
 
 const NavWidths = {
@@ -33,6 +36,10 @@ export const Navigation = () => {
     const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
     const [helpAnchor, setHelpAnchor] = useState<HTMLElement | null>(null);
+
+    const [orgAnchor, setOrgAnchor] = useState<HTMLElement | null>(null);
+
+    const selectedTenant = useTenantStore((state) => state.selectedTenant);
 
     const open = useNavigationStore((state) => state.open);
     const toggleOpen = useNavigationStore((state) => state.toggleOpen);
@@ -154,6 +161,21 @@ export const Navigation = () => {
                         anchorEl={menuAnchor}
                         onClose={() => setMenuAnchor(null)}
                     />
+
+                    {selectedTenant ? (
+                        <>
+                            <NavButton
+                                icon={<Building />}
+                                title={selectedTenant.replace(/\/$/, '')}
+                                onClick={(e) => setOrgAnchor(e.currentTarget)}
+                                isOpen={open}
+                            />
+                            <OrgMenu
+                                anchorEl={orgAnchor}
+                                onClose={() => setOrgAnchor(null)}
+                            />
+                        </>
+                    ) : null}
                 </Box>
             </Stack>
         </Box>

--- a/src/components/shared/PageContainer.tsx
+++ b/src/components/shared/PageContainer.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Box, Paper, Snackbar, Typography, useTheme } from '@mui/material';
 
+import { Building } from 'iconoir-react';
 import { useIntl } from 'react-intl';
 
 import AlertBox from 'src/components/shared/AlertBox';
@@ -13,6 +14,7 @@ import { paperBackground } from 'src/context/Theme';
 import useNotificationStore, {
     notificationStoreSelectors,
 } from 'src/stores/NotificationStore';
+import { useTenantStore } from 'src/stores/Tenant';
 import { useTopBarStore } from 'src/stores/TopBar/Store';
 import { useNavigationStore } from 'src/stores/useNavigationStore';
 
@@ -26,6 +28,7 @@ function PageContainer({ children, hideBackground }: Props) {
     const theme = useTheme();
     const header = useTopBarStore((state) => state.header);
     const navigationOpen = useNavigationStore((state) => state.open);
+    const selectedTenant = useTenantStore((state) => state.selectedTenant);
 
     const notification = useNotificationStore(
         notificationStoreSelectors.notification
@@ -139,6 +142,19 @@ function PageContainer({ children, hideBackground }: Props) {
                         background: backgroundMixin,
                     }}
                 >
+                    {selectedTenant ? (
+                        <>
+                            <Building
+                                aria-hidden
+                                style={{ width: 16, height: 16 }}
+                            />
+                            <Typography>
+                                {selectedTenant.replace(/\/$/, '')}
+                            </Typography>
+                            <Typography aria-hidden>/</Typography>
+                        </>
+                    ) : null}
+
                     <Typography sx={{ fontWeight: 'bold' }}>
                         {intl.formatMessage({ id: header })}
                     </Typography>

--- a/src/hooks/useInitializeSelectedTenant.ts
+++ b/src/hooks/useInitializeSelectedTenant.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+
+import useGlobalSearchParams, {
+    GlobalSearchParams,
+} from 'src/hooks/searchParams/useGlobalSearchParams';
+import { useEntitiesStore_tenantsWithAdmin } from 'src/stores/Entities/hooks';
+import { useTenantStore } from 'src/stores/Tenant';
+import { hasLength } from 'src/utils/misc-utils';
+
+// Initialize the persisted, globally selected organization independently of
+// any selector UI. Deep links take precedence, followed by a still-valid
+// persisted selection, then the first organization available to the user.
+export function useInitializeSelectedTenant() {
+    const selectedTenant = useTenantStore((state) => state.selectedTenant);
+    const setSelectedTenant = useTenantStore(
+        (state) => state.setSelectedTenant
+    );
+    const tenantNames = useEntitiesStore_tenantsWithAdmin();
+
+    const prefixParam = useGlobalSearchParams(GlobalSearchParams.PREFIX);
+    const appliedPrefixParam = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!hasLength(tenantNames)) {
+            return;
+        }
+
+        if (
+            hasLength(prefixParam) &&
+            tenantNames.includes(prefixParam) &&
+            prefixParam !== appliedPrefixParam.current
+        ) {
+            appliedPrefixParam.current = prefixParam;
+
+            if (prefixParam !== selectedTenant) {
+                setSelectedTenant(prefixParam);
+            }
+
+            return;
+        }
+
+        if (!(selectedTenant && tenantNames.includes(selectedTenant))) {
+            setSelectedTenant(tenantNames[0]);
+        }
+    }, [prefixParam, selectedTenant, setSelectedTenant, tenantNames]);
+}

--- a/src/lang/en-US/Navigation.ts
+++ b/src/lang/en-US/Navigation.ts
@@ -2,6 +2,8 @@ import { CommonMessages } from 'src/lang/en-US/CommonMessages';
 import { CTAs } from 'src/lang/en-US/CTAs';
 
 export const Navigation: Record<string, string> = {
+    'tenant.organization': `Organization`,
+
     'helpMenu.docs': `Docs`,
     'helpMenu.docs.link': `https://docs.estuary.dev/`,
     'helpMenu.slack': `Estuary Slack`,

--- a/src/lang/en-US/Navigation.ts
+++ b/src/lang/en-US/Navigation.ts
@@ -2,8 +2,6 @@ import { CommonMessages } from 'src/lang/en-US/CommonMessages';
 import { CTAs } from 'src/lang/en-US/CTAs';
 
 export const Navigation: Record<string, string> = {
-    'tenant.organization': `Organization`,
-
     'helpMenu.docs': `Docs`,
     'helpMenu.docs.link': `https://docs.estuary.dev/`,
     'helpMenu.slack': `Estuary Slack`,


### PR DESCRIPTION
## Summary

- Add a sidebar organization selector backed by the existing global tenant state.
- Show the selected organization in content-header breadcrumbs.
- Remove duplicate selectors from the welcome and Settings pages.

## Validation

- TypeScript typecheck
- ESLint and Prettier
- Vitest: 286 tests passed
