### PR TITLE
Hide managed `collection-data` storage suffix

### DIFF
--- a/src/api/gql/storageMappings.ts
+++ b/src/api/gql/storageMappings.ts
@@ -8,6 +8,23 @@ import { useClient, useQuery } from 'urql';
 import { graphql } from 'src/gql-types';
 import { useTenantStore } from 'src/stores/Tenant';
 
+const COLLECTION_DATA_SUFFIX = 'collection-data/';
+
+function stripCollectionDataSuffix(
+    prefix: string | null | undefined
+): string | null | undefined {
+    if (
+        prefix !== COLLECTION_DATA_SUFFIX &&
+        !prefix?.endsWith(`/${COLLECTION_DATA_SUFFIX}`)
+    ) {
+        return prefix;
+    }
+
+    const base = prefix.slice(0, -COLLECTION_DATA_SUFFIX.length);
+
+    return base || null;
+}
+
 // Public types
 export interface FragmentStore {
     provider: CloudProvider;
@@ -322,7 +339,10 @@ export function useStorageMappings() {
             return {
                 catalogPrefix: edge.node.catalogPrefix,
                 spec: {
-                    fragmentStores: spec.stores.map(fromServerStore),
+                    fragmentStores: spec.stores.map((store) => ({
+                        ...fromServerStore(store),
+                        storagePrefix: stripCollectionDataSuffix(store.prefix),
+                    })),
                     dataPlanes: spec.data_planes ?? [],
                 },
             };


### PR DESCRIPTION
Storage mapping mutations automatically append `collection-data/` to the storage bucket prefix. The API used to strip that addition so the user would see the same value they entered into the UI, but that stripping behavior is moving to the UI in this PR. 

The API will return the full prefix so that other clients (`flowctl`) may use it.