### PR TITLE
Fix Permissions-Policy header rejected by browsers

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -75,7 +75,7 @@ http {
             add_header X-Frame-Options SAMEORIGIN always;
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy no-referrer-when-downgrade always;
-            add_header Permissions-Policy "geolocation=(), microphone=(), camera=() always";
+            add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 
             # Helps isolate the app
             add_header Cross-Origin-Embedder-Policy unsafe-none;


### PR DESCRIPTION
## Problem

The nginx `always` keyword was inside the quoted header value on the `Permissions-Policy` directive:

```nginx
add_header Permissions-Policy "geolocation=(), microphone=(), camera=() always";
```

Browsers therefore received the header value `geolocation=(), microphone=(), camera=() always` and rejected the entire header. The console reports:

> Parse of permissions policy failed because of errors reported by structured header parser

Confirmed on a deployed build on 2026-08-20. As a result the app ships no effective `Permissions-Policy` header in production (Cloud Run service `dashboard` in `estuary-control`).

## Fix

Move `always` outside the quotes so nginx treats it as a directive flag, not part of the header value. This matches the neighboring security headers (`Strict-Transport-Security`, `X-Frame-Options`, etc.).

```nginx
add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
```

One-line change in `public/nginx.conf`.