### PR TITLE
Add a shared BandedDiv component

### DIFF
--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -38,6 +38,30 @@ export function desaturate(color: string, amount: number) {
     });
 }
 
+// MUI's color math (decomposeColor, getContrastText) rejects named CSS colors
+// like `tomato`. Assigning a color to a canvas fillStyle makes the browser
+// parse and normalize it to hex or rgba(), which MUI accepts. The context is
+// reset to black first, so an unparseable color degrades to a black band
+// rather than silently reusing the previous call's color.
+let canvasContext: CanvasRenderingContext2D | null | undefined;
+
+function toDecomposableColor(color: string): string {
+    if (color.startsWith('#') || color.includes('(')) {
+        return color;
+    }
+
+    canvasContext ??= document.createElement('canvas').getContext('2d');
+
+    if (!canvasContext) {
+        return color;
+    }
+
+    canvasContext.fillStyle = '#000000';
+    canvasContext.fillStyle = color;
+
+    return canvasContext.fillStyle as string;
+}
+
 // Rotates its child 90° as one unit. A CSS transform never affects layout —
 // a rotated label would keep its wide horizontal box and stretch the band —
 // so the child is measured and its dimensions swapped onto a spacer, with the
@@ -96,7 +120,8 @@ interface BandedDivProps {
     /** The edge carrying the band. */
     side?: BandSide;
     /**
-     * The band's full-strength color. With `onClick` set, the band rests
+     * The band's full-strength color, as any color the browser can parse —
+     * named CSS colors included. With `onClick` set, the band rests
      * desaturated and comes up to this color on hover.
      */
     bandColor: string;
@@ -142,6 +167,8 @@ export function BandedDiv({
     const verticalBand = side === 'left' || side === 'right';
     const bandFirst = side === 'top' || side === 'left';
 
+    const resolvedBandColor = toDecomposableColor(bandColor);
+
     const cornerRadius = (theme: Theme) => theme.radius[radius];
     const overlap = (theme: Theme) =>
         `calc(${theme.radius[radius]} + ${BAND_OVERLAP_GAP}px)`;
@@ -184,9 +211,10 @@ export function BandedDiv({
                 ...(verticalBand ? { px: 0.5, py: 1.5 } : { px: 1.5, py: 0.5 }),
                 ...tuckSx[side],
                 background: interactive
-                    ? desaturate(bandColor, BAND_REST_SATURATION)
-                    : bandColor,
-                color: (theme) => theme.palette.getContrastText(bandColor),
+                    ? desaturate(resolvedBandColor, BAND_REST_SATURATION)
+                    : resolvedBandColor,
+                color: (theme) =>
+                    theme.palette.getContrastText(resolvedBandColor),
                 transition: 'background-color 0.1s ease',
             }}
         >
@@ -202,7 +230,7 @@ export function BandedDiv({
         overflow: 'hidden',
         ...(interactive
             ? {
-                  [`&:hover .${BAND_CLASS}`]: { background: bandColor },
+                  [`&:hover .${BAND_CLASS}`]: { background: resolvedBandColor },
               }
             : {}),
     };

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -7,6 +7,8 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import { Box, ButtonBase } from '@mui/material';
 import { decomposeColor, recomposeColor } from '@mui/material/styles';
 
+import { defaultOutline } from 'src/context/Theme';
+
 export type BandSide = 'top' | 'bottom' | 'left' | 'right';
 
 /** On the face element, so an owner can restyle it from the frame's hover. */
@@ -198,7 +200,7 @@ export function BandedDiv({
                 // padded, outlined paper face rather than a see-through one.
                 p: 2,
                 background: (theme) => theme.palette.background.paper,
-                border: (theme) => `1px solid ${theme.palette.divider}`,
+                border: (theme) => defaultOutline[theme.palette.mode],
                 ...faceSx,
             }}
         >

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -37,11 +37,12 @@ export function desaturate(color: string, amount: number) {
 }
 
 interface BandedDivProps {
-    /** The edge carrying the band. Omit to render the frame and face alone. */
+    /** The edge carrying the band. */
     side?: BandSide;
     /**
      * The band's full-strength color. With `onClick` set, the band rests
-     * desaturated and comes up to this color on hover.
+     * desaturated and comes up to this color on hover. Omit to render the
+     * frame and face alone.
      */
     bandColor?: string;
     /**
@@ -72,7 +73,7 @@ interface BandedDivProps {
  * the band needs no radius of its own.
  */
 export function BandedDiv({
-    side,
+    side = 'left',
     bandColor,
     label,
     onClick,
@@ -116,7 +117,7 @@ export function BandedDiv({
     );
 
     const band =
-        side && bandColor ? (
+        bandColor !== undefined ? (
             <Stack
                 key="band"
                 className={BAND_CLASS}
@@ -147,7 +148,7 @@ export function BandedDiv({
         alignItems: 'stretch',
         borderRadius: cornerRadius,
         overflow: 'hidden',
-        ...(interactive && side && bandColor
+        ...(interactive && bandColor
             ? {
                   [`&:hover .${BAND_CLASS}`]: { background: bandColor },
               }

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -66,52 +66,65 @@ function toDecomposableColor(color: string): string {
     return canvasContext.fillStyle as string;
 }
 
-// Rotates its child 90° as one unit. A CSS transform never affects layout —
-// a rotated label would keep its wide horizontal box and stretch the band —
-// so the child is measured and its dimensions swapped onto a spacer, with the
-// rotated child centered absolutely inside it.
+// Rotates its child 270° as one unit and hands it the band's full run, so a
+// vertical band's label gets the same canvas an unrotated label gets on a
+// horizontal band. A CSS transform never affects layout, so the sizes are
+// measured: the child's natural height becomes the spacer's width (the band's
+// thickness), the spacer stretches along the band, and the spacer's measured
+// length becomes the rotated child's width.
 function RotatedLabel({ children }: { children: ReactNode }) {
+    const spacerRef = useRef<HTMLDivElement>(null);
     const labelRef = useRef<HTMLDivElement>(null);
-    const [size, setSize] = useState<{ width: number; height: number } | null>(
-        null
-    );
+
+    // The label's natural height, which is the band's thickness.
+    const [thickness, setThickness] = useState<number | null>(null);
+    // The stretched spacer's length, which the rotated label spans.
+    const [run, setRun] = useState<number | null>(null);
 
     useLayoutEffect(() => {
-        const el = labelRef.current;
+        const spacer = spacerRef.current;
+        const label = labelRef.current;
 
-        if (!el) {
+        if (!spacer || !label) {
             return undefined;
         }
 
-        const measure = () =>
-            setSize({ width: el.offsetWidth, height: el.offsetHeight });
+        const measure = () => {
+            setThickness(label.offsetHeight);
+            setRun(spacer.offsetHeight);
+        };
 
         measure();
 
         const observer = new ResizeObserver(measure);
-        observer.observe(el);
+        observer.observe(spacer);
+        observer.observe(label);
 
         return () => observer.disconnect();
     }, []);
 
     return (
         <Box
+            ref={spacerRef}
             sx={{
                 position: 'relative',
-                width: size?.height,
-                height: size?.width,
+                alignSelf: 'stretch',
+                width: thickness ?? undefined,
             }}
         >
             <Box
                 ref={labelRef}
                 sx={{
-                    position: 'absolute',
-                    top: '50%',
-                    left: '50%',
-                    // Sized to its content: an absolutely positioned box would
-                    // otherwise shrink to the narrow spacer and wrap.
-                    width: 'max-content',
-                    transform: 'translate(-50%, -50%) rotate(270deg)',
+                    'position': 'absolute',
+                    'top': '50%',
+                    'left': '50%',
+                    // Until the run is measured, size to content: an
+                    // absolutely positioned box would otherwise shrink to the
+                    // narrow spacer and wrap.
+                    'width': run ?? 'max-content',
+                    'display': 'flex',
+                    'transform': 'translate(-50%, -50%) rotate(270deg)',
+                    '& > *': { flex: 1, minWidth: 0 },
                 }}
             >
                 {children}
@@ -130,9 +143,10 @@ interface BandedDivProps {
      */
     bandColor: string;
     /**
-     * Rendered centered inside the band, and rotated 90° as a unit when the
-     * band is on the left or right. The node owns its internal layout — pass
-     * a row Stack for an icon-and-text label.
+     * Rendered into a slot spanning the band's visible run, stretched to fill
+     * it in either orientation, and rotated 270° as a unit when the band is
+     * on the left or right. The node owns its internal layout and alignment —
+     * e.g. a row Stack with centered content for an icon-and-text label.
      */
     label?: ReactNode;
     /** Makes the whole frame a button, and the band's color hover-driven. */
@@ -238,7 +252,21 @@ export function BandedDiv({
                 transition: 'background-color 0.1s ease',
             }}
         >
-            {verticalBand ? <RotatedLabel>{label}</RotatedLabel> : label}
+            {verticalBand ? (
+                <RotatedLabel>{label}</RotatedLabel>
+            ) : (
+                <Box
+                    sx={{
+                        'flex': 1,
+                        'alignSelf': 'stretch',
+                        'display': 'flex',
+                        'minWidth': 0,
+                        '& > *': { flex: 1, minWidth: 0 },
+                    }}
+                >
+                    {label}
+                </Box>
+            )}
         </Box>
     );
 

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -7,8 +7,6 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import { Box, ButtonBase } from '@mui/material';
 import { decomposeColor, recomposeColor } from '@mui/material/styles';
 
-import { defaultOutline } from 'src/context/Theme';
-
 export type BandSide = 'top' | 'bottom' | 'left' | 'right';
 
 /** On the face element, so an owner can restyle it from the frame's hover. */
@@ -22,6 +20,10 @@ export const BAND_REST_SATURATION = 0.5;
 // How much of the band's visible run stays clear of the face overlap, so its
 // label never slips under the face's edge.
 const BAND_OVERLAP_GAP = 4;
+
+// The least visible band run, in px past the overlap. A label-less band would
+// otherwise collapse to its padding and read as a sliver.
+const BAND_MIN_VISIBLE = 20;
 
 /**
  * Pulls a color toward its own luminance, which is what the CSS `saturate()`
@@ -175,6 +177,8 @@ export function BandedDiv({
     const cornerRadius = (theme: Theme) => theme.radius[radius];
     const overlap = (theme: Theme) =>
         `calc(${theme.radius[radius]} + ${BAND_OVERLAP_GAP}px)`;
+    const minThickness = (theme: Theme) =>
+        `calc(${theme.radius[radius]} + ${BAND_OVERLAP_GAP + BAND_MIN_VISIBLE}px)`;
 
     // The negative margin tucks the band under the face by one corner radius;
     // the matching padding keeps the label out past the overlap.
@@ -196,11 +200,16 @@ export function BandedDiv({
                 minWidth: 0,
                 borderRadius: cornerRadius,
                 // Hardcoded default surface for now: the face must be opaque
-                // for the band tuck to read, so a bare BandedDiv gets a
-                // padded, outlined paper face rather than a see-through one.
+                // for the band tuck to read, so a bare BandedDiv gets a padded
+                // paper face outlined in the band color — desaturated at rest
+                // alongside an interactive band, rising with it on hover.
                 p: 2,
                 background: (theme) => theme.palette.background.paper,
-                border: (theme) => defaultOutline[theme.palette.mode],
+                border: '1px solid',
+                borderColor: interactive
+                    ? desaturate(resolvedBandColor, BAND_REST_SATURATION)
+                    : resolvedBandColor,
+                transition: 'border-color 0.1s ease',
                 ...faceSx,
             }}
         >
@@ -217,7 +226,9 @@ export function BandedDiv({
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                ...(verticalBand ? { px: 0.5, py: 1.5 } : { px: 1.5, py: 0.5 }),
+                ...(verticalBand
+                    ? { px: 0.5, py: 1.5, minWidth: minThickness }
+                    : { px: 1.5, py: 0.5, minHeight: minThickness }),
                 ...tuckSx[side],
                 background: interactive
                     ? desaturate(resolvedBandColor, BAND_REST_SATURATION)
@@ -240,6 +251,9 @@ export function BandedDiv({
         ...(interactive
             ? {
                   [`&:hover .${BAND_CLASS}`]: { background: resolvedBandColor },
+                  [`&:hover .${BANDED_DIV_FACE_CLASS}`]: {
+                      borderColor: resolvedBandColor,
+                  },
               }
             : {}),
     };

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -162,12 +162,6 @@ interface BandedDivProps {
     /** Corner radius shared by the frame and the face. */
     radius?: 'sm' | 'md' | 'lg' | 'xl';
     /**
-     * Merged onto the band, over its defaults. Text styling set here (font
-     * size, weight) inherits into the label, which renders in caption type at
-     * weight 600 unless overridden.
-     */
-    bandSx?: SystemStyleObject<Theme>;
-    /**
      * Merged onto the face, over its default padded paper surface. Keep any
      * background override opaque: the band tucks behind the face, and anything
      * translucent lets the band ghost through.
@@ -192,7 +186,6 @@ export function BandedDiv({
     label,
     onClick,
     radius = 'lg',
-    bandSx,
     faceSx,
     sx,
     children,
@@ -287,12 +280,11 @@ export function BandedDiv({
                 color: (theme) =>
                     theme.palette.getContrastText(resolvedBandColor),
                 transition: 'background-color 0.1s ease',
-                // Band text defaults, inherited by the label so bandSx can
-                // override them.
+                // Band text defaults, inherited by the label. A label that
+                // wants different text styling brings its own element.
                 typography: 'caption',
                 fontWeight: 600,
                 whiteSpace: 'nowrap',
-                ...bandSx,
             }}
         >
             {verticalBand ? (

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -153,8 +153,8 @@ interface BandedDivProps {
      * it in either orientation, and rotated 270° as a unit when the band is
      * on the left or right. A single element owns its internal layout and
      * alignment; a fragment, string, or array is laid onto a default centered
-     * row — caption type, a small gap, no wrapping — so a bare
-     * icon-and-text label works without a wrapper.
+     * row — caption type with a small gap — so a bare icon-and-text label
+     * works without a wrapper. Long labels wrap, thickening the band.
      */
     label?: ReactNode;
     /** Makes the whole frame a button, and the band's color hover-driven. */
@@ -207,11 +207,15 @@ export function BandedDiv({
         ) : (
             <Box
                 sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: 0.75,
-                    minWidth: 0,
+                    'display': 'flex',
+                    'alignItems': 'center',
+                    'justifyContent': 'center',
+                    'gap': 0.75,
+                    'minWidth': 0,
+                    // A wrapping label squeezes the row, and an SVG's minimum
+                    // size resolves to zero, so an unpinned icon would shrink
+                    // away while the text wraps.
+                    '& > svg': { flex: 'none' },
                 }}
             >
                 {label}
@@ -284,7 +288,6 @@ export function BandedDiv({
                 // wants different text styling brings its own element.
                 typography: 'caption',
                 fontWeight: 600,
-                whiteSpace: 'nowrap',
             }}
         >
             {verticalBand ? (

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -194,10 +194,11 @@ export function BandedDiv({
                 minWidth: 0,
                 borderRadius: cornerRadius,
                 // Hardcoded default surface for now: the face must be opaque
-                // for the band tuck to read, so a bare BandedDiv gets a padded
-                // paper face rather than a see-through one.
+                // for the band tuck to read, so a bare BandedDiv gets a
+                // padded, outlined paper face rather than a see-through one.
                 p: 2,
                 background: (theme) => theme.palette.background.paper,
+                border: (theme) => `1px solid ${theme.palette.divider}`,
                 ...faceSx,
             }}
         >

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -1,0 +1,170 @@
+import type { SxProps, Theme } from '@mui/material';
+import type { SystemStyleObject } from '@mui/system/styleFunctionSx';
+import type { ReactNode } from 'react';
+
+import { Box, ButtonBase, Stack } from '@mui/material';
+import { decomposeColor, recomposeColor } from '@mui/material/styles';
+
+export type BandSide = 'top' | 'bottom' | 'left' | 'right';
+
+/** On the face element, so an owner can restyle it from the frame's hover. */
+export const BANDED_DIV_FACE_CLASS = 'banded-div-face';
+
+const BAND_CLASS = 'banded-div-band';
+
+/** How far an interactive band's rest color sits from its full color. */
+export const BAND_REST_SATURATION = 0.5;
+
+// How much of the band's visible run stays clear of the face overlap, so its
+// label never slips under the face's edge.
+const BAND_OVERLAP_GAP = 4;
+
+/**
+ * Pulls a color toward its own luminance, which is what the CSS `saturate()`
+ * filter computes, so a color mixed here matches one the browser filters.
+ * Exported for owners that hold other surfaces to the band's rest color.
+ */
+export function desaturate(color: string, amount: number) {
+    const [red, green, blue] = decomposeColor(color).values;
+    const luminance = 0.213 * red + 0.715 * green + 0.072 * blue;
+    const mix = (channel: number) =>
+        Math.round(luminance + (channel - luminance) * amount);
+
+    return recomposeColor({
+        type: 'rgb',
+        values: [mix(red), mix(green), mix(blue)],
+    });
+}
+
+interface BandedDivProps {
+    /** The edge carrying the band. Omit to render the frame and face alone. */
+    side?: BandSide;
+    /**
+     * The band's full-strength color. With `onClick` set, the band rests
+     * desaturated and comes up to this color on hover.
+     */
+    bandColor?: string;
+    /**
+     * Rendered inside the band, on a centered row. Reads vertically when the
+     * band is on the left or right: text glyphs rotate 90°, icons stay upright.
+     */
+    label?: ReactNode;
+    /** Makes the whole frame a button, and the band's color hover-driven. */
+    onClick?: () => void;
+    /** Corner radius shared by the frame and the face. */
+    radius?: 'sm' | 'md' | 'lg' | 'xl';
+    /**
+     * Merged onto the face. Give the face an opaque background: the band tucks
+     * behind it, and anything translucent lets the band ghost through.
+     */
+    faceSx?: SystemStyleObject<Theme>;
+    sx?: SxProps<Theme>;
+    children: ReactNode;
+}
+
+/**
+ * A rounded frame whose face sits over a colored band poking out one edge.
+ *
+ * The band is pulled under the face by one corner radius, so the face's
+ * rounded corners curve away onto band color rather than opening gaps to the
+ * page. The face paints above it (`zIndex: 1`, opaque), and the frame's
+ * `overflow: hidden` clips the band's outer corners to the frame radius, so
+ * the band needs no radius of its own.
+ */
+export function BandedDiv({
+    side,
+    bandColor,
+    label,
+    onClick,
+    radius = 'lg',
+    faceSx,
+    sx,
+    children,
+}: BandedDivProps) {
+    const interactive = Boolean(onClick);
+    const verticalBand = side === 'left' || side === 'right';
+    const bandFirst = side === 'top' || side === 'left';
+
+    const cornerRadius = (theme: Theme) => theme.radius[radius];
+    const overlap = (theme: Theme) =>
+        `calc(${theme.radius[radius]} + ${BAND_OVERLAP_GAP}px)`;
+
+    // The negative margin tucks the band under the face by one corner radius;
+    // the matching padding keeps the label out past the overlap.
+    const tuckSx: Record<BandSide, SystemStyleObject<Theme>> = {
+        top: { mb: (theme) => `-${cornerRadius(theme)}`, pb: overlap },
+        bottom: { mt: (theme) => `-${cornerRadius(theme)}`, pt: overlap },
+        left: { mr: (theme) => `-${cornerRadius(theme)}`, pr: overlap },
+        right: { ml: (theme) => `-${cornerRadius(theme)}`, pl: overlap },
+    };
+
+    const face = (
+        <Box
+            key="face"
+            className={BANDED_DIV_FACE_CLASS}
+            sx={{
+                position: 'relative',
+                zIndex: 1,
+                flex: 1,
+                minWidth: 0,
+                borderRadius: cornerRadius,
+                ...faceSx,
+            }}
+        >
+            {children}
+        </Box>
+    );
+
+    const band =
+        side && bandColor ? (
+            <Stack
+                key="band"
+                className={BAND_CLASS}
+                direction="row"
+                spacing={0.75}
+                sx={{
+                    flex: 'none',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    ...(verticalBand
+                        ? { px: 0.5, py: 1.5, writingMode: 'vertical-rl' }
+                        : { px: 1.5, py: 0.5 }),
+                    ...tuckSx[side],
+                    background: interactive
+                        ? desaturate(bandColor, BAND_REST_SATURATION)
+                        : bandColor,
+                    color: (theme) => theme.palette.getContrastText(bandColor),
+                    transition: 'background-color 0.1s ease',
+                }}
+            >
+                {label}
+            </Stack>
+        ) : null;
+
+    const frameSx: SystemStyleObject<Theme> = {
+        display: 'flex',
+        flexDirection: verticalBand ? 'row' : 'column',
+        alignItems: 'stretch',
+        borderRadius: cornerRadius,
+        overflow: 'hidden',
+        ...(interactive && side && bandColor
+            ? {
+                  [`&:hover .${BAND_CLASS}`]: { background: bandColor },
+              }
+            : {}),
+    };
+
+    const content = bandFirst ? [band, face] : [face, band];
+    const sxLayers = Array.isArray(sx) ? sx : [sx ?? {}];
+
+    return onClick ? (
+        <ButtonBase
+            onClick={onClick}
+            sx={[frameSx, { textAlign: 'left' }, ...sxLayers]}
+        >
+            {content}
+        </ButtonBase>
+    ) : (
+        <Box sx={[frameSx, ...sxLayers]}>{content}</Box>
+    );
+}

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -83,7 +83,7 @@ function RotatedLabel({ children }: { children: ReactNode }) {
                     // Sized to its content: an absolutely positioned box would
                     // otherwise shrink to the narrow spacer and wrap.
                     width: 'max-content',
-                    transform: 'translate(-50%, -50%) rotate(90deg)',
+                    transform: 'translate(-50%, -50%) rotate(270deg)',
                 }}
             >
                 {children}
@@ -97,10 +97,9 @@ interface BandedDivProps {
     side?: BandSide;
     /**
      * The band's full-strength color. With `onClick` set, the band rests
-     * desaturated and comes up to this color on hover. Omit to render the
-     * frame and face alone.
+     * desaturated and comes up to this color on hover.
      */
-    bandColor?: string;
+    bandColor: string;
     /**
      * Rendered centered inside the band, and rotated 90° as a unit when the
      * band is on the left or right. The node owns its internal layout — pass
@@ -173,30 +172,27 @@ export function BandedDiv({
         </Box>
     );
 
-    const band =
-        bandColor !== undefined ? (
-            <Box
-                key="band"
-                className={BAND_CLASS}
-                sx={{
-                    flex: 'none',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    ...(verticalBand
-                        ? { px: 0.5, py: 1.5 }
-                        : { px: 1.5, py: 0.5 }),
-                    ...tuckSx[side],
-                    background: interactive
-                        ? desaturate(bandColor, BAND_REST_SATURATION)
-                        : bandColor,
-                    color: (theme) => theme.palette.getContrastText(bandColor),
-                    transition: 'background-color 0.1s ease',
-                }}
-            >
-                {verticalBand ? <RotatedLabel>{label}</RotatedLabel> : label}
-            </Box>
-        ) : null;
+    const band = (
+        <Box
+            key="band"
+            className={BAND_CLASS}
+            sx={{
+                flex: 'none',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                ...(verticalBand ? { px: 0.5, py: 1.5 } : { px: 1.5, py: 0.5 }),
+                ...tuckSx[side],
+                background: interactive
+                    ? desaturate(bandColor, BAND_REST_SATURATION)
+                    : bandColor,
+                color: (theme) => theme.palette.getContrastText(bandColor),
+                transition: 'background-color 0.1s ease',
+            }}
+        >
+            {verticalBand ? <RotatedLabel>{label}</RotatedLabel> : label}
+        </Box>
+    );
 
     const frameSx: SystemStyleObject<Theme> = {
         display: 'flex',
@@ -204,7 +200,7 @@ export function BandedDiv({
         alignItems: 'stretch',
         borderRadius: cornerRadius,
         overflow: 'hidden',
-        ...(interactive && bandColor
+        ...(interactive
             ? {
                   [`&:hover .${BAND_CLASS}`]: { background: bandColor },
               }

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -136,8 +136,9 @@ interface BandedDivProps {
     /** Corner radius shared by the frame and the face. */
     radius?: 'sm' | 'md' | 'lg' | 'xl';
     /**
-     * Merged onto the face. Give the face an opaque background: the band tucks
-     * behind it, and anything translucent lets the band ghost through.
+     * Merged onto the face, over its default padded paper surface. Keep any
+     * background override opaque: the band tucks behind the face, and anything
+     * translucent lets the band ghost through.
      */
     faceSx?: SystemStyleObject<Theme>;
     sx?: SxProps<Theme>;
@@ -192,6 +193,11 @@ export function BandedDiv({
                 flex: 1,
                 minWidth: 0,
                 borderRadius: cornerRadius,
+                // Hardcoded default surface for now: the face must be opaque
+                // for the band tuck to read, so a bare BandedDiv gets a padded
+                // paper face rather than a see-through one.
+                p: 2,
+                background: (theme) => theme.palette.background.paper,
                 ...faceSx,
             }}
         >

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -2,7 +2,13 @@ import type { SxProps, Theme } from '@mui/material';
 import type { SystemStyleObject } from '@mui/system/styleFunctionSx';
 import type { ReactNode } from 'react';
 
-import { useLayoutEffect, useRef, useState } from 'react';
+import {
+    Fragment,
+    isValidElement,
+    useLayoutEffect,
+    useRef,
+    useState,
+} from 'react';
 
 import { Box, ButtonBase } from '@mui/material';
 import { decomposeColor, recomposeColor } from '@mui/material/styles';
@@ -145,8 +151,10 @@ interface BandedDivProps {
     /**
      * Rendered into a slot spanning the band's visible run, stretched to fill
      * it in either orientation, and rotated 270° as a unit when the band is
-     * on the left or right. The node owns its internal layout and alignment —
-     * e.g. a row Stack with centered content for an icon-and-text label.
+     * on the left or right. A single element owns its internal layout and
+     * alignment; a fragment, string, or array is laid onto a default centered
+     * row — caption type, a small gap, no wrapping — so a bare
+     * icon-and-text label works without a wrapper.
      */
     label?: ReactNode;
     /** Makes the whole frame a button, and the band's color hover-driven. */
@@ -187,6 +195,31 @@ export function BandedDiv({
     const bandFirst = side === 'top' || side === 'left';
 
     const resolvedBandColor = toDecomposableColor(bandColor);
+
+    // A single element owns the slot. Anything looser — a fragment, string,
+    // or array — gets the default treatment: a centered row with a sane gap
+    // between children.
+    const labelOwnsLayout = isValidElement(label) && label.type !== Fragment;
+
+    const labelContent =
+        labelOwnsLayout || label === null || label === undefined ? (
+            label
+        ) : (
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 0.75,
+                    minWidth: 0,
+                    typography: 'caption',
+                    fontWeight: 600,
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                {label}
+            </Box>
+        );
 
     const cornerRadius = (theme: Theme) => theme.radius[radius];
     const overlap = (theme: Theme) =>
@@ -253,7 +286,7 @@ export function BandedDiv({
             }}
         >
             {verticalBand ? (
-                <RotatedLabel>{label}</RotatedLabel>
+                <RotatedLabel>{labelContent}</RotatedLabel>
             ) : (
                 <Box
                     sx={{
@@ -264,7 +297,7 @@ export function BandedDiv({
                         '& > *': { flex: 1, minWidth: 0 },
                     }}
                 >
-                    {label}
+                    {labelContent}
                 </Box>
             )}
         </Box>

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -2,7 +2,9 @@ import type { SxProps, Theme } from '@mui/material';
 import type { SystemStyleObject } from '@mui/system/styleFunctionSx';
 import type { ReactNode } from 'react';
 
-import { Box, ButtonBase, Stack } from '@mui/material';
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import { Box, ButtonBase } from '@mui/material';
 import { decomposeColor, recomposeColor } from '@mui/material/styles';
 
 export type BandSide = 'top' | 'bottom' | 'left' | 'right';
@@ -36,6 +38,60 @@ export function desaturate(color: string, amount: number) {
     });
 }
 
+// Rotates its child 90° as one unit. A CSS transform never affects layout —
+// a rotated label would keep its wide horizontal box and stretch the band —
+// so the child is measured and its dimensions swapped onto a spacer, with the
+// rotated child centered absolutely inside it.
+function RotatedLabel({ children }: { children: ReactNode }) {
+    const labelRef = useRef<HTMLDivElement>(null);
+    const [size, setSize] = useState<{ width: number; height: number } | null>(
+        null
+    );
+
+    useLayoutEffect(() => {
+        const el = labelRef.current;
+
+        if (!el) {
+            return undefined;
+        }
+
+        const measure = () =>
+            setSize({ width: el.offsetWidth, height: el.offsetHeight });
+
+        measure();
+
+        const observer = new ResizeObserver(measure);
+        observer.observe(el);
+
+        return () => observer.disconnect();
+    }, []);
+
+    return (
+        <Box
+            sx={{
+                position: 'relative',
+                width: size?.height,
+                height: size?.width,
+            }}
+        >
+            <Box
+                ref={labelRef}
+                sx={{
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    // Sized to its content: an absolutely positioned box would
+                    // otherwise shrink to the narrow spacer and wrap.
+                    width: 'max-content',
+                    transform: 'translate(-50%, -50%) rotate(90deg)',
+                }}
+            >
+                {children}
+            </Box>
+        </Box>
+    );
+}
+
 interface BandedDivProps {
     /** The edge carrying the band. */
     side?: BandSide;
@@ -46,8 +102,9 @@ interface BandedDivProps {
      */
     bandColor?: string;
     /**
-     * Rendered inside the band, on a centered row. Reads vertically when the
-     * band is on the left or right: text glyphs rotate 90°, icons stay upright.
+     * Rendered centered inside the band, and rotated 90° as a unit when the
+     * band is on the left or right. The node owns its internal layout — pass
+     * a row Stack for an icon-and-text label.
      */
     label?: ReactNode;
     /** Makes the whole frame a button, and the band's color hover-driven. */
@@ -118,17 +175,16 @@ export function BandedDiv({
 
     const band =
         bandColor !== undefined ? (
-            <Stack
+            <Box
                 key="band"
                 className={BAND_CLASS}
-                direction="row"
-                spacing={0.75}
                 sx={{
                     flex: 'none',
+                    display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
                     ...(verticalBand
-                        ? { px: 0.5, py: 1.5, writingMode: 'vertical-rl' }
+                        ? { px: 0.5, py: 1.5 }
                         : { px: 1.5, py: 0.5 }),
                     ...tuckSx[side],
                     background: interactive
@@ -138,8 +194,8 @@ export function BandedDiv({
                     transition: 'background-color 0.1s ease',
                 }}
             >
-                {label}
-            </Stack>
+                {verticalBand ? <RotatedLabel>{label}</RotatedLabel> : label}
+            </Box>
         ) : null;
 
     const frameSx: SystemStyleObject<Theme> = {

--- a/src/components/shared/BandedDiv.tsx
+++ b/src/components/shared/BandedDiv.tsx
@@ -162,6 +162,12 @@ interface BandedDivProps {
     /** Corner radius shared by the frame and the face. */
     radius?: 'sm' | 'md' | 'lg' | 'xl';
     /**
+     * Merged onto the band, over its defaults. Text styling set here (font
+     * size, weight) inherits into the label, which renders in caption type at
+     * weight 600 unless overridden.
+     */
+    bandSx?: SystemStyleObject<Theme>;
+    /**
      * Merged onto the face, over its default padded paper surface. Keep any
      * background override opaque: the band tucks behind the face, and anything
      * translucent lets the band ghost through.
@@ -186,6 +192,7 @@ export function BandedDiv({
     label,
     onClick,
     radius = 'lg',
+    bandSx,
     faceSx,
     sx,
     children,
@@ -212,9 +219,6 @@ export function BandedDiv({
                     justifyContent: 'center',
                     gap: 0.75,
                     minWidth: 0,
-                    typography: 'caption',
-                    fontWeight: 600,
-                    whiteSpace: 'nowrap',
                 }}
             >
                 {label}
@@ -283,6 +287,12 @@ export function BandedDiv({
                 color: (theme) =>
                     theme.palette.getContrastText(resolvedBandColor),
                 transition: 'background-color 0.1s ease',
+                // Band text defaults, inherited by the label so bandSx can
+                // override them.
+                typography: 'caption',
+                fontWeight: 600,
+                whiteSpace: 'nowrap',
+                ...bandSx,
             }}
         >
             {verticalBand ? (

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -108,6 +108,35 @@ declare module '@mui/material/Typography' {
     }
 }
 
+// Border-radius scale. Roundness tracks an element's size and prominence:
+// larger, more container-like surfaces get more rounding, small controls get
+// less, and `full` fully rounds pills/toggles. Values are px strings so they
+// read literally in `sx`/`styled` `borderRadius` — a *number* there is
+// multiplied by `theme.shape.borderRadius`, a string is used as-is. When
+// nesting a rounded element in the corner of another, keep corners concentric:
+// inner radius = outer radius − padding.
+interface RadiusScale {
+    /** 4px — small insets: code strips, option panels, compact tiles */
+    sm: string;
+    /** 8px — monogram/icon tiles, settings panels */
+    md: string;
+    /** 12px — cards */
+    lg: string;
+    /** 16px — large or prominent surfaces (page containers, hero blocks) */
+    xl: string;
+    /** Fully rounded — pills, toggle buttons */
+    full: string;
+}
+
+declare module '@mui/material/styles' {
+    interface Theme {
+        radius: RadiusScale;
+    }
+    interface ThemeOptions {
+        radius?: RadiusScale;
+    }
+}
+
 // Colors
 const sample_blue = {
     100: '#DCE6FE',
@@ -1082,6 +1111,13 @@ const themeSettings = createTheme({
     },
     shape: {
         borderRadius: 2,
+    },
+    radius: {
+        sm: '4px',
+        md: '8px',
+        lg: '12px',
+        xl: '16px',
+        full: '9999px',
     },
     typography: {
         fontFamily: [


### PR DESCRIPTION
## Changes

Adds `theme.radius` and `src/components/shared/BandedDiv.tsx`. Nothing consumes either yet; the service accounts UI (#1989) is the first caller and stacks on top of this PR.

### `theme.radius`

A named border-radius scale on the augmented theme (`sm` 4px, `md` 8px, `lg` 12px, `xl` 16px, `full`), so roundness tracks an element's size and prominence and surfaces of the same class round the same way. Values are px strings, which `sx` and `styled` use literally — a *number* in `borderRadius` is multiplied by `theme.shape.borderRadius` instead.

### `BandedDiv`

A rounded frame whose face sits over a colored band poking out one edge.

- The band is pulled under the face by one corner radius, so the face's rounded corners curve away onto band color rather than opening gaps to the page. The face paints above it (`zIndex: 1`, opaque), and the frame's `overflow: hidden` clips the band's outer corners, so the band needs no radius of its own.
- `side` picks the banded edge and defaults to `left`. `bandColor` is required, and accepts any color the browser can parse — named CSS colors included, normalized through a canvas `fillStyle` because MUI's color math rejects them.
- `label` fills a slot spanning the band's visible run. A single element owns its own layout; a fragment, string, or array is laid onto a default centered row (caption type, small gap) so a bare icon-and-text label works without a wrapper. Long labels wrap and thicken the band.
- Vertical bands rotate the label 270° as one unit and hand it the band's full run. Since a CSS transform never affects layout, `RotatedLabel` measures with a `ResizeObserver`: the label's natural height becomes the band's thickness, and the stretched spacer's length becomes the rotated label's width.
- With `onClick` set, the frame becomes a `ButtonBase` and the band rests desaturated, coming up to full color on hover. `desaturate` and `BAND_REST_SATURATION` are exported so an owner can hold other surfaces to the same rest color, and `BANDED_DIV_FACE_CLASS` lets an owner restyle the face from the frame's hover.
- The face defaults to an opaque padded surface with a border tinted toward the band color. `faceSx` merges onto the face; `sx` targets the frame.

## Tests

### Manually tested

-   Rendered through the service account cards on #1989: bottom band on expiring keys, hover raising band and border together, band label wrapping at narrow card widths.

### Automated tests

-   None. Typecheck, ESLint, and Prettier pass.
