### PR TITLE
details: Show how far behind a materialization is in time

### DIFF
--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -5,6 +5,7 @@ import type {
     CatalogStats_Backlog,
     CatalogStats_Dashboard,
     CatalogStats_Details,
+    CatalogStats_LastPublished,
     Entity,
 } from 'src/types';
 
@@ -269,6 +270,23 @@ const getMaterializationBacklog = (catalogName: string) => {
         .returns<CatalogStats_Backlog[]>();
 };
 
+// Where each of a materialization's source collections has been written up to,
+// which pairs with the task's own `lastSourcePublishedAt` to say how far behind
+// it is in time. `lastPublishedAt` reduces by maximizing, so a month's row
+// already holds the latest publication within that month; two months of rows
+// place the frontier of any collection still being written to.
+const getCollectionsLastPublished = (collectionNames: string[]) => {
+    const previousMonth = DateTime.utc().startOf('month').minus({ months: 1 });
+
+    return supabaseClient
+        .from(TABLES.CATALOG_STATS)
+        .select(STATS_DOCUMENT_QUERY)
+        .in('catalog_name', collectionNames)
+        .eq('grain', monthlyGrain)
+        .gte('ts', previousMonth.toFormat(defaultQueryDateFormat))
+        .returns<CatalogStats_LastPublished[]>();
+};
+
 const getStatsForDashboard = (tenant: string) => {
     return supabaseClient
         .from(TABLES.CATALOG_STATS)
@@ -329,6 +347,7 @@ const getStatsForDashboard = (tenant: string) => {
 // };
 
 export {
+    getCollectionsLastPublished,
     getMaterializationBacklog,
     getStatsByName,
     getStatsForDashboard,

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/BacklogSection.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/BacklogSection.tsx
@@ -24,7 +24,7 @@ export function BacklogSection({ entityName }: BacklogSectionProps) {
 
     return (
         <Typography component="div">
-            {formatBytes(backlog.bytesBehind)}
+            {formatBytes(backlog.bytesBehind, 0)}
         </Typography>
     );
 }

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/TimeLagSection.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/TimeLagSection.tsx
@@ -1,0 +1,31 @@
+import type { TimeLagSectionProps } from 'src/components/shared/Entity/Details/Overview/DetailsSection/types';
+
+import { Typography } from '@mui/material';
+
+import { Duration } from 'luxon';
+
+import { useMaterializationBacklog } from 'src/hooks/details/useMaterializationBacklog';
+import { toHumanDuration } from 'src/services/luxon';
+
+// One unit is enough to convey a lag at a glance — "1 day" rather than trailing
+// hours and minutes that will be stale by the time they are read.
+const formatLag = (seconds: number) =>
+    toHumanDuration(Duration.fromObject({ seconds }), { maxUnits: 1 });
+
+export function TimeLagSection({ entityName }: TimeLagSectionProps) {
+    const { timeLag } = useMaterializationBacklog(entityName);
+
+    if (!timeLag) {
+        return <Typography component="div">&mdash;</Typography>;
+    }
+
+    // A zero lag means every binding sits at or past its collection's frontier,
+    // caught up in time. Shown as "current" to match the data backlog row.
+    if (timeLag.seconds === 0) {
+        return <Typography component="div">current</Typography>;
+    }
+
+    return (
+        <Typography component="div">{formatLag(timeLag.seconds)}</Typography>
+    );
+}

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/index.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/index.tsx
@@ -12,6 +12,7 @@ import { BacklogSection } from 'src/components/shared/Entity/Details/Overview/De
 import ConnectorSection from 'src/components/shared/Entity/Details/Overview/DetailsSection/ConnectorSection';
 import { TIME_SETTINGS } from 'src/components/shared/Entity/Details/Overview/DetailsSection/shared';
 import StatusSection from 'src/components/shared/Entity/Details/Overview/DetailsSection/StatusSection';
+import { TimeLagSection } from 'src/components/shared/Entity/Details/Overview/DetailsSection/TimeLagSection';
 import KeyValueList from 'src/components/shared/KeyValueList';
 import { useEntityType } from 'src/context/EntityContext';
 import { useMaterializationBacklog } from 'src/hooks/details/useMaterializationBacklog';
@@ -39,11 +40,12 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
     // Passing an empty name leaves the queries unissued, so this costs nothing
     // for a task with no backlog rows to show. Where it does apply, the request
     // is shared with the rows themselves rather than repeated.
-    const { loading: backlogLoading } = useMaterializationBacklog(
-        // TODO: this is a bit of a hack. An empty string below prevents the hook from firing - necessary because
-        // DetailsSection is used for more than just materializations. Would be nice to split this out into more composable components.
-        showBacklog ? entityName : ''
-    );
+    const { loading: backlogLoading, timeLagLoading } =
+        useMaterializationBacklog(
+            // TODO: this is a bit of a hack. An empty string below prevents the hook from firing - necessary because
+            // DetailsSection is used for more than just materializations. Would be nice to split this out into more composable components.
+            showBacklog ? entityName : ''
+        );
 
     const data = useMemo(() => {
         const response = [];
@@ -51,7 +53,7 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
         // If there is nothing to show then display the loading status. The
         // backlog rows are covered here as well, so the card fills in once,
         // rather than settling and then filling those two in behind it.
-        if (!latestLiveSpec || backlogLoading) {
+        if (!latestLiveSpec || backlogLoading || timeLagLoading) {
             response.push(
                 {
                     title: <Skeleton width="33%" />,
@@ -91,6 +93,15 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
             response.push({
                 title: 'Data Backlog',
                 val: <BacklogSection entityName={entityName} />,
+            });
+
+            // Both rows are shown for any V2 materialization. When the lag cannot
+            // be computed — a source collection whose producer is not on V2 records
+            // no `lastPublishedAt` to compare against — the row renders an em-dash
+            // rather than dropping out.
+            response.push({
+                title: 'Time Behind',
+                val: <TimeLagSection entityName={entityName} />,
             });
         }
 
@@ -142,6 +153,7 @@ function DetailsSection({ entityName, latestLiveSpec }: DetailsSectionProps) {
         intl,
         latestLiveSpec,
         showBacklog,
+        timeLagLoading,
     ]);
 
     return (

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/types.ts
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/types.ts
@@ -17,3 +17,7 @@ export interface StatusSectionProps {
 export interface BacklogSectionProps {
     entityName: DetailsSectionProps['entityName'];
 }
+
+export interface TimeLagSectionProps {
+    entityName: DetailsSectionProps['entityName'];
+}

--- a/src/components/tables/cells/stats/shared.ts
+++ b/src/components/tables/cells/stats/shared.ts
@@ -3,10 +3,10 @@ import readable from 'readable-numbers';
 
 // TODO: Move formatBytes into the utils directory since it is widely used
 //   and replace applicable independent instances of prettyBytes.
-export const formatBytes = (val: any) =>
+export const formatBytes = (val: any, fractionDigits = 2) =>
     prettyBytes(val ?? 0, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits,
     });
 
 export const formatDocs = (val: any) => readable(val ?? 0, 2, false);

--- a/src/hooks/details/__tests__/shared.test.ts
+++ b/src/hooks/details/__tests__/shared.test.ts
@@ -1,14 +1,24 @@
-import type { CatalogStats_Backlog } from 'src/types';
+import type {
+    CatalogStats_Backlog,
+    CatalogStats_LastPublished,
+} from 'src/types';
 
 import { formatBytes } from 'src/components/tables/cells/stats/shared';
-import { parseMaterializationBacklog } from 'src/hooks/details/shared';
+import {
+    computeMaterializationTimeLag,
+    latestPublishedByCollection,
+    parseMaterializationBacklog,
+} from 'src/hooks/details/shared';
 
 // Builds one hourly stats row for a task. `catalog_stats.flow_document` holds a
 // materialization's per-binding stats under `taskStats.materialize`, keyed by
 // source collection name. See ops-catalog/stats.schema.yaml of estuary/flow.
 const statsRow = (
     ts: string,
-    materialize?: Record<string, { bytesBehind?: number | string }>
+    materialize?: Record<
+        string,
+        { bytesBehind?: number | string; lastSourcePublishedAt?: string }
+    >
 ): CatalogStats_Backlog => ({
     catalog_name: 'acmeCo/warehouse',
     grain: 'hourly',
@@ -119,6 +129,20 @@ describe('parseMaterializationBacklog', () => {
         expect(parseMaterializationBacklog([])).toBeNull();
     });
 
+    test('carries each binding source timestamp through for the time lag', () => {
+        const backlog = parseMaterializationBacklog([
+            statsRow('2026-08-07T19:00:00Z', {
+                'acmeCo/orders': {
+                    lastSourcePublishedAt: '2026-08-07T12:00:00Z',
+                },
+            }),
+        ]);
+
+        expect(backlog?.bindings[0].lastSourcePublishedAt).toBe(
+            '2026-08-07T12:00:00Z'
+        );
+    });
+
     // A real hourly row from hyphametrics/snowflake/materialize-snowflake, with
     // the per-binding `out` and `right` tallies dropped since nothing reads them.
     // Twelve bindings, of which three are behind. Note the `interval` heartbeat
@@ -191,7 +215,7 @@ describe('parseMaterializationBacklog', () => {
         test('renders the total the way the card does', () => {
             const backlog = parseMaterializationBacklog([row]);
 
-            expect(formatBytes(backlog?.bytesBehind)).toBe('1.13 MB');
+            expect(formatBytes(backlog?.bytesBehind, 0)).toBe('1 MB');
         });
 
         test('reports the stats document timestamp', () => {
@@ -199,5 +223,134 @@ describe('parseMaterializationBacklog', () => {
                 '2026-08-07T20:00:00.000Z'
             );
         });
+    });
+});
+
+describe('latestPublishedByCollection', () => {
+    const row = (
+        catalogName: string,
+        lastPublishedAt?: string
+    ): CatalogStats_LastPublished => ({
+        catalog_name: catalogName,
+        grain: 'monthly',
+        ts: '2026-08-01T00:00:00Z',
+        flow_document: lastPublishedAt
+            ? { statsSummary: { lastPublishedAt } }
+            : { statsSummary: {} },
+    });
+
+    test('keeps the latest timestamp per collection across rows', () => {
+        expect(
+            latestPublishedByCollection([
+                row('acmeCo/orders', '2026-07-31T23:00:00Z'),
+                row('acmeCo/orders', '2026-08-07T12:00:00Z'),
+                row('acmeCo/shipments', '2026-08-06T09:00:00Z'),
+            ])
+        ).toEqual({
+            'acmeCo/orders': '2026-08-07T12:00:00Z',
+            'acmeCo/shipments': '2026-08-06T09:00:00Z',
+        });
+    });
+
+    // A row written because a materialization read the collection records no
+    // publication of its own, so the newest row may carry no timestamp.
+    test('ignores rows with no lastPublishedAt', () => {
+        expect(
+            latestPublishedByCollection([
+                row('acmeCo/orders', '2026-08-07T12:00:00Z'),
+                row('acmeCo/orders'),
+            ])
+        ).toEqual({ 'acmeCo/orders': '2026-08-07T12:00:00Z' });
+    });
+});
+
+describe('computeMaterializationTimeLag', () => {
+    test('reports the gap for a binding that is behind', () => {
+        const lag = computeMaterializationTimeLag(
+            [
+                {
+                    collectionName: 'acmeCo/orders',
+                    lastSourcePublishedAt: '2026-08-07T12:00:00Z',
+                },
+            ],
+            { 'acmeCo/orders': '2026-08-07T12:05:00Z' }
+        );
+
+        expect(lag?.seconds).toBe(300);
+    });
+
+    test('takes the worst binding, not the sum', () => {
+        const lag = computeMaterializationTimeLag(
+            [
+                {
+                    collectionName: 'acmeCo/orders',
+                    lastSourcePublishedAt: '2026-08-07T12:00:00Z',
+                },
+                {
+                    collectionName: 'acmeCo/shipments',
+                    lastSourcePublishedAt: '2026-08-07T11:00:00Z',
+                },
+            ],
+            {
+                'acmeCo/orders': '2026-08-07T12:05:00Z',
+                'acmeCo/shipments': '2026-08-07T12:05:00Z',
+            }
+        );
+
+        expect(lag?.seconds).toBe(3900);
+        expect(lag?.bindings[0].collectionName).toBe('acmeCo/shipments');
+    });
+
+    // The two timestamps come from rows written by different tasks at different
+    // moments, so a binding can sit past its collection's recorded frontier.
+    test('clamps a binding that has read past the frontier to zero', () => {
+        const lag = computeMaterializationTimeLag(
+            [
+                {
+                    collectionName: 'acmeCo/orders',
+                    lastSourcePublishedAt: '2026-08-07T12:05:00Z',
+                },
+            ],
+            { 'acmeCo/orders': '2026-08-07T12:00:00Z' }
+        );
+
+        expect(lag?.seconds).toBe(0);
+    });
+
+    test('skips bindings missing either timestamp', () => {
+        expect(
+            computeMaterializationTimeLag(
+                [{ collectionName: 'acmeCo/orders' }],
+                {
+                    'acmeCo/orders': '2026-08-07T12:00:00Z',
+                }
+            )
+        ).toBeNull();
+
+        expect(
+            computeMaterializationTimeLag(
+                [
+                    {
+                        collectionName: 'acmeCo/orders',
+                        lastSourcePublishedAt: '2026-08-07T12:00:00Z',
+                    },
+                ],
+                {}
+            )
+        ).toBeNull();
+    });
+
+    test('ignores unparseable timestamps', () => {
+        expect(
+            computeMaterializationTimeLag(
+                [
+                    {
+                        collectionName: 'acmeCo/orders',
+                        lastSourcePublishedAt: 'not a timestamp',
+                    },
+                ],
+                { 'acmeCo/orders': '2026-08-07T12:00:00Z' }
+            )
+        ).toBeNull();
     });
 });

--- a/src/hooks/details/shared.ts
+++ b/src/hooks/details/shared.ts
@@ -1,10 +1,14 @@
-import type { CatalogStats_Backlog } from 'src/types';
+import type {
+    CatalogStats_Backlog,
+    CatalogStats_LastPublished,
+} from 'src/types';
 
 import { hasLength } from 'src/utils/misc-utils';
 
 interface BindingReading {
     collectionName: string;
     bytesBehind: number;
+    lastSourcePublishedAt?: string;
 }
 
 export interface MaterializationBacklog {
@@ -12,6 +16,16 @@ export interface MaterializationBacklog {
     bytesBehind: number;
     // The timestamp of the stats document the readings came from.
     ts: string;
+}
+
+interface BindingTimeLag {
+    collectionName: string;
+    seconds: number;
+}
+
+export interface MaterializationTimeLag {
+    bindings: BindingTimeLag[];
+    seconds: number;
 }
 
 // `bytesBehind` is a u64 in the stats protocol, and the default JSON encoding for
@@ -69,6 +83,7 @@ export const parseMaterializationBacklog = (
         .map(([collectionName, bindingStats]) => ({
             collectionName,
             bytesBehind: toByteCount(bindingStats?.bytesBehind),
+            lastSourcePublishedAt: bindingStats?.lastSourcePublishedAt,
         }))
         .sort((left, right) => right.bytesBehind - left.bytesBehind);
 
@@ -79,5 +94,76 @@ export const parseMaterializationBacklog = (
             0
         ),
         ts: latest.ts,
+    };
+};
+
+// The latest publication timestamp per collection across a set of stats rows.
+// `lastPublishedAt` reduces by maximizing within a row's grain, but a collection
+// spans several rows, and the newest row does not necessarily carry the field —
+// a row written because a materialization read the collection records no
+// publication of its own.
+export const latestPublishedByCollection = (
+    rows: CatalogStats_LastPublished[]
+): Record<string, string> =>
+    rows.reduce<Record<string, string>>((latest, row) => {
+        const lastPublishedAt =
+            row.flow_document?.statsSummary?.lastPublishedAt;
+
+        if (!lastPublishedAt) {
+            return latest;
+        }
+
+        const known = latest[row.catalog_name];
+
+        return !known || Date.parse(lastPublishedAt) > Date.parse(known)
+            ? { ...latest, [row.catalog_name]: lastPublishedAt }
+            : latest;
+    }, {});
+
+// How far behind a materialization is in source-publication time: the gap
+// between the newest document published to a source collection and the newest
+// one the binding has processed. A task is only as caught up as its worst
+// binding, so the task-level figure is the maximum rather than a sum.
+//
+// Returns null when no binding has both timestamps, which is the case for a
+// runtime that reports neither and for a collection nothing has published to.
+export const computeMaterializationTimeLag = (
+    bindings: Array<
+        Pick<BindingReading, 'collectionName' | 'lastSourcePublishedAt'>
+    >,
+    lastPublishedByCollection: Record<string, string>
+): MaterializationTimeLag | null => {
+    const lags = bindings.flatMap(
+        ({ collectionName, lastSourcePublishedAt }) => {
+            const lastPublishedAt = lastPublishedByCollection[collectionName];
+
+            if (!lastSourcePublishedAt || !lastPublishedAt) {
+                return [];
+            }
+
+            const seconds =
+                (Date.parse(lastPublishedAt) -
+                    Date.parse(lastSourcePublishedAt)) /
+                1000;
+
+            if (!Number.isFinite(seconds)) {
+                return [];
+            }
+
+            // A binding can sit at or past its collection's recorded frontier,
+            // since the two timestamps come from rows written by different tasks
+            // at different moments. Anything at or beyond it has read everything
+            // the collection currently holds.
+            return [{ collectionName, seconds: Math.max(seconds, 0) }];
+        }
+    );
+
+    if (!hasLength(lags)) {
+        return null;
+    }
+
+    return {
+        bindings: lags.sort((left, right) => right.seconds - left.seconds),
+        seconds: lags[0].seconds,
     };
 };

--- a/src/hooks/details/useMaterializationBacklog.ts
+++ b/src/hooks/details/useMaterializationBacklog.ts
@@ -1,11 +1,21 @@
-import type { MaterializationBacklog } from 'src/hooks/details/shared';
+import type {
+    MaterializationBacklog,
+    MaterializationTimeLag,
+} from 'src/hooks/details/shared';
 
 import { useMemo } from 'react';
 
 import { useQuery } from '@supabase-cache-helpers/postgrest-swr';
 
-import { getMaterializationBacklog } from 'src/api/stats';
-import { parseMaterializationBacklog } from 'src/hooks/details/shared';
+import {
+    getCollectionsLastPublished,
+    getMaterializationBacklog,
+} from 'src/api/stats';
+import {
+    computeMaterializationTimeLag,
+    latestPublishedByCollection,
+    parseMaterializationBacklog,
+} from 'src/hooks/details/shared';
 import { hasLength } from 'src/utils/misc-utils';
 
 const REFRESH_INTERVAL = 15000;
@@ -15,8 +25,10 @@ const SWR_CONFIG = {
     refreshInterval: REFRESH_INTERVAL,
 };
 
-// How far behind a materialization is, taken from its newest hourly stats row
-// that describes its bindings.
+// How far behind a materialization is, in bytes and in time. The bytes come from
+// the task's newest hourly stats row that describes its bindings; the time lag
+// additionally needs where each source collection has been published up to, so it
+// resolves in a second step once the bindings are known.
 export function useMaterializationBacklog(catalogName: string) {
     const { data, error, isValidating } = useQuery(
         hasLength(catalogName) ? getMaterializationBacklog(catalogName) : null,
@@ -28,9 +40,47 @@ export function useMaterializationBacklog(catalogName: string) {
         [data]
     );
 
-    // True only until the first response lands. A background refresh leaves this
+    const collectionNames = useMemo(
+        () =>
+            backlog?.bindings.map(({ collectionName }) => collectionName) ?? [],
+        [backlog]
+    );
+
+    const { data: collectionStats, error: collectionStatsError } = useQuery(
+        hasLength(collectionNames)
+            ? getCollectionsLastPublished(collectionNames)
+            : null,
+        SWR_CONFIG
+    );
+
+    const timeLag = useMemo<MaterializationTimeLag | null>(() => {
+        if (!backlog || !collectionStats) {
+            return null;
+        }
+
+        return computeMaterializationTimeLag(
+            backlog.bindings,
+            latestPublishedByCollection(collectionStats)
+        );
+    }, [backlog, collectionStats]);
+
+    // True only until the first response lands. A background refresh leaves these
     // false, so a value already on screen is never replaced by a loading state.
     const loading = isValidating && !data;
 
-    return { backlog, loading, error, isValidating };
+    // The lag needs the follow-up query as well, which cannot start until the
+    // bindings are known. A failure there has to end the wait too, or a caller
+    // holding a placeholder until this clears would hold it indefinitely.
+    const timeLagLoading =
+        loading ||
+        Boolean(backlog && !collectionStats && !collectionStatsError);
+
+    return {
+        backlog,
+        loading,
+        error,
+        isValidating,
+        timeLag,
+        timeLagLoading,
+    };
 }

--- a/src/services/__tests__/luxon.test.ts
+++ b/src/services/__tests__/luxon.test.ts
@@ -1,7 +1,7 @@
-import { DateTime } from 'luxon';
+import { DateTime, Duration } from 'luxon';
 
 import { DataGrains } from 'src/components/graphs/types';
-import { LUXON_GRAIN_SETTINGS } from 'src/services/luxon';
+import { LUXON_GRAIN_SETTINGS, toHumanDuration } from 'src/services/luxon';
 
 // The chart formatter calls DateTime.fromISO(ts) without { setZone: true }, so Luxon
 // converts the UTC timestamp to the local timezone by default.  Users in timezones
@@ -104,5 +104,39 @@ describe('LUXON_GRAIN_SETTINGS', () => {
             expect(relativeUnit).toBe('hours');
             expect(timeUnit).toBe('hour');
         });
+    });
+});
+
+describe('toHumanDuration', () => {
+    const lag = Duration.fromObject({
+        seconds: 1 * 86400 + 6 * 3600 + 27 * 60 + 28,
+    });
+
+    test('spells out every unit by default', () => {
+        expect(toHumanDuration(lag)).toBe(
+            '1 day, 6 hours, 27 minutes, 28 seconds'
+        );
+    });
+
+    test('keeps only the largest units when capped', () => {
+        expect(toHumanDuration(lag, { maxUnits: 2 })).toBe('1 day, 6 hours');
+    });
+
+    test('caps against the units that survive, not the raw shift', () => {
+        // No whole hours, so minutes are the second significant unit.
+        expect(
+            toHumanDuration(
+                Duration.fromObject({ seconds: 86400 + 27 * 60 + 28 }),
+                { maxUnits: 2 }
+            )
+        ).toBe('1 day, 27 minutes');
+    });
+
+    test('renders zero rather than an empty string', () => {
+        expect(
+            toHumanDuration(Duration.fromObject({ seconds: 0 }), {
+                maxUnits: 2,
+            })
+        ).toBe('0 seconds');
     });
 });

--- a/src/services/luxon.ts
+++ b/src/services/luxon.ts
@@ -66,31 +66,48 @@ export const LUXON_GRAIN_SETTINGS: {
     },
 };
 
+// Spells out a duration in whole units, leaving out the units that are zero.
+// Luxon's own `toHuman` keeps them, which turns a few seconds into
+// "0 days, 0 hours, 0 minutes, 3 seconds".
+//
+// `maxUnits` keeps only that many of the largest units still standing, so a long
+// span reads as "1 day, 6 hours" instead of trailing minutes and seconds that add
+// no information at that scale. Omit it to spell out every unit.
 // Based on https://github.com/moment/luxon/issues/1134#issuecomment-1668033880
-export const toAbsHumanDuration = (start: DateTime, end: DateTime): string => {
-    // Better Duration.toHuman support https://github.com/moment/luxon/issues/1134
-    const duration = end
-        .diff(start)
+export const toHumanDuration = (
+    duration: Duration,
+    { maxUnits }: { maxUnits?: number } = {}
+): string => {
+    const units = duration
         .shiftTo('days', 'hours', 'minutes', 'seconds')
         .toObject();
 
-    const prefix = start > end ? 'in ' : '';
-    const suffix = end > start ? ' ago' : '';
-
-    if ('seconds' in duration) {
-        duration.seconds = Math.round(duration.seconds!);
+    if ('seconds' in units) {
+        units.seconds = Math.round(units.seconds!);
     }
 
+    // `shiftTo` orders the units largest first, and dropping the zeroes preserves
+    // that order, so the leading entries are the significant ones.
+    const significant = Object.entries(units)
+        .filter(([_key, value]) => value !== 0)
+        .map(([key, value]) => [key, Math.abs(value)]);
+
     const cleanedDuration = Object.fromEntries(
-        Object.entries(duration)
-            .filter(([_key, value]) => value !== 0)
-            .map(([key, value]) => [key, Math.abs(value)])
+        maxUnits ? significant.slice(0, maxUnits) : significant
     ) as DurationObjectUnits;
 
     if (Object.keys(cleanedDuration).length === 0) {
         cleanedDuration.seconds = 0;
     }
 
-    const human = Duration.fromObject(cleanedDuration).toHuman();
-    return `${prefix}${human}${suffix}`;
+    return Duration.fromObject(cleanedDuration).toHuman();
+};
+
+// The signed variant: the gap between two moments, worded relative to now with
+// an "in "/" ago" affix.
+export const toAbsHumanDuration = (start: DateTime, end: DateTime): string => {
+    const prefix = start > end ? 'in ' : '';
+    const suffix = end > start ? ' ago' : '';
+
+    return `${prefix}${toHumanDuration(end.diff(start))}${suffix}`;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,8 +152,10 @@ export interface CatalogStats_Dashboard extends BaseCatalogStats {
 // The slice of `catalog_stats.flow_document` that describes a materialization's
 // bindings. The keys of `materialize` are source collection names.
 //
-// `bytesBehind` is how much of that collection the binding has yet to read.
-// Bindings with nothing left to read omit it rather than reporting zero.
+// `bytesBehind` is how much of that collection the binding has yet to read, and
+// `lastSourcePublishedAt` is the publication timestamp of the newest source
+// document it has processed. Bindings with nothing left to read omit
+// `bytesBehind` rather than reporting zero.
 export interface CatalogStats_Backlog extends BaseCatalogStats {
     flow_document: {
         taskStats?: {
@@ -162,6 +164,7 @@ export interface CatalogStats_Backlog extends BaseCatalogStats {
                     // A u64 in the stats protocol, so it may arrive as a number
                     // or as a string depending on the producer's JSON encoding.
                     bytesBehind?: number | string;
+                    lastSourcePublishedAt?: string;
                 };
             };
             // Metered uptime, which a task reports on its own schedule. It can be
@@ -171,6 +174,18 @@ export interface CatalogStats_Backlog extends BaseCatalogStats {
                 uptimeSeconds: number;
                 usageRate?: number;
             };
+        };
+    };
+}
+
+// A collection's own stats row, where `lastPublishedAt` is the publication
+// timestamp of the newest document written to it. It reduces by maximizing, so
+// the newest row that carries the field holds the latest publication within that
+// row's time grain.
+export interface CatalogStats_LastPublished extends BaseCatalogStats {
+    flow_document: {
+        statsSummary?: {
+            lastPublishedAt?: string;
         };
     };
 }


### PR DESCRIPTION
## Changes

Adds a **Time Behind** row to the materialization details card, beside Data Backlog: how far behind the task is in source-publication time — the gap between the newest document published to a source collection and the newest one the task has processed.

- Shown for V2-runtime materializations only. Renders `—` when the lag can't be computed (e.g. a source collection whose producing capture isn't on V2, so no `lastPublishedAt` is recorded).
- Task-level figure is the worst binding's lag, since a task is only as caught up as its furthest-behind binding.
- Durations render to two units ("1 day, 6 hours") via a reusable `toHumanDuration` luxon helper.


