### PR TITLE
Rebuild AlertBox on BandedDiv

### DIFF
--- a/src/app/guards/GrantGuard/RedeemInviteLink.tsx
+++ b/src/app/guards/GrantGuard/RedeemInviteLink.tsx
@@ -67,7 +67,7 @@ export function RedeemInviteLink({ grantToken }: Props) {
                         })}
                     </Typography>
 
-                    <Error error={redeemError} condensed />
+                    <Error error={redeemError} />
 
                     <MessageWithLink messageID="tenant.grantDirective.error.message.help" />
                 </Stack>

--- a/src/app/guards/TenantGuard/SsoUserMessage.tsx
+++ b/src/app/guards/TenantGuard/SsoUserMessage.tsx
@@ -13,7 +13,6 @@ function SsoUserMessage() {
     return (
         <FullPageWrapper fullWidth>
             <AlertBox
-                short
                 severity="info"
                 title={intl.formatMessage({ id: 'tenant.usedSso.title' })}
             >

--- a/src/components/admin/Api/RefreshToken/CreateDialog.tsx
+++ b/src/components/admin/Api/RefreshToken/CreateDialog.tsx
@@ -133,7 +133,7 @@ export function CreateRefreshTokenDialog({ open, onClose, onCreated }: Props) {
             <DialogContent>
                 <Stack spacing={3} sx={{ mb: 1 }}>
                     {serverError ? (
-                        <Error severity="error" error={serverError} condensed />
+                        <Error severity="error" error={serverError} />
                     ) : null}
 
                     {token ? (

--- a/src/components/admin/Api/RefreshToken/CreateDialog.tsx
+++ b/src/components/admin/Api/RefreshToken/CreateDialog.tsx
@@ -137,7 +137,7 @@ export function CreateRefreshTokenDialog({ open, onClose, onCreated }: Props) {
                     ) : null}
 
                     {token ? (
-                        <AlertBox severity="info" short data-private>
+                        <AlertBox severity="info" data-private>
                             <Typography sx={{ mb: 1 }}>
                                 <FormattedMessage id="admin.cli_api.refreshToken.dialog.alert.copyToken" />
                             </Typography>

--- a/src/components/admin/Api/RefreshToken/RevokeDialog.tsx
+++ b/src/components/admin/Api/RefreshToken/RevokeDialog.tsx
@@ -64,9 +64,7 @@ export function RevokeDialog({ open, onClose, id, detail }: Props) {
             </DialogTitle>
             <DialogContent>
                 <Stack spacing={1}>
-                    {error ? (
-                        <Error condensed error={error} severity="error" />
-                    ) : null}
+                    {error ? <Error error={error} severity="error" /> : null}
                     <Typography>
                         {detail ? (
                             <FormattedMessage

--- a/src/components/admin/Billing/CapturePaymentMethod.tsx
+++ b/src/components/admin/Billing/CapturePaymentMethod.tsx
@@ -136,9 +136,7 @@ export const PaymentForm = ({ onSuccess, onError }: PaymentFormProps) => {
         <>
             <DialogContent sx={{ overflowY: 'scroll' }}>
                 {loadingError ? (
-                    <AlertBox short severity="error">
-                        {loadingError}
-                    </AlertBox>
+                    <AlertBox severity="error">{loadingError}</AlertBox>
                 ) : null}
                 <AddressElement
                     options={{

--- a/src/components/admin/Billing/LoadError.tsx
+++ b/src/components/admin/Billing/LoadError.tsx
@@ -17,7 +17,6 @@ function BillingLoadError() {
     return (
         <Grid size={{ xs: 12 }}>
             <AlertBox
-                short
                 severity="warning"
                 title={
                     <FormattedMessage id="admin.billing.error.details.header" />

--- a/src/components/admin/Billing/PaymentMethods.tsx
+++ b/src/components/admin/Billing/PaymentMethods.tsx
@@ -155,7 +155,7 @@ const PaymentMethods = ({ showAddPayment }: AdminBillingProps) => {
     return (
         <Stack spacing={serverErrored ? 0 : 3}>
             {setupIntentSecret === INTENT_SECRET_ERROR ? (
-                <AlertBox short severity="error">
+                <AlertBox severity="error">
                     <Typography component="div">
                         <FormattedMessage id="admin.billing.paymentMethods.cta.addPaymentMethod.error" />
                     </Typography>
@@ -198,7 +198,7 @@ const PaymentMethods = ({ showAddPayment }: AdminBillingProps) => {
             </Stack>
 
             {serverErrored ? (
-                <AlertBox short severity="error">
+                <AlertBox severity="error">
                     <Typography component="div">
                         <FormattedMessage id="admin.billing.error.paymentMethodsError" />
                     </Typography>

--- a/src/components/admin/Billing/index.tsx
+++ b/src/components/admin/Billing/index.tsx
@@ -233,7 +233,7 @@ function AdminBilling({ showAddPayment }: AdminBillingProps) {
                                         id: 'admin.billing.paymentMethods.header',
                                     })}
                                 </Typography>
-                                <AlertBox short severity="error">
+                                <AlertBox severity="error">
                                     <Typography component="div">
                                         {intl.formatMessage({
                                             id: 'admin.billing.error.paymentMethodsError',

--- a/src/components/admin/Settings/PrefixAlerts/Dialog/ServerErrors.tsx
+++ b/src/components/admin/Settings/PrefixAlerts/Dialog/ServerErrors.tsx
@@ -22,7 +22,6 @@ export default function ServerErrors() {
             {serverErrors.map((error, index) =>
                 error ? (
                     <Error
-                        condensed
                         error={error}
                         key={`prefix-alert-save-error-${index}`}
                         severity="error"

--- a/src/components/admin/Settings/StorageMappings/Dialog/Create/index.tsx
+++ b/src/components/admin/Settings/StorageMappings/Dialog/Create/index.tsx
@@ -101,7 +101,7 @@ function CreateMappingWizardInner({
                               id: 'storageMappings.wizard.title.configure',
                           }),
                           component: (
-                              <AlertBox short severity="error">
+                              <AlertBox severity="error">
                                   {intl.formatMessage({
                                       id: 'storageMappings.dialog.error.loadFailed',
                                   })}

--- a/src/components/admin/Settings/StorageMappings/Dialog/Update/index.tsx
+++ b/src/components/admin/Settings/StorageMappings/Dialog/Update/index.tsx
@@ -360,7 +360,7 @@ export function UpdateMappingWizard() {
                     id: 'storageMappings.dialog.update.title',
                 }),
                 component: (
-                    <AlertBox short severity="error">
+                    <AlertBox severity="error">
                         {intl.formatMessage({
                             id: 'storageMappings.dialog.error.loadFailed',
                         })}

--- a/src/components/collection/DataPreview/HydrationError.tsx
+++ b/src/components/collection/DataPreview/HydrationError.tsx
@@ -27,7 +27,7 @@ function HydrationError({ readError }: HydrationErrorProps) {
         );
     }
 
-    return <Error error={readError} condensed />;
+    return <Error error={readError} />;
 }
 
 export default HydrationError;

--- a/src/components/collection/DataPreview/HydrationError.tsx
+++ b/src/components/collection/DataPreview/HydrationError.tsx
@@ -14,7 +14,6 @@ function HydrationError({ readError }: HydrationErrorProps) {
         return (
             <AlertBox
                 severity="info"
-                short
                 title={intl.formatMessage({
                     id: 'detailsPanel.dataPreview.suspended.title',
                 })}

--- a/src/components/collection/DataPreview/index.tsx
+++ b/src/components/collection/DataPreview/index.tsx
@@ -156,7 +156,7 @@ export function DataPreview({ collectionName }: Props) {
                 ) : null}
 
                 {tenantHidesError || hide ? (
-                    <AlertBox short severity="info">
+                    <AlertBox severity="info">
                         {intl.formatMessage({
                             id: 'detailsPanel.dataPreview.hidden',
                         })}

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -365,7 +365,7 @@ function CollectionSelectorList({
                 open={displayNotification}
                 placement="top"
             >
-                <AlertBox hideIcon short severity="success" title={null}>
+                <AlertBox hideIcon severity="success" title={null}>
                     {notificationMessage}
                 </AlertBox>
             </Popper>

--- a/src/components/collection/Selector/List/index.tsx
+++ b/src/components/collection/Selector/List/index.tsx
@@ -365,7 +365,7 @@ function CollectionSelectorList({
                 open={displayNotification}
                 placement="top"
             >
-                <AlertBox hideIcon severity="success" title={null}>
+                <AlertBox severity="success" title={null}>
                     {notificationMessage}
                 </AlertBox>
             </Popper>

--- a/src/components/collection/schema/Editor/DisabledWarning.tsx
+++ b/src/components/collection/schema/Editor/DisabledWarning.tsx
@@ -18,7 +18,6 @@ function DisabledWarning() {
     return (
         <AlertBox
             sx={{ maxWidth: 'fit-content' }}
-            short
             severity="warning"
             title={intl.formatMessage({
                 id: 'schemaEditor.editing.disabled.title',

--- a/src/components/collection/schema/Editor/SkimProjectionErrors.tsx
+++ b/src/components/collection/schema/Editor/SkimProjectionErrors.tsx
@@ -57,7 +57,6 @@ function SkimProjectionErrors() {
         >
             <Collapse component={Grid} in={show}>
                 <AlertBox
-                    short
                     severity="error"
                     title={intl.formatMessage({
                         id: 'schemaEditor.error.title',

--- a/src/components/editor/Bindings/Backfill/BackfillDescription.tsx
+++ b/src/components/editor/Bindings/Backfill/BackfillDescription.tsx
@@ -24,7 +24,7 @@ export default function BackfillDescription({ allBindings }: Props) {
             </Typography>
 
             {allBindings && entityType === 'materialization' ? (
-                <AlertBox severity="warning" short>
+                <AlertBox severity="warning">
                     {intl.formatMessage({
                         id: `workflows.collectionSelector.manualBackfill.message.materialization${suffix}.warning`,
                     })}

--- a/src/components/editor/Bindings/Backfill/BackfillNotSupportedAlert.tsx
+++ b/src/components/editor/Bindings/Backfill/BackfillNotSupportedAlert.tsx
@@ -14,7 +14,6 @@ function BackfillNotSupportedAlert() {
         <Box sx={{ mt: 3, maxWidth: 'fit-content' }}>
             <AlertBox
                 severity="info"
-                short
                 title={intl.formatMessage(
                     {
                         id: 'workflows.collectionSelector.manualBackfill.notSupported.title',

--- a/src/components/editor/Bindings/Backfill/EvolvedAlert.tsx
+++ b/src/components/editor/Bindings/Backfill/EvolvedAlert.tsx
@@ -9,7 +9,7 @@ function EvolvedAlert() {
     const intl = useIntl();
 
     return (
-        <AlertBox short severity="success">
+        <AlertBox severity="success">
             {intl.formatMessage(
                 { id: 'workflows.collectionSelector.evolvedCollections.alert' },
                 {

--- a/src/components/editor/Bindings/Backfill/PreSaveConfirmation.tsx
+++ b/src/components/editor/Bindings/Backfill/PreSaveConfirmation.tsx
@@ -18,7 +18,6 @@ export function PreSaveConfirmation() {
     return (
         <Stack spacing={1}>
             <AlertBox
-                short
                 severity="warning"
                 title={intl.formatMessage({
                     id: 'workflows.dataFlowBackfill.preSaveConfirmation.title',

--- a/src/components/editor/Bindings/Editor.tsx
+++ b/src/components/editor/Bindings/Editor.tsx
@@ -105,14 +105,13 @@ function BindingsEditor({ itemType, readOnly = false }: Props) {
                     ) : collectionData || collectionData === null ? (
                         <Stack spacing={2}>
                             {schemaUpdateErrored ? (
-                                <AlertBox severity="warning" short>
+                                <AlertBox severity="warning">
                                     <FormattedMessage id="workflows.collectionSelector.schemaEdit.alert.message.schemaUpdateError" />
                                 </AlertBox>
                             ) : null}
 
                             {collectionInitializationAlert ? (
                                 <AlertBox
-                                    short
                                     severity={
                                         collectionInitializationAlert.severity
                                     }
@@ -182,7 +181,6 @@ function BindingsEditor({ itemType, readOnly = false }: Props) {
                     ) : (
                         <AlertBox
                             severity="warning"
-                            short
                             title={
                                 <FormattedMessage id="workflows.collectionSelector.error.title.missingCollectionSchema" />
                             }

--- a/src/components/editor/Bindings/SelectorEmpty.tsx
+++ b/src/components/editor/Bindings/SelectorEmpty.tsx
@@ -17,7 +17,6 @@ function SelectorEmpty() {
         <Box sx={{ pt: 1, px: 1 }}>
             <AlertBox
                 severity="warning"
-                short
                 title={intl.formatMessage({
                     id: ENTITY_SETTINGS[entityType].workFlows
                         .bindingsEmptyTitleIntlKey,

--- a/src/components/editor/Shards/Disable/Warning.tsx
+++ b/src/components/editor/Shards/Disable/Warning.tsx
@@ -26,7 +26,6 @@ function ShardsDisableWarning() {
                 }}
             >
                 <AlertBox
-                    short
                     severity="warning"
                     title={
                         <FormattedMessage

--- a/src/components/fieldSelection/Error.tsx
+++ b/src/components/fieldSelection/Error.tsx
@@ -22,7 +22,7 @@ const FieldValidationError = ({ bindingUUID }: BindingUUIDProp) => {
     }
 
     return (
-        <AlertBox severity="error" short>
+        <AlertBox severity="error">
             <Typography>
                 {intl.formatMessage({
                     id: 'fieldSelection.error.validationFailed',

--- a/src/components/fieldSelection/FieldActions/GroupByKeys/KeyChangeAlert.tsx
+++ b/src/components/fieldSelection/FieldActions/GroupByKeys/KeyChangeAlert.tsx
@@ -17,7 +17,7 @@ const KeyChangeAlert = ({ bindingUUID }: BindingUUIDProp) => {
     }
 
     return (
-        <AlertBox severity="warning" short>
+        <AlertBox severity="warning">
             <Typography>
                 {intl.formatMessage({
                     id: 'fieldSelection.groupBy.alert.backfillRequired',

--- a/src/components/fieldSelection/RefreshStatus.tsx
+++ b/src/components/fieldSelection/RefreshStatus.tsx
@@ -15,7 +15,7 @@ function RefreshStatus({ show }: RefreshStatusProps) {
 
     return (
         <Collapse in={Boolean(!draftId || show)} unmountOnExit>
-            <AlertBox short severity="info">
+            <AlertBox severity="info">
                 {intl.formatMessage({ id: 'fieldSelection.refresh.alert' })}
             </AlertBox>
         </Collapse>

--- a/src/components/fullPage/Error.tsx
+++ b/src/components/fullPage/Error.tsx
@@ -83,7 +83,7 @@ function FullPageError({
                 </Stack>
 
                 <Divider />
-                <Error error={error} condensed />
+                <Error error={error} />
             </Stack>
         </FullPageWrapper>
     );

--- a/src/components/home/dashboard/AlertingOverview/index.tsx
+++ b/src/components/home/dashboard/AlertingOverview/index.tsx
@@ -81,7 +81,7 @@ export default function AlertingOverview({
                 })}
             >
                 {error ? (
-                    <AlertBox short severity="error">
+                    <AlertBox severity="error">
                         {intl.formatMessage({
                             id: 'alert.active.fetchError.title',
                         })}

--- a/src/components/home/hero/AcceptDemoInvitation.tsx
+++ b/src/components/home/hero/AcceptDemoInvitation.tsx
@@ -97,11 +97,7 @@ function AcceptDemoInvitation({
         <Stack>
             {serverError ? (
                 <Box sx={{ mb: 3 }}>
-                    <Error
-                        error={serverError}
-                        condensed={true}
-                        hideTitle={true}
-                    />
+                    <Error error={serverError} hideTitle={true} />
                 </Box>
             ) : null}
 

--- a/src/components/inputs/PrefixedName/index.tsx
+++ b/src/components/inputs/PrefixedName/index.tsx
@@ -151,7 +151,7 @@ function PrefixedName({
     // Let the user know they cannot enter a name due to not having access
     if (!hasLength(objectRoles)) {
         return (
-            <AlertBox short severity="warning">
+            <AlertBox severity="warning">
                 {intl.formatMessage({
                     id: 'custom.prefixedName.noAccessGrants',
                 })}

--- a/src/components/journals/Alerts.tsx
+++ b/src/components/journals/Alerts.tsx
@@ -40,7 +40,6 @@ function JournalAlerts({
             <Box sx={{ mb: 3 }}>
                 <AlertBox
                     severity="warning"
-                    short
                     title={<FormattedMessage id={title} />}
                 >
                     {typeof message === 'string' ? (

--- a/src/components/login/MagicLinkInputs.tsx
+++ b/src/components/login/MagicLinkInputs.tsx
@@ -88,7 +88,7 @@ const MagicLinkInputs = ({ onSubmit, showToken }: Props) => {
                         mb: 5,
                     }}
                 >
-                    <AlertBox severity="error" short>
+                    <AlertBox severity="error">
                         <Typography>{submitError.message}</Typography>
                     </AlertBox>
                 </Box>

--- a/src/components/login/Notifications.tsx
+++ b/src/components/login/Notifications.tsx
@@ -20,7 +20,7 @@ function LoginNotifications({ notificationMessage, notificationTitle }: Props) {
                 }}
                 autoHideDuration={10000}
             >
-                <AlertBox severity="error" short title={notificationTitle}>
+                <AlertBox severity="error" title={notificationTitle}>
                     {notificationMessage}
                 </AlertBox>
             </Snackbar>

--- a/src/components/login/SSO/index.tsx
+++ b/src/components/login/SSO/index.tsx
@@ -56,7 +56,7 @@ export const SSOForm = ({ grantToken }: DefaultLoginProps) => {
             </Typography>
             {submitError ? (
                 <Box>
-                    <AlertBox severity="error" short>
+                    <AlertBox severity="error">
                         <Typography>{submitError}</Typography>
                         <Typography>
                             {intl.formatMessage({ id: 'error.tryAgain' })}

--- a/src/components/logs/StoppedAlert.tsx
+++ b/src/components/logs/StoppedAlert.tsx
@@ -14,7 +14,7 @@ function StoppedAlert() {
 
     return (
         <Collapse in={showAlert}>
-            <AlertBox severity="info" short>
+            <AlertBox severity="info">
                 <FormattedMessage
                     id={
                         networkFailure

--- a/src/components/materialization/TrialOnlyPrefixAlert.tsx
+++ b/src/components/materialization/TrialOnlyPrefixAlert.tsx
@@ -18,7 +18,7 @@ function TrialOnlyPrefixAlert({
     }
 
     return (
-        <AlertBox severity="warning" short>
+        <AlertBox severity="warning">
             <Typography>{message}</Typography>
         </AlertBox>
     );

--- a/src/components/materialization/targetNaming/Dialog.tsx
+++ b/src/components/materialization/targetNaming/Dialog.tsx
@@ -66,9 +66,7 @@ function TargetNamingDialog({
             <DialogContent>
                 <Stack spacing={2}>
                     {alertMessage ? (
-                        <AlertBox severity="info" short>
-                            {alertMessage}
-                        </AlertBox>
+                        <AlertBox severity="info">{alertMessage}</AlertBox>
                     ) : null}
                     <TargetNamingFormContent
                         initialStrategy={initialStrategy}

--- a/src/components/projections/Edit/Dialog.tsx
+++ b/src/components/projections/Edit/Dialog.tsx
@@ -63,7 +63,7 @@ function EditProjectionDialog({
             <DialogContent>
                 {serverError ? (
                     <Box style={{ marginBottom: 16 }}>
-                        <Error condensed error={serverError} severity="error" />
+                        <Error error={serverError} severity="error" />
                     </Box>
                 ) : null}
 

--- a/src/components/projections/Redact/Dialog.tsx
+++ b/src/components/projections/Redact/Dialog.tsx
@@ -59,7 +59,7 @@ const RedactFieldDialog = ({
             <DialogContent>
                 {error ? (
                     <Box style={{ marginBottom: 16, width: 500 }}>
-                        <Error condensed error={error} severity="error" />
+                        <Error error={error} severity="error" />
                     </Box>
                 ) : null}
 

--- a/src/components/schema/KeyAutoComplete/ReadOnly.tsx
+++ b/src/components/schema/KeyAutoComplete/ReadOnly.tsx
@@ -52,7 +52,6 @@ function ReadOnly({ value }: Props) {
 
             {valueEmpty ? (
                 <AlertBox
-                    short
                     severity="warning"
                     title={
                         <FormattedMessage id="keyAutoComplete.keys.missing.title" />
@@ -108,11 +107,11 @@ function ReadOnly({ value }: Props) {
             )}
 
             {skimProjectionResponseEmpty ? (
-                <AlertBox short severity="warning">
+                <AlertBox severity="warning">
                     <FormattedMessage id="keyAutoComplete.noOptions.message" />
                 </AlertBox>
             ) : noUsableKeys ? (
-                <AlertBox short severity="warning">
+                <AlertBox severity="warning">
                     <FormattedMessage id="keyAutoComplete.noUsableKeys.message" />
                 </AlertBox>
             ) : null}

--- a/src/components/schema/PropertiesViewer.tsx
+++ b/src/components/schema/PropertiesViewer.tsx
@@ -89,7 +89,6 @@ function PropertiesViewer({ disabled, editorProps }: Props) {
                 }}
             >
                 <AlertBox
-                    short
                     severity="error"
                     title={intl.formatMessage({
                         id: 'schemaEditor.error.title',

--- a/src/components/shared/AlertBox.tsx
+++ b/src/components/shared/AlertBox.tsx
@@ -43,10 +43,6 @@ export interface AlertBoxProps {
     onClose?: () => void;
     sx?: SxProps<Theme>;
     title?: ReactNode;
-    /** @deprecated Ignored. AlertBox has a single presentation. */
-    short?: boolean;
-    /** @deprecated Ignored. Pass the header copy as `title`. */
-    headerMessage?: string | ReactNode;
 }
 
 /**

--- a/src/components/shared/AlertBox.tsx
+++ b/src/components/shared/AlertBox.tsx
@@ -1,150 +1,113 @@
-import type { AlertBoxProps } from 'src/components/shared/types';
+import type { AlertColor, SxProps, Theme } from '@mui/material';
+import type { ReactNode } from 'react';
 
-import { forwardRef, useMemo } from 'react';
+import { forwardRef } from 'react';
 
-import {
-    Alert,
-    alertClasses,
-    AlertTitle,
-    Typography,
-    useTheme,
-} from '@mui/material';
+import { AlertTitle, Box, IconButton, useTheme } from '@mui/material';
 
 import {
     CheckCircle,
     InfoCircle,
     WarningHexagon,
     WarningTriangle,
+    Xmark,
 } from 'iconoir-react';
-import { useIntl } from 'react-intl';
 
-import { alertBackground, alertTextPrimary } from 'src/context/Theme';
+import { BandedDiv } from 'src/components/shared/BandedDiv';
+import { paperBackground } from 'src/context/Theme';
 
-const SHARED_STYLING = {
-    borderRadius: 2,
-    borderTopRightRadius: 0,
-    borderBottomRightRadius: 0,
+// Alert copy, softened off pure black in light mode so the severity band stays
+// the loudest thing in the box.
+const ALERT_TEXT = {
+    light: 'rgba(0, 0, 0, 0.8)',
+    dark: 'rgb(255, 255, 255)',
 };
 
-const HEADER_MESSAGE = {
-    warning: 'alert.warning',
-    success: 'alert.success',
-    info: 'alert.info',
-    error: 'alert.error',
+const SEVERITY_ICON = {
+    error: WarningHexagon,
+    warning: WarningTriangle,
+    info: InfoCircle,
+    success: CheckCircle,
 };
 
-const AlertBox = forwardRef<any, AlertBoxProps>(function NavLinkRef(
-    { short, severity, headerMessage, hideIcon, title, children, onClose, sx },
-    ref
-) {
-    const intl = useIntl();
-    const theme = useTheme();
+// Iconoir icons render at 1.5em, so an explicit width/height is the only way
+// to get the px size asked for.
+const ICON_SIZE = 20;
 
-    const iconComponentStyling = useMemo(
-        () =>
-            !short
-                ? {
-                      color: alertTextPrimary[theme.palette.mode],
-                      fontSize: '1em',
-                      marginLeft: 'auto',
-                      marginRight: 'auto',
-                  }
-                : undefined,
-        [short, theme.palette.mode]
-    );
+export interface AlertBoxProps {
+    severity: AlertColor;
+    children?: ReactNode;
+    /** Leaves the severity band bare, with no icon in it. */
+    hideIcon?: boolean;
+    /** Adds a close button to the end of the alert's first row. */
+    onClose?: () => void;
+    sx?: SxProps<Theme>;
+    title?: ReactNode;
+    /** @deprecated Ignored. AlertBox has a single presentation. */
+    short?: boolean;
+    /** @deprecated Ignored. Pass the header copy as `title`. */
+    headerMessage?: string | ReactNode;
+}
 
-    const header = useMemo(() => {
-        if (short) {
-            return null;
-        }
+/**
+ * A severity-banded box for messages the user has to read: the band carries
+ * the severity color and its icon, and the face carries the copy.
+ *
+ * The ref lands on the alert's content, which is what a caller scrolling an
+ * alert into view wants to reach.
+ */
+export const AlertBox = forwardRef<HTMLDivElement, AlertBoxProps>(
+    function AlertBox(
+        { severity, children, hideIcon, onClose, sx, title },
+        ref
+    ) {
+        const theme = useTheme();
 
-        let headerChild;
-        if (headerMessage) {
-            headerChild = headerMessage;
-        } else if (HEADER_MESSAGE[severity]) {
-            headerChild = intl.formatMessage({
-                id: HEADER_MESSAGE[severity],
-            });
-        }
+        const Icon = SEVERITY_ICON[severity];
 
-        if (headerChild) {
-            return (
-                <Typography
-                    variant="h4"
-                    component="div"
-                    sx={{
-                        pb: 1,
-                    }}
+        return (
+            <BandedDiv
+                side="left"
+                radius="sm"
+                bandColor={theme.palette[severity][theme.palette.mode]}
+                label={
+                    hideIcon ? undefined : (
+                        <Icon width={ICON_SIZE} height={ICON_SIZE} />
+                    )
+                }
+                faceSx={{
+                    px: 1.5,
+                    py: 1,
+                    background: paperBackground[theme.palette.mode],
+                    color: ALERT_TEXT[theme.palette.mode],
+                }}
+                sx={sx}
+            >
+                <Box
+                    ref={ref}
+                    role="alert"
+                    sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}
                 >
-                    {headerChild}
-                </Typography>
-            );
-        }
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                        {title ? <AlertTitle>{title}</AlertTitle> : null}
 
-        return null;
-    }, [headerMessage, intl, severity, short]);
+                        {children}
+                    </Box>
 
-    return (
-        <Alert
-            {...(hideIcon ? { icon: false } : {})}
-            ref={ref}
-            severity={severity}
-            variant="outlined"
-            iconMapping={{
-                error: <WarningHexagon style={iconComponentStyling} />,
-                warning: <WarningTriangle style={iconComponentStyling} />,
-                info: <InfoCircle style={iconComponentStyling} />,
-                success: <CheckCircle style={iconComponentStyling} />,
-            }}
-            onClose={onClose}
-            sx={{
-                ...(sx ?? {}),
-                backgroundColor: alertBackground[theme.palette.mode],
-                color: alertTextPrimary[theme.palette.mode],
-                borderColor: theme.palette[severity][theme.palette.mode],
-                padding: 0,
-                pl: hideIcon ? 2 : undefined,
-                [`& > .${alertClasses.message}`]: {
-                    p: 1,
-                    pl: 0,
-                    width: '100%',
-                },
-                [`& > .${alertClasses.action}`]: short
-                    ? {
-                          margin: 0,
-                          padding: 1,
-                          paddingTop: 0.5,
-                          alignItems: 'center',
-                      }
-                    : {
-                          margin: 0,
-                          padding: 1,
-                      },
-                [`& > .${alertClasses.icon}`]: short
-                    ? {
-                          ...SHARED_STYLING,
-                          borderLeftColor:
-                              theme.palette[severity][theme.palette.mode],
-                          color: alertTextPrimary[theme.palette.mode],
-                          mr: 0,
-                          px: 1,
-                          borderLeftStyle: 'solid',
-                          borderLeftWidth: 15,
-                      }
-                    : {
-                          ...SHARED_STYLING,
-                          background:
-                              theme.palette[severity][theme.palette.mode],
-                          px: 3,
-                          pt: 2,
-                      },
-            }}
-        >
-            {header}
-            {title ? <AlertTitle>{title}</AlertTitle> : null}
-            {children}
-        </Alert>
-    );
-});
+                    {onClose ? (
+                        <IconButton
+                            aria-label="Close"
+                            onClick={onClose}
+                            size="small"
+                            sx={{ color: 'inherit', flex: 'none' }}
+                        >
+                            <Xmark width={16} height={16} />
+                        </IconButton>
+                    ) : null}
+                </Box>
+            </BandedDiv>
+        );
+    }
+);
 
 export default AlertBox;

--- a/src/components/shared/AlertBox.tsx
+++ b/src/components/shared/AlertBox.tsx
@@ -5,13 +5,7 @@ import { forwardRef } from 'react';
 
 import { AlertTitle, Box, IconButton, useTheme } from '@mui/material';
 
-import {
-    CheckCircle,
-    InfoCircle,
-    WarningHexagon,
-    WarningTriangle,
-    Xmark,
-} from 'iconoir-react';
+import { Xmark } from 'iconoir-react';
 
 import { BandedDiv } from 'src/components/shared/BandedDiv';
 import { paperBackground } from 'src/context/Theme';
@@ -23,22 +17,9 @@ const ALERT_TEXT = {
     dark: 'rgb(255, 255, 255)',
 };
 
-const SEVERITY_ICON = {
-    error: WarningHexagon,
-    warning: WarningTriangle,
-    info: InfoCircle,
-    success: CheckCircle,
-};
-
-// Iconoir icons render at 1.5em, so an explicit width/height is the only way
-// to get the px size asked for.
-const ICON_SIZE = 20;
-
 export interface AlertBoxProps {
     severity: AlertColor;
     children?: ReactNode;
-    /** Leaves the severity band bare, with no icon in it. */
-    hideIcon?: boolean;
     /** Adds a close button to the end of the alert's first row. */
     onClose?: () => void;
     sx?: SxProps<Theme>;
@@ -47,30 +28,20 @@ export interface AlertBoxProps {
 
 /**
  * A severity-banded box for messages the user has to read: the band carries
- * the severity color and its icon, and the face carries the copy.
+ * the severity color, and the face carries the copy.
  *
  * The ref lands on the alert's content, which is what a caller scrolling an
  * alert into view wants to reach.
  */
 export const AlertBox = forwardRef<HTMLDivElement, AlertBoxProps>(
-    function AlertBox(
-        { severity, children, hideIcon, onClose, sx, title },
-        ref
-    ) {
+    function AlertBox({ severity, children, onClose, sx, title }, ref) {
         const theme = useTheme();
-
-        const Icon = SEVERITY_ICON[severity];
 
         return (
             <BandedDiv
                 side="left"
-                radius="sm"
+                radius="md"
                 bandColor={theme.palette[severity][theme.palette.mode]}
-                label={
-                    hideIcon ? undefined : (
-                        <Icon width={ICON_SIZE} height={ICON_SIZE} />
-                    )
-                }
                 faceSx={{
                     px: 1.5,
                     py: 1,

--- a/src/components/shared/Endpoints/TaskEndpoints.tsx
+++ b/src/components/shared/Endpoints/TaskEndpoints.tsx
@@ -32,7 +32,6 @@ export function TaskEndpoints({ reactorAddress, taskName }: TaskEndpointProps) {
             {typeof reactorAddress === 'string' &&
             typeof gatewayHostname !== 'string' ? (
                 <Error
-                    condensed
                     error={{
                         message: 'details.taskEndpoints.error.message',
                     }}

--- a/src/components/shared/Entity/CatalogEditor.tsx
+++ b/src/components/shared/Entity/CatalogEditor.tsx
@@ -51,7 +51,6 @@ function CatalogEditor({ message }: Props) {
                             sx={{
                                 maxWidth: 'fit-content',
                             }}
-                            short
                             severity="warning"
                             title="Editing disabled"
                         >

--- a/src/components/shared/Entity/Create/index.tsx
+++ b/src/components/shared/Entity/Create/index.tsx
@@ -147,7 +147,6 @@ function EntityCreate({
     if (detailsHydrationError) {
         return (
             <Error
-                condensed
                 error={{
                     ...BASE_ERROR,
                     message: detailsHydrationError,

--- a/src/components/shared/Entity/Details/History/DiffViewer.tsx
+++ b/src/components/shared/Entity/Details/History/DiffViewer.tsx
@@ -185,7 +185,6 @@ function DiffViewer() {
             </Grid>
             {pubSpecs.error ? (
                 <Error
-                    condensed
                     error={
                         pubSpecs.error ?? {
                             ...BASE_ERROR,

--- a/src/components/shared/Entity/Details/History/PublicationList.tsx
+++ b/src/components/shared/Entity/Details/History/PublicationList.tsx
@@ -100,7 +100,6 @@ function PublicationList() {
                 </List>
             ) : error || !hasLength(publications) ? (
                 <Error
-                    condensed
                     error={
                         error ?? {
                             ...BASE_ERROR,

--- a/src/components/shared/Entity/Details/Logs/Status/ServerError.tsx
+++ b/src/components/shared/Entity/Details/Logs/Status/ServerError.tsx
@@ -13,7 +13,6 @@ export default function ServerError() {
     return (
         <AlertBox
             severity="error"
-            short
             title={serverError.error ? serverError.message : undefined}
         >
             <Message

--- a/src/components/shared/Entity/Details/Ops/HydrationErrorAlert.tsx
+++ b/src/components/shared/Entity/Details/Ops/HydrationErrorAlert.tsx
@@ -22,7 +22,6 @@ function HydrationErrorAlert({ hydrationError }: HydrationErrorAlertProps) {
                 title={intl.formatMessage({
                     id: 'ops.logsTable.hydrationError',
                 })}
-                short
                 sx={{
                     maxWidth: 'fit-content',
                 }}

--- a/src/components/shared/Entity/Details/Ops/index.tsx
+++ b/src/components/shared/Entity/Details/Ops/index.tsx
@@ -31,7 +31,7 @@ function Ops() {
 
     if (!shouldShowLogs) {
         return (
-            <AlertBox short severity="warning">
+            <AlertBox severity="warning">
                 {intl.formatMessage({ id: 'ops.shouldNotShowLogs' })}
             </AlertBox>
         );

--- a/src/components/shared/Entity/Details/Overview/DetailsSection/StatusSection.tsx
+++ b/src/components/shared/Entity/Details/Overview/DetailsSection/StatusSection.tsx
@@ -20,7 +20,7 @@ function StatusSection({ entityName }: StatusSectionProps) {
 
     if (disabled) {
         return (
-            <AlertBox severity="warning" short sx={{ maxWidth: 'fit-content' }}>
+            <AlertBox severity="warning" sx={{ maxWidth: 'fit-content' }}>
                 {intl.formatMessage({
                     id: 'detailsPanel.status.taskDisabled.message',
                 })}

--- a/src/components/shared/Entity/Details/Overview/NotificationSettings/index.tsx
+++ b/src/components/shared/Entity/Details/Overview/NotificationSettings/index.tsx
@@ -73,7 +73,7 @@ function NotificationSettings({ taskName }: Props) {
                 ) : null}
 
                 {subscriptionExists === false ? (
-                    <AlertBox short severity="info">
+                    <AlertBox severity="info">
                         <MessageWithButton
                             messageId="details.settings.notifications.alert.userNotSubscribed.message"
                             clickHandler={() => {

--- a/src/components/shared/Entity/Details/Overview/NotificationSettings/index.tsx
+++ b/src/components/shared/Entity/Details/Overview/NotificationSettings/index.tsx
@@ -65,11 +65,11 @@ function NotificationSettings({ taskName }: Props) {
         >
             <Stack spacing={1} sx={{ mb: alertsExist ? 2 : undefined }}>
                 {subscriptionError ? (
-                    <Error error={subscriptionError} condensed hideTitle />
+                    <Error error={subscriptionError} hideTitle />
                 ) : null}
 
                 {updateSettingsError ? (
-                    <Error error={updateSettingsError} condensed hideTitle />
+                    <Error error={updateSettingsError} hideTitle />
                 ) : null}
 
                 {subscriptionExists === false ? (

--- a/src/components/shared/Entity/DetailsForm/Form.tsx
+++ b/src/components/shared/Entity/DetailsForm/Form.tsx
@@ -48,7 +48,6 @@ function DetailsFormForm({ entityType, readOnly }: Props) {
                         sx={{
                             maxWidth: 'fit-content',
                         }}
-                        short
                         severity="info"
                     >
                         {intl.formatMessage({
@@ -76,7 +75,7 @@ function DetailsFormForm({ entityType, readOnly }: Props) {
                         />
                     </Box>
                 ) : (
-                    <AlertBox severity="warning" short>
+                    <AlertBox severity="warning">
                         {intl.formatMessage({
                             id: `${messagePrefix}.missingConnectors`,
                         })}

--- a/src/components/shared/Entity/Edit/index.tsx
+++ b/src/components/shared/Entity/Edit/index.tsx
@@ -172,7 +172,6 @@ function EntityEdit({
 
             {detailsHydrationError ? (
                 <Error
-                    condensed
                     error={{
                         ...BASE_ERROR,
                         message: detailsHydrationError,

--- a/src/components/shared/Entity/Edit/index.tsx
+++ b/src/components/shared/Entity/Edit/index.tsx
@@ -198,7 +198,6 @@ function EntityEdit({
 
                     {draftInitializationError ? (
                         <AlertBox
-                            short={false}
                             severity={draftInitializationError.severity}
                             sx={{
                                 mb: 2,

--- a/src/components/shared/Entity/EndpointConfig/Form.tsx
+++ b/src/components/shared/Entity/EndpointConfig/Form.tsx
@@ -62,7 +62,7 @@ function EndpointConfigForm({ readOnly }: Props) {
                 onChange={setEndpointConfig}
             />
             {endpointCanBeEmpty ? (
-                <AlertBox short severity="info">
+                <AlertBox severity="info">
                     <FormattedMessage
                         id="entityCreate.endpointConfig.configCanBeBlank.message"
                         values={{

--- a/src/components/shared/Entity/EndpointConfig/SectionContent.tsx
+++ b/src/components/shared/Entity/EndpointConfig/SectionContent.tsx
@@ -110,7 +110,7 @@ const SectionContent = ({ readOnly = false }: SectionContentProps) => {
 
             {readOnly ? (
                 <Box sx={{ mb: 3 }}>
-                    <AlertBox severity="info" short>
+                    <AlertBox severity="info">
                         {intl.formatMessage({
                             id: 'entityEdit.alert.endpointConfigDisabled',
                         })}
@@ -120,7 +120,7 @@ const SectionContent = ({ readOnly = false }: SectionContentProps) => {
 
             {endpointCanBeEmpty ? (
                 <Box sx={{ mb: 3 }}>
-                    <AlertBox severity="info" short>
+                    <AlertBox severity="info">
                         {intl.formatMessage({
                             id: 'workflows.alert.endpointConfigEmpty',
                         })}

--- a/src/components/shared/Entity/Error/DraftErrors.tsx
+++ b/src/components/shared/Entity/Error/DraftErrors.tsx
@@ -109,7 +109,7 @@ function DraftErrors({
 
         if (enableAlertStyling) {
             return (
-                <AlertBox short hideIcon severity="error">
+                <AlertBox hideIcon severity="error">
                     {content}
                 </AlertBox>
             );

--- a/src/components/shared/Entity/Error/DraftErrors.tsx
+++ b/src/components/shared/Entity/Error/DraftErrors.tsx
@@ -108,11 +108,7 @@ function DraftErrors({
         );
 
         if (enableAlertStyling) {
-            return (
-                <AlertBox hideIcon severity="error">
-                    {content}
-                </AlertBox>
-            );
+            return <AlertBox severity="error">{content}</AlertBox>;
         }
 
         return <Box>{content}</Box>;

--- a/src/components/shared/Entity/HeaderSummary.tsx
+++ b/src/components/shared/Entity/HeaderSummary.tsx
@@ -16,7 +16,6 @@ function HeaderSummary({ severity, title, children }: Props) {
     return (
         <Box sx={{ width: '100%', mb: 2 }}>
             <AlertBox
-                short
                 severity={severity}
                 title={
                     <Typography

--- a/src/components/shared/Entity/IncompatibleCollections/index.tsx
+++ b/src/components/shared/Entity/IncompatibleCollections/index.tsx
@@ -24,7 +24,6 @@ function IncompatibleCollections() {
             unmountOnExit
         >
             <AlertBox
-                short
                 severity="warning"
                 title={
                     <Typography

--- a/src/components/shared/Entity/Shard/HydrationError.tsx
+++ b/src/components/shared/Entity/Shard/HydrationError.tsx
@@ -11,7 +11,6 @@ function HydrationError({ error }: HydrationErrorProps) {
     return (
         <AlertBox
             severity="error"
-            short
             title={intl.formatMessage({
                 id: 'detailsPanel.shardDetails.fetchError',
             })}

--- a/src/components/shared/Entity/Status.tsx
+++ b/src/components/shared/Entity/Status.tsx
@@ -10,7 +10,7 @@ function Status() {
 
     if (key && severity) {
         return (
-            <AlertBox severity={severity} short>
+            <AlertBox severity={severity}>
                 <Typography sx={{ mr: 1 }}>
                     <FormattedMessage id={key} />
                 </Typography>

--- a/src/components/shared/Entity/ValidationErrorSummary/index.tsx
+++ b/src/components/shared/Entity/ValidationErrorSummary/index.tsx
@@ -28,15 +28,10 @@ import { hasLength } from 'src/utils/misc-utils';
 
 interface Props {
     ErrorComponent?: any | boolean;
-    hideIcon?: boolean;
     headerMessageId?: string;
 }
 
-function ValidationErrorSummary({
-    headerMessageId,
-    hideIcon,
-    ErrorComponent,
-}: Props) {
+function ValidationErrorSummary({ headerMessageId, ErrorComponent }: Props) {
     const intl = useIntl();
     const scrollToTarget = useRef<HTMLDivElement>(null);
     const scrollIntoView = useScrollIntoView(scrollToTarget);
@@ -87,7 +82,7 @@ function ValidationErrorSummary({
 
     return show ? (
         <Collapse in={formErrorsExist} timeout="auto" unmountOnExit>
-            <AlertBox severity="error" hideIcon={hideIcon} ref={scrollToTarget}>
+            <AlertBox severity="error" ref={scrollToTarget}>
                 <AlertTitle>
                     {intl.formatMessage({
                         id: headerMessageId ?? defaultHeaderMessageId,

--- a/src/components/shared/Entity/ValidationErrorSummary/index.tsx
+++ b/src/components/shared/Entity/ValidationErrorSummary/index.tsx
@@ -87,12 +87,7 @@ function ValidationErrorSummary({
 
     return show ? (
         <Collapse in={formErrorsExist} timeout="auto" unmountOnExit>
-            <AlertBox
-                short={false}
-                severity="error"
-                hideIcon={hideIcon}
-                ref={scrollToTarget}
-            >
+            <AlertBox severity="error" hideIcon={hideIcon} ref={scrollToTarget}>
                 <AlertTitle>
                     {intl.formatMessage({
                         id: headerMessageId ?? defaultHeaderMessageId,

--- a/src/components/shared/Entity/Warnings.tsx
+++ b/src/components/shared/Entity/Warnings.tsx
@@ -20,7 +20,6 @@ function EntityWarnings() {
     return (
         <Collapse in={warnEmptyBindings} unmountOnExit>
             <AlertBox
-                short
                 severity="warning"
                 title={<FormattedMessage id="workflows.entityWarnings.title" />}
             >

--- a/src/components/shared/Error/index.tsx
+++ b/src/components/shared/Error/index.tsx
@@ -11,7 +11,6 @@ import AlertBox from 'src/components/shared/AlertBox';
 import Message from 'src/components/shared/Error/Message';
 
 export interface ErrorProps {
-    condensed?: boolean;
     error?: ErrorDetails;
     hideIcon?: boolean;
     hideTitle?: boolean;
@@ -22,7 +21,6 @@ export interface ErrorProps {
 }
 
 function Error({
-    condensed,
     error,
     hideIcon,
     hideTitle,

--- a/src/components/shared/Error/index.tsx
+++ b/src/components/shared/Error/index.tsx
@@ -47,7 +47,6 @@ function Error({
         <Box sx={{ width: '100%' }}>
             <AlertBox
                 severity={severity ?? 'error'}
-                short={Boolean(condensed)}
                 hideIcon={hideIcon}
                 title={
                     !hideTitle ? (

--- a/src/components/shared/Error/index.tsx
+++ b/src/components/shared/Error/index.tsx
@@ -12,7 +12,6 @@ import Message from 'src/components/shared/Error/Message';
 
 export interface ErrorProps {
     error?: ErrorDetails;
-    hideIcon?: boolean;
     hideTitle?: boolean;
     linkOptions?: ExternalLinkOptions;
     noAlertBox?: boolean;
@@ -22,7 +21,6 @@ export interface ErrorProps {
 
 function Error({
     error,
-    hideIcon,
     hideTitle,
     linkOptions,
     noAlertBox,
@@ -45,7 +43,6 @@ function Error({
         <Box sx={{ width: '100%' }}>
             <AlertBox
                 severity={severity ?? 'error'}
-                hideIcon={hideIcon}
                 title={
                     !hideTitle ? (
                         <AlertTitle>

--- a/src/components/shared/ErrorBoundryWrapper.tsx
+++ b/src/components/shared/ErrorBoundryWrapper.tsx
@@ -40,7 +40,6 @@ function ErrorFallback({ error }: { error: Error }): JSX.Element {
 
     return (
         <AlertBox
-            short
             severity="error"
             title={intl.formatMessage({ id: 'errorBoundry.title' })}
         >

--- a/src/components/shared/ErrorDialog/index.tsx
+++ b/src/components/shared/ErrorDialog/index.tsx
@@ -36,7 +36,7 @@ function ErrorDialog({ name, dialogTitle, bodyTitle, body, cta }: Props) {
         >
             <DialogTitle id={labelledBy}>{dialogTitle}</DialogTitle>
             <DialogContent>
-                <AlertBox short severity="info" title={bodyTitle}>
+                <AlertBox severity="info" title={bodyTitle}>
                     <DialogContentText id={describedby} component="div">
                         {body}
                     </DialogContentText>

--- a/src/components/shared/ErrorImporting/index.tsx
+++ b/src/components/shared/ErrorImporting/index.tsx
@@ -46,7 +46,7 @@ export function ErrorImporting({ error }: FallbackProps) {
     }, [error]);
 
     if (stopTrying) {
-        return <Error error={error} condensed />;
+        return <Error error={error} />;
     }
 
     return <FullPageSpinner />;

--- a/src/components/shared/HydrationError.tsx
+++ b/src/components/shared/HydrationError.tsx
@@ -20,7 +20,6 @@ function HydrationError({ children }: BaseComponentProps) {
                     })}
                 </Typography>
             }
-            short
         >
             {children ? <Typography>{children}</Typography> : null}
 

--- a/src/components/shared/PageContainer.tsx
+++ b/src/components/shared/PageContainer.tsx
@@ -123,7 +123,6 @@ function PageContainer({ children, hideBackground }: Props) {
                 >
                     <AlertBox
                         severity={notification.severity}
-                        short
                         onClose={() => {
                             handlers.notificationClose(notification);
                         }}

--- a/src/components/shared/WizardDialog/WizardContent.tsx
+++ b/src/components/shared/WizardDialog/WizardContent.tsx
@@ -44,7 +44,7 @@ export function WizardContent() {
     return (
         <DialogContent>
             <Collapse in={Boolean(error)}>
-                <AlertBox short severity="error" sx={{ mb: 2 }}>
+                <AlertBox severity="error" sx={{ mb: 2 }}>
                     {error}
                 </AlertBox>
             </Collapse>

--- a/src/components/shared/guards/AdminCapability.tsx
+++ b/src/components/shared/guards/AdminCapability.tsx
@@ -17,7 +17,6 @@ function AdminCapabilityGuard({ children }: InputBaseComponentProps) {
         return (
             <AlertBox
                 severity="error"
-                short
                 title={intl.formatMessage({
                     id: 'workflows.guards.admin.title',
                 })}

--- a/src/components/shared/guards/EditCapability.tsx
+++ b/src/components/shared/guards/EditCapability.tsx
@@ -14,7 +14,6 @@ function EditCapabilityGuard({ children }: BaseComponentProps) {
     if (canEditEntity === false) {
         return (
             <AlertBox
-                short={false}
                 severity="error"
                 title={intl.formatMessage({
                     id: 'workflows.guards.edit.title',

--- a/src/components/shared/specPropEditor/SpecPropInvalidSetting.tsx
+++ b/src/components/shared/specPropEditor/SpecPropInvalidSetting.tsx
@@ -23,7 +23,7 @@ function SpecPropInvalidSetting({
             : stringifyJSON(currentSetting);
 
     return (
-        <AlertBox severity="error" short sx={{ maxWidth: 'fit-content' }}>
+        <AlertBox severity="error" sx={{ maxWidth: 'fit-content' }}>
             <Typography>
                 {intl.formatMessage(
                     {

--- a/src/components/shared/types.ts
+++ b/src/components/shared/types.ts
@@ -1,18 +1,6 @@
-import type { AlertColor, SxProps } from '@mui/material';
+import type { SxProps } from '@mui/material';
 import type { ReactNode } from 'react';
 import type { BaseComponentProps } from 'src/types';
-
-// TODO (AlertBox) we defaulted short to false at the start. That was a mistake
-//  so we need to get `short` to default to `true` soon.
-export interface AlertBoxProps extends BaseComponentProps {
-    severity: AlertColor;
-    short: boolean; // Forcing this on... but do not want to change all calls right now
-    sx?: SxProps;
-    headerMessage?: string | ReactNode;
-    hideIcon?: boolean;
-    onClose?: () => void;
-    title?: string | ReactNode;
-}
 
 export interface RadioMenuItemProps {
     description: string;

--- a/src/components/sidePanelDocs/Iframe.tsx
+++ b/src/components/sidePanelDocs/Iframe.tsx
@@ -93,7 +93,6 @@ function SidePanelIframe({ show }: Props) {
                 }}
             >
                 <AlertBox
-                    short
                     severity="info"
                     title={<FormattedMessage id="docs.iframe.disabled.title" />}
                 >

--- a/src/components/tables/AccessGrants/AccessLinks/Dialog/index.tsx
+++ b/src/components/tables/AccessGrants/AccessLinks/Dialog/index.tsx
@@ -69,11 +69,7 @@ function PrefixInvitationDialog({ open, setOpen }: BaseDialogProps) {
             <DialogContent>
                 {error ? (
                     <Box sx={{ mb: 3 }}>
-                        <Error
-                            error={error}
-                            condensed={true}
-                            hideTitle={true}
-                        />
+                        <Error error={error} hideTitle={true} />
                     </Box>
                 ) : null}
 

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
@@ -85,11 +85,7 @@ function ShareDataDialog({ open, setOpen }: Props) {
                                 </Typography>
                             </AlertBox>
                         ) : (
-                            <Error
-                                error={serverError}
-                                condensed={true}
-                                hideTitle={true}
-                            />
+                            <Error error={serverError} hideTitle={true} />
                         )}
                     </Box>
                 ) : null}

--- a/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
+++ b/src/components/tables/AccessGrants/DataSharing/Dialog/index.tsx
@@ -73,13 +73,13 @@ function ShareDataDialog({ open, setOpen }: Props) {
                 {serverError ? (
                     <Box sx={{ mb: 3 }}>
                         {serverError.code === '42501' ? (
-                            <AlertBox severity="error" short>
+                            <AlertBox severity="error">
                                 <Typography>
                                     <FormattedMessage id="admin.prefix.issueGrant.error.invalidPrefix" />
                                 </Typography>
                             </AlertBox>
                         ) : serverError.code === '23505' ? (
-                            <AlertBox severity="error" short>
+                            <AlertBox severity="error">
                                 <Typography>
                                     <FormattedMessage id="admin.prefix.issueGrant.error.duplicatePrefix" />
                                 </Typography>

--- a/src/components/tables/AlertHistory/index.tsx
+++ b/src/components/tables/AlertHistory/index.tsx
@@ -239,7 +239,6 @@ function AlertHistoryTable({
         <>
             {active && totalActiveAlertsCount > MAX_ACTIVE_ALERTS ? (
                 <AlertBox
-                    short
                     sx={{
                         maxWidth: 'fit-content',
                     }}

--- a/src/components/tables/Logs/HydrationWarning.tsx
+++ b/src/components/tables/Logs/HydrationWarning.tsx
@@ -15,7 +15,6 @@ function HydrationWarning() {
         return (
             <AlertBox
                 severity="info"
-                short
                 title={intl.formatMessage({
                     id: `ops.hydrationWarning.${hydrationWarning}.title`,
                 })}

--- a/src/components/tables/RowActions/AccessGrants/Progress.tsx
+++ b/src/components/tables/RowActions/AccessGrants/Progress.tsx
@@ -62,11 +62,7 @@ function Progress({
                     renderError ? (
                         renderError(error)
                     ) : (
-                        <Error
-                            error={error}
-                            condensed={true}
-                            hideTitle={true}
-                        />
+                        <Error error={error} hideTitle={true} />
                     )
                 ) : null}
             </Box>

--- a/src/components/tables/RowActions/Delete/Confirmation.tsx
+++ b/src/components/tables/RowActions/Delete/Confirmation.tsx
@@ -10,7 +10,7 @@ function DeleteConfirmation({ count }: BaseConfirmationProps) {
     const intl = useIntl();
 
     return (
-        <AlertBox severity="warning" short>
+        <AlertBox severity="warning">
             <Typography component="div">
                 {intl.formatMessage(
                     { id: 'entityTable.delete.confirm' },

--- a/src/components/tables/RowActions/DisableEnable/Confirmation.tsx
+++ b/src/components/tables/RowActions/DisableEnable/Confirmation.tsx
@@ -13,7 +13,7 @@ function DisableEnableConfirmation({
     const intl = useIntl();
 
     return (
-        <AlertBox severity="info" short>
+        <AlertBox severity="info">
             <Typography component="div">
                 {intl.formatMessage(
                     { id: 'entityTable.disableEnable.confirm' },

--- a/src/components/tables/RowActions/Shared/ConfirmationWithExplination.tsx
+++ b/src/components/tables/RowActions/Shared/ConfirmationWithExplination.tsx
@@ -84,12 +84,11 @@ function ConfirmationWithExplanation({
         <Box>
             {potentiallyDangerousUpdates.length > 0 ? (
                 <AlertBox
-                    short={false}
                     sx={{
                         my: 1,
                         p: 3,
                     }}
-                    headerMessage={intl.formatMessage({
+                    title={intl.formatMessage({
                         id: 'accessGrants.actions.extra.confirmation.title',
                     })}
                     severity="warning"

--- a/src/components/tables/RowActions/Shared/progress/ErrorViewer.tsx
+++ b/src/components/tables/RowActions/Shared/progress/ErrorViewer.tsx
@@ -15,7 +15,7 @@ function ErrorViewer({ error, renderError, state }: ErrorViewerProps) {
             {renderError ? (
                 renderError(error, state)
             ) : (
-                <Error error={error} hideTitle condensed noAlertBox={skipped} />
+                <Error error={error} hideTitle noAlertBox={skipped} />
             )}
         </Box>
     );

--- a/src/components/tables/RowActions/Shared/progress/RenderError.tsx
+++ b/src/components/tables/RowActions/Shared/progress/RenderError.tsx
@@ -18,7 +18,6 @@ function RenderError({ draftId, error, skipped }: RenderErrorProps) {
                 <Error
                     error={error}
                     severity={skipped ? 'info' : undefined}
-                    hideIcon={skipped}
                     hideTitle
                 />
             ) : null}

--- a/src/components/tables/RowActions/Shared/progress/RenderError.tsx
+++ b/src/components/tables/RowActions/Shared/progress/RenderError.tsx
@@ -19,7 +19,6 @@ function RenderError({ draftId, error, skipped }: RenderErrorProps) {
                     error={error}
                     severity={skipped ? 'info' : undefined}
                     hideIcon={skipped}
-                    condensed
                     hideTitle
                 />
             ) : null}

--- a/src/components/tables/cells/entityStatus/ControllerErrors/index.tsx
+++ b/src/components/tables/cells/entityStatus/ControllerErrors/index.tsx
@@ -1,6 +1,6 @@
 import type { ControllerErrorsProps } from 'src/components/tables/cells/entityStatus/ControllerErrors/types';
 
-import { alertClasses, Box, TableCell, Typography } from '@mui/material';
+import { Box, TableCell, Typography } from '@mui/material';
 
 import AlertBox from 'src/components/shared/AlertBox';
 import ButtonWithPopper from 'src/components/shared/buttons/ButtonWithPopper';
@@ -45,13 +45,9 @@ export default function ControllerErrors({
                 popper={
                     <AlertBox
                         severity="error"
-                        short
                         sx={{
                             mb: 1,
                             width: 600,
-                            [`& .${alertClasses.message}`]: {
-                                width: '100%',
-                            },
                         }}
                     >
                         {errors.map((error, index) => (

--- a/src/components/transformation/create/BetaWarningAndError.tsx
+++ b/src/components/transformation/create/BetaWarningAndError.tsx
@@ -27,7 +27,6 @@ const BetaWarningAndError = () => {
                 <Box>
                     <AlertBox
                         severity="warning"
-                        short
                         title={intl.formatMessage({ id: 'confirm.title' })}
                     >
                         {intl.formatMessage({
@@ -41,7 +40,6 @@ const BetaWarningAndError = () => {
                 <Box>
                     <AlertBox
                         severity="error"
-                        short
                         title={intl.formatMessage({
                             id: 'common.fail',
                         })}
@@ -54,7 +52,6 @@ const BetaWarningAndError = () => {
             {nameMissing || surveyMissing || nameInvalid ? (
                 <Box>
                     <AlertBox
-                        short
                         severity="error"
                         title={intl.formatMessage({ id: 'error.title' })}
                     >

--- a/src/context/ConnectorTag.tsx
+++ b/src/context/ConnectorTag.tsx
@@ -135,7 +135,6 @@ export const ConnectorTagProvider = ({
     if (fetchError) {
         return (
             <ErrorComponent
-                condensed
                 error={{
                     ...BASE_ERROR,
                     message: intl.formatMessage({

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -607,12 +607,6 @@ const alternativeDataGridHeader = {
     dark: 'transparent',
 };
 
-export const alertTextPrimary = {
-    light: 'rgba(0, 0, 0, 0.8)',
-    dark: 'rgb(255, 255, 255)',
-};
-export const alertBackground = paperBackground;
-
 export const alertColorsReversed: {
     [k in AlertColor]: { light: string; dark: string };
 } = {

--- a/src/directives/ClickToAccept.tsx
+++ b/src/directives/ClickToAccept.tsx
@@ -144,7 +144,6 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
 
                 {showErrors ? (
                     <AlertBox
-                        short
                         severity="error"
                         title={intl.formatMessage({ id: 'error.title' })}
                     >
@@ -155,7 +154,6 @@ const ClickToAccept = ({ directive, status, mutate }: DirectiveProps) => {
                 {serverError ? (
                     <AlertBox
                         severity="error"
-                        short
                         title={intl.formatMessage({ id: 'common.fail' })}
                     >
                         {serverError}

--- a/src/forms/renderers/Informational/SshEndpoint.tsx
+++ b/src/forms/renderers/Informational/SshEndpoint.tsx
@@ -21,7 +21,6 @@ function SshEndpointInfo() {
         >
             <AlertBox
                 severity="info"
-                short
                 title={intl.formatMessage({
                     id: 'informational.sshEndpoint.title',
                 })}

--- a/src/generatedModules/FileUpload/FileUploadDialog.tsx
+++ b/src/generatedModules/FileUpload/FileUploadDialog.tsx
@@ -165,9 +165,7 @@ export const FileUploadDialog = ({
             <DialogContent>
                 <Stack spacing={2}>
                     {fileError ? (
-                        <AlertBox severity="error" short>
-                            {fileError}
-                        </AlertBox>
+                        <AlertBox severity="error">{fileError}</AlertBox>
                     ) : null}
                     <Box
                         sx={{

--- a/src/lang/en-US/CommonMessages.ts
+++ b/src/lang/en-US/CommonMessages.ts
@@ -110,12 +110,6 @@ export const CommonMessages: Record<string, string> = {
 
     'common.pathShort.prefix': '.../',
 
-    // Alert messages
-    'alert.error': 'Error',
-    'alert.warning': 'Warning',
-    'alert.success': 'Success',
-    'alert.info': 'Important',
-
     // Used in directives
     'directives.returning': `Welcome back. You still need to provide some information before using the application.`,
     'directives.grant.skipped.title': `Access Grant Token Skipped`,

--- a/src/pages/DataPlaneAuthReq.tsx
+++ b/src/pages/DataPlaneAuthReq.tsx
@@ -135,7 +135,6 @@ const DataPlaneAuthReq = () => {
             <Box style={{ marginBottom: 2, padding: 2 }}>
                 {redirectResult.error ? (
                     <Error
-                        condensed
                         error={
                             typeof redirectResult.error === 'string'
                                 ? {

--- a/src/pages/SSORequired.tsx
+++ b/src/pages/SSORequired.tsx
@@ -67,7 +67,7 @@ export function SSORequired() {
 
     return (
         <FullPageDialog>
-            <Error error={error} condensed={true} hideTitle={true} />
+            <Error error={error} hideTitle={true} />
             <Stack
                 spacing={3}
                 alignItems="center"

--- a/src/pages/dev/TestJsonForms.tsx
+++ b/src/pages/dev/TestJsonForms.tsx
@@ -117,7 +117,6 @@ const TestJsonForms = () => {
                 >
                     {serverError ? (
                         <AlertBox
-                            short
                             severity="error"
                             title="Failed to fetch list of connectors"
                         >
@@ -127,7 +126,6 @@ const TestJsonForms = () => {
 
                     {error !== null ? (
                         <AlertBox
-                            short
                             severity="error"
                             title="Failed to parse input"
                         >
@@ -135,7 +133,7 @@ const TestJsonForms = () => {
                         </AlertBox>
                     ) : null}
 
-                    <AlertBox severity="info" short title="Instructions">
+                    <AlertBox severity="info" title="Instructions">
                         <Box>
                             1. TESTING OAUTH - Select a connector in the
                             dropdown. This will be the connector that is looked

--- a/src/pages/marketplace/Verification.tsx
+++ b/src/pages/marketplace/Verification.tsx
@@ -76,7 +76,6 @@ function MarketplaceVerification() {
                 {serverError ? (
                     <Error
                         error={{ ...BASE_ERROR, message: serverError.message }}
-                        condensed
                     />
                 ) : null}
 

--- a/src/stores/Workflow/Hydrator.tsx
+++ b/src/stores/Workflow/Hydrator.tsx
@@ -35,7 +35,6 @@ function WorkflowHydratorInner({ children }: WorkflowInitializerProps) {
     if (hydrationError) {
         return (
             <Error
-                condensed
                 error={{
                     ...BASE_ERROR,
                     message: hydrationError,


### PR DESCRIPTION
## Changes

Rebuilds `AlertBox` on the `BandedDiv` from #2073. The severity color moves into the band; the copy sits on the face.

Stacked on #2073 (BandedDiv) and under #1989 (service accounts).

### The component

- The MUI `Alert` is gone, and with it the `alertClasses` overrides that were reshaping its icon, message, and action slots, plus `iconMapping` and `SHARED_STYLING`. The frame, the band tuck, and the severity-tinted face border all come from `BandedDiv`.
- The band is bare — its color carries the severity on its own. `side="left"`, `radius="sm"` (4px, matching the old alert), `bandColor={theme.palette[severity][mode]}` (unchanged from the old border color).
- `role="alert"` and the forwarded ref land on the alert's content, which is what `ValidationErrorSummary` scrolls into view.
- `onClose` renders its own close button now that MUI isn't supplying one.

### The API

`AlertBoxProps` is `severity`, `children`, `onClose`, `sx`, `title`, and it moved next to the component. Removed:

- **`short`** — 86 call sites set it, 82 of them the same way. A band reads the same whatever the message length, so there was nothing left for the compact/tall split to express.
- **`headerMessage`** and the four `alert.*` messages — the `h4` header they fed is gone. The one caller passes its copy as `title`.
- **`hideIcon`** — nothing to hide once the icon went.
- **`condensed` on `Error`** — it only ever picked the AlertBox presentation. Off 26 call sites.

`alertBackground` and `alertTextPrimary` came out of `Theme.tsx`, which had no other consumer for them.

`AlertBox` now has a named export alongside the default; the 77 existing importers are untouched.

## Tests

### Manually tested

-   `/admin/billing` against the local stack, both payment-provider alerts: band `rgb(193,75,96)` at a 24px visible run, face border `1px solid rgb(193,75,96)`, `role="alert"` present.

### Automated tests

-   None. Typecheck, ESLint, and Prettier pass.

## Screenshots

_Band-only alert, dark mode — severity color at the left edge, copy on the face._
