### PR TITLE
details: Show a materialization's data backlog

### DIFF
--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -2,6 +2,7 @@ import type { PostgrestResponse } from '@supabase/postgrest-js';
 import type { DataByHourRange } from 'src/components/graphs/types';
 import type {
     CatalogStats,
+    CatalogStats_Backlog,
     CatalogStats_Dashboard,
     CatalogStats_Details,
     Entity,
@@ -78,6 +79,10 @@ const MATERIALIZATION_QUERY = `
     docs_read:docs_read_by_me,
     bytes_read:bytes_read_by_me
 `;
+
+// Per-binding readings live in the stats document rather than in dedicated
+// columns, so anything below binding granularity has to come out of the JSON.
+const STATS_DOCUMENT_QUERY = `${BASE_QUERY},flow_document`;
 
 const hourlyGrain = 'hourly';
 const dailyGrain = 'daily';
@@ -244,6 +249,26 @@ const getStatsForDetails = (
         .returns<CatalogStats_Details[]>();
 };
 
+// `bytesBehind` is a gauge describing where a materialization stands right now,
+// so the newest reading is the only one worth showing, and hourly is the finest
+// grain available.
+//
+// A few rows are fetched rather than just the newest, because a row carries no
+// binding stats at all when a usage heartbeat opened the hour — see
+// `newestBindingStats`, which picks the newest row that does.
+const BACKLOG_HOURS = 6;
+
+const getMaterializationBacklog = (catalogName: string) => {
+    return supabaseClient
+        .from(TABLES.CATALOG_STATS)
+        .select(STATS_DOCUMENT_QUERY)
+        .eq('catalog_name', catalogName)
+        .eq('grain', hourlyGrain)
+        .order('ts', { ascending: false })
+        .limit(BACKLOG_HOURS)
+        .returns<CatalogStats_Backlog[]>();
+};
+
 const getStatsForDashboard = (tenant: string) => {
     return supabaseClient
         .from(TABLES.CATALOG_STATS)
@@ -303,4 +328,9 @@ const getStatsForDashboard = (tenant: string) => {
 //     );
 // };
 
-export { getStatsByName, getStatsForDashboard, getStatsForDetails };
+export {
+    getMaterializationBacklog,
+    getStatsByName,
+    getStatsForDashboard,
+    getStatsForDetails,
+};

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/BacklogSection.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/BacklogSection.tsx
@@ -1,0 +1,30 @@
+import type { BacklogSectionProps } from 'src/components/shared/Entity/Details/Overview/DetailsSection/types';
+
+import { Typography } from '@mui/material';
+
+import { formatBytes } from 'src/components/tables/cells/stats/shared';
+import { useMaterializationBacklog } from 'src/hooks/details/useMaterializationBacklog';
+
+export function BacklogSection({ entityName }: BacklogSectionProps) {
+    const { backlog, error } = useMaterializationBacklog(entityName);
+
+    // A failed request leaves `backlog` null, the same shape as a caught-up
+    // task, so check the error first to avoid reporting a stats failure as
+    // "current".
+    if (error) {
+        return <Typography component="div">&mdash;</Typography>;
+    }
+
+    // A binding omits `bytesBehind` once it has nothing left to read, so a task
+    // whose bindings report nothing has caught up. The card holds its skeleton
+    // until this has loaded, so an empty result here is an answer, not a wait.
+    if (!backlog || backlog.bytesBehind === 0) {
+        return <Typography component="div">current</Typography>;
+    }
+
+    return (
+        <Typography component="div">
+            {formatBytes(backlog.bytesBehind)}
+        </Typography>
+    );
+}

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/index.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/index.tsx
@@ -8,12 +8,15 @@ import { useIntl } from 'react-intl';
 
 import CardWrapper from 'src/components/shared/CardWrapper';
 import DataPlane from 'src/components/shared/Entity/DataPlane';
+import { BacklogSection } from 'src/components/shared/Entity/Details/Overview/DetailsSection/BacklogSection';
 import ConnectorSection from 'src/components/shared/Entity/Details/Overview/DetailsSection/ConnectorSection';
 import { TIME_SETTINGS } from 'src/components/shared/Entity/Details/Overview/DetailsSection/shared';
 import StatusSection from 'src/components/shared/Entity/Details/Overview/DetailsSection/StatusSection';
 import KeyValueList from 'src/components/shared/KeyValueList';
 import { useEntityType } from 'src/context/EntityContext';
+import { useMaterializationBacklog } from 'src/hooks/details/useMaterializationBacklog';
 import useRelatedEntities from 'src/hooks/details/useRelatedEntities';
+import { useShardDetail_runtimeV2 } from 'src/stores/ShardDetail/hooks';
 import {
     formatDataPlaneName,
     getDataPlaneScope,
@@ -28,11 +31,27 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
 
     const relatedEntities = useRelatedEntities();
 
+    // Only the V2 runtime reports a task's progress through its bindings, so
+    // there is nothing to show for a task running on anything else.
+    const runtimeV2 = useShardDetail_runtimeV2(entityName);
+    const showBacklog = entityType === 'materialization' && runtimeV2;
+
+    // Passing an empty name leaves the queries unissued, so this costs nothing
+    // for a task with no backlog rows to show. Where it does apply, the request
+    // is shared with the rows themselves rather than repeated.
+    const { loading: backlogLoading } = useMaterializationBacklog(
+        // TODO: this is a bit of a hack. An empty string below prevents the hook from firing - necessary because
+        // DetailsSection is used for more than just materializations. Would be nice to split this out into more composable components.
+        showBacklog ? entityName : ''
+    );
+
     const data = useMemo(() => {
         const response = [];
 
-        // If there is nothing to show then display the loading status
-        if (!latestLiveSpec) {
+        // If there is nothing to show then display the loading status. The
+        // backlog rows are covered here as well, so the card fills in once,
+        // rather than settling and then filling those two in behind it.
+        if (!latestLiveSpec || backlogLoading) {
             response.push(
                 {
                     title: <Skeleton width="33%" />,
@@ -65,6 +84,13 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
                     id: 'data.connectorStatus',
                 }),
                 val: <StatusSection entityName={entityName} />,
+            });
+        }
+
+        if (showBacklog) {
+            response.push({
+                title: 'Data Backlog',
+                val: <BacklogSection entityName={entityName} />,
             });
         }
 
@@ -109,7 +135,14 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
         });
 
         return response;
-    }, [entityName, entityType, intl, latestLiveSpec]);
+    }, [
+        backlogLoading,
+        entityName,
+        entityType,
+        intl,
+        latestLiveSpec,
+        showBacklog,
+    ]);
 
     return (
         <CardWrapper

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/types.ts
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/types.ts
@@ -13,3 +13,7 @@ export interface ConnectorSectionProps {
 export interface StatusSectionProps {
     entityName: DetailsSectionProps['entityName'];
 }
+
+export interface BacklogSectionProps {
+    entityName: DetailsSectionProps['entityName'];
+}

--- a/src/hooks/details/__tests__/shared.test.ts
+++ b/src/hooks/details/__tests__/shared.test.ts
@@ -1,0 +1,203 @@
+import type { CatalogStats_Backlog } from 'src/types';
+
+import { formatBytes } from 'src/components/tables/cells/stats/shared';
+import { parseMaterializationBacklog } from 'src/hooks/details/shared';
+
+// Builds one hourly stats row for a task. `catalog_stats.flow_document` holds a
+// materialization's per-binding stats under `taskStats.materialize`, keyed by
+// source collection name. See ops-catalog/stats.schema.yaml of estuary/flow.
+const statsRow = (
+    ts: string,
+    materialize?: Record<string, { bytesBehind?: number | string }>
+): CatalogStats_Backlog => ({
+    catalog_name: 'acmeCo/warehouse',
+    grain: 'hourly',
+    ts,
+    flow_document: materialize
+        ? { taskStats: { materialize } }
+        : { taskStats: {} },
+});
+
+describe('parseMaterializationBacklog', () => {
+    test('sums the readings of every binding in the row', () => {
+        const backlog = parseMaterializationBacklog([
+            statsRow('2026-08-07T19:00:00Z', {
+                'acmeCo/orders': { bytesBehind: 1000 },
+                'acmeCo/shipments': { bytesBehind: 2500 },
+            }),
+        ]);
+
+        expect(backlog?.bytesBehind).toBe(3500);
+    });
+
+    test('reads only the newest row, ignoring older readings', () => {
+        const backlog = parseMaterializationBacklog([
+            statsRow('2026-08-07T18:00:00Z', {
+                'acmeCo/orders': { bytesBehind: 2500 },
+            }),
+            statsRow('2026-08-07T19:00:00Z', {
+                'acmeCo/orders': { bytesBehind: 1000 },
+            }),
+        ]);
+
+        expect(backlog?.bytesBehind).toBe(1000);
+        expect(backlog?.ts).toBe('2026-08-07T19:00:00Z');
+    });
+
+    // A binding omits the field once it has nothing left to read, so an absent
+    // reading is zero rather than unknown.
+    test('treats a binding with no reading as caught up', () => {
+        const backlog = parseMaterializationBacklog([
+            statsRow('2026-08-07T19:00:00Z', {
+                'acmeCo/orders': { bytesBehind: 1000 },
+                'acmeCo/shipments': {},
+            }),
+        ]);
+
+        expect(backlog?.bytesBehind).toBe(1000);
+        expect(backlog?.bindings).toHaveLength(2);
+    });
+
+    // A usage heartbeat opens the hour's row without describing any bindings, so
+    // the newest row can exist while saying nothing about the task.
+    test('skips a newer row that carries no binding stats at all', () => {
+        const backlog = parseMaterializationBacklog([
+            statsRow('2026-08-07T20:00:00Z'),
+            statsRow('2026-08-07T19:00:00Z', {
+                'acmeCo/orders': { bytesBehind: 1000 },
+            }),
+        ]);
+
+        expect(backlog?.bytesBehind).toBe(1000);
+        expect(backlog?.ts).toBe('2026-08-07T19:00:00Z');
+    });
+
+    // `bytesBehind` is a u64, and the default JSON encoding for those is a string
+    // so large values survive. estuary/flow patches its Rust encoder to emit a
+    // number, but the encoding is not uniform across producers.
+    test('accepts a reading encoded as a string', () => {
+        const backlog = parseMaterializationBacklog([
+            statsRow('2026-08-07T19:00:00Z', {
+                'acmeCo/orders': { bytesBehind: '1000' },
+                'acmeCo/shipments': { bytesBehind: 2500 },
+            }),
+        ]);
+
+        expect(backlog?.bytesBehind).toBe(3500);
+    });
+
+    test('ignores a reading that is neither a number nor numeric', () => {
+        const backlog = parseMaterializationBacklog([
+            statsRow('2026-08-07T19:00:00Z', {
+                'acmeCo/orders': { bytesBehind: 'lots' },
+            }),
+        ]);
+
+        expect(backlog?.bytesBehind).toBe(0);
+    });
+
+    // The whole task is current when every binding has caught up, which is what
+    // the card shows in place of a figure.
+    test('totals zero when no binding reports a reading', () => {
+        const backlog = parseMaterializationBacklog([
+            statsRow('2026-08-07T20:00:00Z', {
+                'acmeCo/orders': {},
+                'acmeCo/shipments': {},
+            }),
+        ]);
+
+        expect(backlog?.bytesBehind).toBe(0);
+        expect(backlog?.bindings).toHaveLength(2);
+    });
+
+    // Captures and collections have no `materialize` stats at all, and neither do
+    // materializations that have yet to process anything.
+    test('returns null when no row has materialize stats', () => {
+        expect(
+            parseMaterializationBacklog([statsRow('2026-08-07T20:00:00Z')])
+        ).toBeNull();
+        expect(parseMaterializationBacklog([])).toBeNull();
+    });
+
+    // A real hourly row from hyphametrics/snowflake/materialize-snowflake, with
+    // the per-binding `out` and `right` tallies dropped since nothing reads them.
+    // Twelve bindings, of which three are behind. Note the `interval` heartbeat
+    // sharing the row with the binding stats.
+    describe('a production stats row', () => {
+        const row: CatalogStats_Backlog = {
+            catalog_name: 'hyphametrics/snowflake/materialize-snowflake',
+            grain: 'hourly',
+            ts: '2026-08-07T20:00:00.000Z',
+            flow_document: {
+                taskStats: {
+                    materialize: {
+                        'hyphametrics/mongodb/raw-personicore/adscatalog': {},
+                        'hyphametrics/mongodb/raw-personicore/brandcatalogs':
+                            {},
+                        'hyphametrics/mongodb/raw-personicore/contentcatalogs':
+                            {},
+                        'hyphametrics/mongodb/raw-personicore/coremeters': {
+                            bytesBehind: 3655,
+                        },
+                        'hyphametrics/mongodb/raw-personicore/hd_logpresences':
+                            {
+                                bytesBehind: 587,
+                            },
+                        'hyphametrics/mongodb/raw-personicore/households': {},
+                        'hyphametrics/mongodb/raw-personicore/logcoremeterstats':
+                            {},
+                        'hyphametrics/mongodb/raw-personicore/mediasources': {},
+                        'hyphametrics/mongodb/raw-personicore/panelists': {},
+                        'hyphametrics/mongodb/raw-personicore/personaldevices':
+                            {},
+                        'hyphametrics/mongodb/raw-personicore/routers': {},
+                        'hyphametrics/mongodb/raw-personicore/viewershipcontents':
+                            {
+                                bytesBehind: 1130136,
+                            },
+                    },
+                    interval: { uptimeSeconds: 1800, usageRate: 1 },
+                },
+            },
+        };
+
+        test('totals the three bindings that are behind', () => {
+            expect(parseMaterializationBacklog([row])?.bytesBehind).toBe(
+                1134378
+            );
+        });
+
+        test('keeps all twelve bindings, worst first', () => {
+            const backlog = parseMaterializationBacklog([row]);
+
+            expect(backlog?.bindings).toHaveLength(12);
+            expect(
+                backlog?.bindings
+                    .filter(({ bytesBehind }) => bytesBehind > 0)
+                    .map(({ collectionName, bytesBehind }) => [
+                        collectionName,
+                        bytesBehind,
+                    ])
+            ).toEqual([
+                [
+                    'hyphametrics/mongodb/raw-personicore/viewershipcontents',
+                    1130136,
+                ],
+                ['hyphametrics/mongodb/raw-personicore/coremeters', 3655],
+                ['hyphametrics/mongodb/raw-personicore/hd_logpresences', 587],
+            ]);
+        });
+
+        test('renders the total the way the card does', () => {
+            const backlog = parseMaterializationBacklog([row]);
+
+            expect(formatBytes(backlog?.bytesBehind)).toBe('1.13 MB');
+        });
+
+        test('reports the stats document timestamp', () => {
+            expect(parseMaterializationBacklog([row])?.ts).toBe(
+                '2026-08-07T20:00:00.000Z'
+            );
+        });
+    });
+});

--- a/src/hooks/details/shared.ts
+++ b/src/hooks/details/shared.ts
@@ -1,0 +1,83 @@
+import type { CatalogStats_Backlog } from 'src/types';
+
+import { hasLength } from 'src/utils/misc-utils';
+
+interface BindingReading {
+    collectionName: string;
+    bytesBehind: number;
+}
+
+export interface MaterializationBacklog {
+    bindings: BindingReading[];
+    bytesBehind: number;
+    // The timestamp of the stats document the readings came from.
+    ts: string;
+}
+
+// `bytesBehind` is a u64 in the stats protocol, and the default JSON encoding for
+// those is a string so that values beyond 2^53 survive the trip. estuary/flow
+// patches its Rust encoder to emit a number instead, but the encoding is not
+// guaranteed to be uniform across producers, so accept either form.
+//
+// A binding with nothing left to read omits the field, so an absent reading is
+// zero rather than unknown.
+const toByteCount = (value: unknown): number => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : 0;
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number(value);
+
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
+
+    return 0;
+};
+
+// The most recent stats row that actually describes the task's bindings.
+//
+// An hourly row is opened by whichever stats document lands first in that hour,
+// and a usage heartbeat carries no `materialize` block at all — so the newest row
+// for a task can exist while saying nothing about its bindings.
+const newestBindingStats = (
+    rows: CatalogStats_Backlog[]
+): CatalogStats_Backlog | null =>
+    [...rows]
+        .sort((left, right) => Date.parse(right.ts) - Date.parse(left.ts))
+        .find(({ flow_document }) =>
+            hasLength(Object.keys(flow_document?.taskStats?.materialize ?? {}))
+        ) ?? null;
+
+// How far behind a materialization is, totalled across its bindings. Bindings
+// that report no reading have caught up and contribute nothing, so a total of
+// zero means the task is current.
+//
+// Returns null when no row describes the bindings at all.
+export const parseMaterializationBacklog = (
+    rows: CatalogStats_Backlog[]
+): MaterializationBacklog | null => {
+    const latest = newestBindingStats(rows);
+
+    if (!latest) {
+        return null;
+    }
+
+    const bindings = Object.entries(
+        latest.flow_document?.taskStats?.materialize ?? {}
+    )
+        .map(([collectionName, bindingStats]) => ({
+            collectionName,
+            bytesBehind: toByteCount(bindingStats?.bytesBehind),
+        }))
+        .sort((left, right) => right.bytesBehind - left.bytesBehind);
+
+    return {
+        bindings,
+        bytesBehind: bindings.reduce(
+            (total, { bytesBehind }) => total + bytesBehind,
+            0
+        ),
+        ts: latest.ts,
+    };
+};

--- a/src/hooks/details/useMaterializationBacklog.ts
+++ b/src/hooks/details/useMaterializationBacklog.ts
@@ -1,0 +1,36 @@
+import type { MaterializationBacklog } from 'src/hooks/details/shared';
+
+import { useMemo } from 'react';
+
+import { useQuery } from '@supabase-cache-helpers/postgrest-swr';
+
+import { getMaterializationBacklog } from 'src/api/stats';
+import { parseMaterializationBacklog } from 'src/hooks/details/shared';
+import { hasLength } from 'src/utils/misc-utils';
+
+const REFRESH_INTERVAL = 15000;
+
+const SWR_CONFIG = {
+    revalidateOnMount: true,
+    refreshInterval: REFRESH_INTERVAL,
+};
+
+// How far behind a materialization is, taken from its newest hourly stats row
+// that describes its bindings.
+export function useMaterializationBacklog(catalogName: string) {
+    const { data, error, isValidating } = useQuery(
+        hasLength(catalogName) ? getMaterializationBacklog(catalogName) : null,
+        SWR_CONFIG
+    );
+
+    const backlog = useMemo<MaterializationBacklog | null>(
+        () => (data ? parseMaterializationBacklog(data) : null),
+        [data]
+    );
+
+    // True only until the first response lands. A background refresh leaves this
+    // false, so a value already on screen is never replaced by a loading state.
+    const loading = isValidating && !data;
+
+    return { backlog, loading, error, isValidating };
+}

--- a/src/stores/ShardDetail/Store.ts
+++ b/src/stores/ShardDetail/Store.ts
@@ -152,6 +152,9 @@ const getEverythingForDictionary = (
             case SHARD_LABELS.HOSTNAME:
                 response.hostname = label.value;
                 break;
+            case SHARD_LABELS.RUNTIME_V2:
+                response.runtimeV2 = label.value === 'true';
+                break;
             default:
                 if (label.name?.startsWith(PORT_PROTO_PREFIX)) {
                     response.portProtocol = label.value;

--- a/src/stores/ShardDetail/hooks.ts
+++ b/src/stores/ShardDetail/hooks.ts
@@ -99,6 +99,20 @@ export const useShardDetail_setDictionaryHydrated = () => {
     >(storeName(entityType), (state) => state.setDictionaryHydrated);
 };
 
+// Whether a task runs on the V2 runtime, which is the only runtime that reports
+// per-binding progress in its stats documents. A task's shards all come from one
+// template, so any shard carrying the flag settles it.
+export const useShardDetail_runtimeV2 = (taskName: string) => {
+    const entityType = useEntityType();
+
+    const shards = useZustandStore<
+        ShardDetailStore,
+        ShardDetailStore['shardDictionary'][string]
+    >(storeName(entityType), (state) => state.shardDictionary[taskName]);
+
+    return Boolean(shards?.some(({ runtimeV2 }) => runtimeV2));
+};
+
 export const useShardDetail_readDictionary = (
     taskName: string,
     taskTypes?: ShardEntityTypes[]

--- a/src/stores/ShardDetail/types.ts
+++ b/src/stores/ShardDetail/types.ts
@@ -45,6 +45,7 @@ export interface TaskShardDetails {
     portProtocol?: any;
     protoPrefix?: any;
     publicPrefix?: any;
+    runtimeV2?: boolean;
     shardEndpoints?: EndpointsDictionary;
     spec?: Shard['spec'];
     status?: Shard['status'];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -149,6 +149,32 @@ export interface CatalogStats_Dashboard extends BaseCatalogStats {
     bytes_read_by_me?: number;
 }
 
+// The slice of `catalog_stats.flow_document` that describes a materialization's
+// bindings. The keys of `materialize` are source collection names.
+//
+// `bytesBehind` is how much of that collection the binding has yet to read.
+// Bindings with nothing left to read omit it rather than reporting zero.
+export interface CatalogStats_Backlog extends BaseCatalogStats {
+    flow_document: {
+        taskStats?: {
+            materialize?: {
+                [collectionName: string]: {
+                    // A u64 in the stats protocol, so it may arrive as a number
+                    // or as a string depending on the producer's JSON encoding.
+                    bytesBehind?: number | string;
+                };
+            };
+            // Metered uptime, which a task reports on its own schedule. It can be
+            // the only thing in a row, which is how a row comes to exist without
+            // describing any bindings.
+            interval?: {
+                uptimeSeconds: number;
+                usageRate?: number;
+            };
+        };
+    };
+}
+
 export interface Directive {
     created_at: Date;
     detail: null;

--- a/src/utils/dataPlane-utils.ts
+++ b/src/utils/dataPlane-utils.ts
@@ -28,6 +28,10 @@ import { hasLength, OPENID_HOST } from 'src/utils/misc-utils';
 export enum SHARD_LABELS {
     EXPOSE_PORT = 'estuary.dev/expose-port',
     HOSTNAME = 'estuary.dev/hostname',
+    // Set when a task's shard template carries the `enable-runtime-v2` flag,
+    // which selects the V2 task runtime. Only the V2 runtime reports the
+    // per-binding progress readings in a task's stats documents.
+    RUNTIME_V2 = 'estuary.dev/flag/enable-runtime-v2',
     TASK_NAME = 'estuary.dev/task-name',
     TASK_TYPE = 'estuary.dev/task-type',
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -140,6 +140,7 @@ export default defineConfig({
         deps: {
             inline: ['@estuary/flow-web'],
         },
+        include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
         exclude: [
             '**/playwright-tests/**',
 
@@ -188,9 +189,6 @@ export default defineConfig({
 
         // Quality Control
         checker({
-            eslint: {
-                lintCommand: 'lint',
-            },
             typescript: {
                 tsconfigPath: './tsconfig.json',
             },


### PR DESCRIPTION
Adds a **Data Backlog** row to the Overview details card for materializations, showing how many bytes are left to read across all bindings.

The value comes from `bytesBehind` in `catalog_stats.flow_document` (`taskStats.materialize`, keyed by source collection). Only the V2 runtime reports it, so the row is gated on the `estuary.dev/flag/enable-runtime-v2` shard label. It's a gauge, not a counter, so only the newest stats row with binding data is used — heartbeat rows open the hour without any. A binding that omits the field is caught up.

Also included: scoped the vitest `include` to `src/` so sibling worktrees aren't picked up, and dropped the ESLint plugin from the Vite dev-server checker (it was hitting EMFILE on macOS).
