### PR TITLE
Show one decimal place in the materialization data backlog

### DIFF
--- a/src/components/shared/Entity/Details/Overview/DetailsSection/BacklogSection.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/BacklogSection.tsx
@@ -24,7 +24,7 @@ export function BacklogSection({ entityName }: BacklogSectionProps) {
 
     return (
         <Typography component="div">
-            {formatBytes(backlog.bytesBehind, 0)}
+            {formatBytes(backlog.bytesBehind, 1)}
         </Typography>
     );
 }

--- a/src/hooks/details/__tests__/shared.test.ts
+++ b/src/hooks/details/__tests__/shared.test.ts
@@ -215,7 +215,7 @@ describe('parseMaterializationBacklog', () => {
         test('renders the total the way the card does', () => {
             const backlog = parseMaterializationBacklog([row]);
 
-            expect(formatBytes(backlog?.bytesBehind, 0)).toBe('1 MB');
+            expect(formatBytes(backlog?.bytesBehind, 1)).toBe('1.1 MB');
         });
 
         test('reports the stats document timestamp', () => {


### PR DESCRIPTION
<img width="168" height="117" alt="Screenshot 2026-08-26 at 11 18 01 AM" src="https://github.com/user-attachments/assets/6c991354-f837-4b16-a211-8f78f18c939f" />
